### PR TITLE
Fixing bug with latest WP nightly build where null term IDs are returning the first term

### DIFF
--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -318,6 +318,9 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	 */
 	public function get_value( $value ) {
 		$id = intval( $value );
+		if ( ! $id )
+			return null;
+
 		$term = $this->get_term( $id );
 		$value = is_object( $term ) ? $term->name : '';
 		return apply_filters( 'fm_datasource_term_get_value', $value, $term, $this );


### PR DESCRIPTION
Specifically addresses an issue on VIP
