### PR TITLE
reference minified tinymce file directly

### DIFF
--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -62,7 +62,7 @@ class Fieldmanager_RichTextArea extends Fieldmanager_Field {
 				wp_enqueue_script( 'tiny_mce.js', includes_url( 'js/tinymce/tiny_mce.js' ) );
 				wp_enqueue_script( 'wp-langs-en.js', includes_url( 'js/tinymce/langs/wp-langs-en.js' ) );
 			} else {
-				wp_enqueue_script( 'tiny_mce.js', includes_url( 'js/tinymce/tinymce.js' ) );
+				wp_enqueue_script( 'tiny_mce.js', includes_url( 'js/tinymce/tinymce.min.js' ) );
 				wp_enqueue_style( 'editor-buttons' );
 			}
 


### PR DESCRIPTION
I don't really understand why they've made this change, and even more strangely, it's not reflected in the [trac browser](https://core.trac.wordpress.org/browser/trunk#src/wp-includes/js/tinymce) even though when you pull from SVN the non-minified file has been removed.

I'm going to give a patch to VIP on a zendesk ticket along with asking about the change, let's hold off on merging this until we hear from them maybe?
