### PR TITLE
Restricting "Add element" to the immediate fm-wrapper scope

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -50,7 +50,7 @@ define( 'FM_GLOBAL_ASSET_VERSION', 1 );
  * Add CSS and JS to admin area, hooked into admin_enqueue_scripts.
  */
 function fieldmanager_enqueue_scripts() {
-	wp_enqueue_script( 'fieldmanager_script', fieldmanager_get_baseurl() . 'js/fieldmanager.js', array( 'jquery' ), '1.0.1' );
+	wp_enqueue_script( 'fieldmanager_script', fieldmanager_get_baseurl() . 'js/fieldmanager.js', array( 'jquery' ), '1.0.2' );
 	wp_enqueue_style( 'fieldmanager_style', fieldmanager_get_baseurl() . 'css/fieldmanager.css', array(), '1.0.0' );
 	wp_enqueue_script( 'jquery-ui-sortable' );
 }

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -90,7 +90,7 @@ var match_value = function( values, match_string ) {
 
 fm_add_another = function( $element ) {
 	var el_name = $element.attr( 'data-related-element' );
-	$new_element = $( '.fmjs-proto.fm-' + el_name ).first().clone();
+	$new_element = $( '.fmjs-proto.fm-' + el_name, $element.closest( '.fm-wrapper' ) ).first().clone();
 	$new_element.removeClass( 'fmjs-proto' );
 	$new_element = $new_element.insertBefore( $element.parent() );
 	fm_renumber( $element.parents( '.fm-wrapper' ) );


### PR DESCRIPTION
This resolves a bug whereby two groups, named differently, with identically-named children, will have a conflict when blocks 2->n's "Add element" button is clicked. The second (or beyond) add element button adds an element in the correct place, based off the first wrapper's prototype.
