### PR TITLE
Actually pass in_footer option to closure

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -118,7 +118,7 @@ function fm_add_script( $handle, $path, $deps = array(), $ver = false, $in_foote
 	if ( !$ver ) $ver = FM_GLOBAL_ASSET_VERSION;
 	if ( $plugin_dir == "" ) $plugin_dir = fieldmanager_get_baseurl(); // allow overrides for child plugins
 	$add_script = function() use ( $handle, $path, $deps, $ver, $in_footer, $data_object, $data, $plugin_dir ) {
-		wp_enqueue_script( $handle, $plugin_dir . $path, $deps, $ver );
+		wp_enqueue_script( $handle, $plugin_dir . $path, $deps, $ver, $in_footer );
 		if ( !empty( $data_object ) && !empty( $data ) ) wp_localize_script( $handle, $data_object, $data );
 	};
 


### PR DESCRIPTION
While working on a plugin, I came across the need to load footer scripts. The wrapper doesn't actually allow for this although the var is passed, it's not used in the wp_enqueue_script call. I've appended, unless there is a reason it was dropped.
