### PR TITLE
Add in change trigger for hidden fields

### DIFF
--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -17,7 +17,6 @@ fm.autocomplete = {
 				ac_params.select = function( e, ui ) {
 					e.preventDefault();
 					$el.val( ui.item.label );
-					$hidden.val( ui.item.value );
 					$hidden.val( ui.item.value ).trigger( 'change' );
 				};
 				ac_params.focus = function( e, ui ) {


### PR DESCRIPTION
Resubmitting this PR, the last one had a bunch of commits from Broadway in it.  This fires an change trigger for when autocomplete updates it's corresponding hidden field.  This will allow us to know when an autocomplete item has been selected.
