### PR TITLE
Add margin to "Add More" buttons inside of groups

### DIFF
--- a/css/fieldmanager.css
+++ b/css/fieldmanager.css
@@ -53,6 +53,10 @@ div.fm-group-label-wrapper {
 	margin-bottom: 5px;
 }
 
+.fm-group .fm-add-another-wrapper {
+	margin-bottom: 15px;
+}
+
 .fmjs-proto {
 	display: none;
 }


### PR DESCRIPTION
Attempted fix for https://github.com/alleyinteractive/wordpress-fieldmanager/issues/82.
