### PR TITLE
Removing duplicate include of wplink plugin

### DIFF
--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -191,7 +191,6 @@ if ( "undefined" === typeof tinyMCEPreInit ) tinyMCEPreInit = { base: "%s", suff
 				'toolbar3' => $buttons[2],
 				'toolbar4' => $buttons[3],
 			) );
-			$plugins[] = 'wplink';
 		}
 
 		$options['plugins'] = implode( ',', array_unique( apply_filters('tiny_mce_plugins', $plugins ) ) );


### PR DESCRIPTION
This isn't urgent because the duplicate doesn't cause any issues, just cleanup.

The `wplink` plugin is already included above on [line 157](https://github.com/alleyinteractive/wordpress-fieldmanager/blob/f794acc83ffb985fd0546df12c0a9b030b4071f9/php/class-fieldmanager-richtextarea.php#L157).

The additional inclusion of `link` here was because [I misdiagnosed](https://github.com/alleyinteractive/wordpress-fieldmanager/pull/97) missing buttons as being from the missing plugin, whereas it seems that it had actually been from a problem in the trunk version of wplink which has since been fixed.
