### PR TITLE
Taxonomies with a space in them break search-as-you-type

### DIFF
--- a/js/fieldmanager-select.js
+++ b/js/fieldmanager-select.js
@@ -70,7 +70,7 @@ $( document ).ready( function() {
 					// If there are optgroups present, use special processing
 					$resultObj.filter("optgroup").each( function( index, element ) {
 						// See if the optgroup already exists
-						var optgroup_selector = "optgroup[label=" + $(this).attr("label") + "]";
+						var optgroup_selector = "optgroup[label='" + $(this).attr("label") + "']";
 						if( $fm_select_field.find(optgroup_selector).length > 0 ) {
 							// The optgroup exists. Append these options to the existing optgroup.
 							fm_append_options( $fm_select_field.find(optgroup_selector), $(this).children("option") );


### PR DESCRIPTION
With a taxonomy called "Radio Shows", the selector that sets the value of optgroup_selector breaks. Simple fix: Add single quotes to allow for use of strings.

Please reply in https://jira.rogersdigitalmedia.com/browse/SPNETREBRAND-1065 when this bug has been resolved.
