### PR TITLE
When presaving the source posts, also remove all other entries of the same reciprocal to avoid duplicates

### DIFF
--- a/php/datasource/class-fieldmanager-datasource-post.php
+++ b/php/datasource/class-fieldmanager-datasource-post.php
@@ -163,7 +163,7 @@ class Fieldmanager_Datasource_Post extends Fieldmanager_Datasource {
     public function presave_alter_values( Fieldmanager_Field $field, $values, $current_values ) {
         if ( $field->data_type != 'post' || !$this->reciprocal ) return $values;
         foreach ( $current_values as $reciprocal_post_id ) {
-            delete_post_meta( $reciprocal_post_id, $this->reciprocal, $field->data_id );
+            delete_post_meta( $reciprocal_post_id, $this->reciprocal );
         }
         return $values;
     }


### PR DESCRIPTION
Without this change, a post that's added to a new parent will have reciprocal meta keys for both parents.

This definitely fixes the issue, but I'm concerned about whether this would introduce new issues. Does it need to go and remove the child post as a value from other parents? Are there uses where the child should be present in multiple parents and able to reference them all as an array? If that's the case then maybe the more appropriate fix would actually be to fetch all and use the most recent value for this specific issue in the theme code, with no changes in FM? Or, is it possible to hook into the deletion of the parent post and then delete all the child reciprocals?
