### PR TITLE
Don't set inline fields to block on JS validation errors

### DIFF
--- a/css/fieldmanager-validation.css
+++ b/css/fieldmanager-validation.css
@@ -3,3 +3,7 @@
 	color: red;
 	display: block;
 }
+
+.fm-label-inline + .fm-element.fm-js-error {
+	display: inline;
+}


### PR DESCRIPTION
This attempts to address an issue where when a field with `'inline_label' => true` fails a jQuery Validation test, the `.fm-js-error` styles switch the field to a block label so long as the error message displays.
