### PR TITLE
Correcting the initial quantity of fields for empty repeating groups/fields. Potentially aids with issue #18.

### DIFF
--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -330,13 +330,21 @@ abstract class Fieldmanager_Field {
 	 * @return string HTML for all form elements.
 	 */
 	public function element_markup( $values = array() ) {
+		if ( ! is_array( $values ) && ! $values )
+			$count = 0;
+		elseif ( !is_array( $values ) )
+			$count = 1;
+		else
+			$count = count( $values );
+
 		$values = $this->preload_alter_values( $values );
+
 		if ( $this->limit == 0 ) {
-			if ( count( $values ) + $this->extra_elements <= $this->starting_count ) {
+			if ( $count + $this->extra_elements <= $this->starting_count ) {
 				$max = $this->starting_count;
 			}
 			else {
-				$max = count( $values ) + $this->extra_elements;
+				$max = $count + $this->extra_elements;
 			}
 		}
 		else {


### PR DESCRIPTION
While this potentially addresses issue #18, a better route would probably be to use a stricter data type for `$values`.
