### PR TITLE
Prevent missing fields from throwing a nonce error

### DIFF
--- a/php/context/class-fieldmanager-context-post.php
+++ b/php/context/class-fieldmanager-context-post.php
@@ -149,7 +149,11 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 		if ( !isset( $_POST['post_type'] ) || ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || $_POST['action'] != 'editpost' )
 			return;
 
-		if ( get_post_type( $post_id ) == 'revision' ) return; // prevents saving the same post twice; FM does not yet use revisions.
+		// prevent saving the same post twice; FM does not yet use revisions.
+		if ( get_post_type( $post_id ) == 'revision' ) return;
+
+		// prevent nonce errors from missing fields
+		if ( ! isset( $_POST[ $this->fm->name ], $_POST['fieldmanager-' . $this->fm->name . '-nonce'] ) ) return;
 
 		$use_this_post_type = False;
 		foreach ( $this->post_types as $type ) {


### PR DESCRIPTION
We will need to do this (or similar) across all contexts. I can add the other contexts to this PR, but wanted to run the gist of the solution by here first.

The problem I ran into is that if a fieldmanager field is added between the time that a user loads the new/edit post screen and the time that the user saves the draft or publishes the post, Fieldmanager will throw an exception about an invalid nonce. Fieldmanager currently mandates that the field is present in the POST data.

What this PR does is ensure that both the field data and nonce are present before proceeding. If the nonce is there but the data isn't, the field will be saved as empty. If the field is there but the nonce isn't, the normal nonce check will continue and fail.