### PR TITLE
Bugfix: errors from repeatable subgroups

### DIFF
--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -599,12 +599,14 @@ abstract class Fieldmanager_Field {
 				return;
 			}
 
-			// UNLESS doing cron, where we should just do nothing if there are no values to process
-			if ( defined( 'DOING_CRON' ) && DOING_CRON && empty( $values ) ) {
+			// OR doing cron, where we should just do nothing if there are no values to process.
+			// OR we've now accumulated some cases where a null value instead of an empty array is an acceptable case to
+			// just bail out instead of throwing an error. If it WAS an attack, bailing should prevent damage.
+			if ( null === $values || ( defined( 'DOING_CRON' ) && DOING_CRON && empty( $values ) ) ) {
 				return;
-			} else {
-				$this->_unauthorized_access( '$values should be an array because $limit is ' . $this->limit );
 			}
+
+			$this->_unauthorized_access( '$values should be an array because $limit is ' . $this->limit );
 		}
 
 		// If $this->limit is not 0 or 1, and $values has more than $limit, that could also be an attack...
@@ -636,7 +638,7 @@ abstract class Fieldmanager_Field {
 		// If this update results in fewer children, trigger presave on empty children to make up the difference.
 		if ( ! empty( $current_values ) && is_array( $current_values ) ) {
 			foreach ( array_diff( array_keys( $current_values ), array_keys( $values ) ) as $i ) {
-				$values[ $i ] = array();
+				$values[ $i ] = null;
 			}
 		}
 

--- a/tests/php/test-fieldmanager-datasource-post.php
+++ b/tests/php/test-fieldmanager-datasource-post.php
@@ -258,41 +258,4 @@ class Test_Fieldmanager_Datasource_Post extends WP_UnitTestCase {
 
 		$this->save_values( $children, $this->parent_post, $test_data );
 	}
-
-	/*
-	 * Test building and saving a nested group
-	 */
-	public function test_saving_nested_groups() {
-
-		$meta_group = new \Fieldmanager_Group( '', array(
-			'name'        => 'distribution',
-			'tabbed'      => true,
-			) );
-
-		$social_group = new \Fieldmanager_Group( 'Social', array(
-			'name'        => 'social',
-			) );
-		$social_group->add_child( new \Fieldmanager_Group( 'Twitter', array(
-			'name'                    => 'twitter',
-			'children'                => array(
-				'share_text'          => new \Fieldmanager_TextArea( 'Sharing Text', array(
-					'description'     => 'What text would you like the user to include in their tweet? (Defaults to title)',
-					'attributes'      => array(
-						'style'           => 'width:100%',
-						)
-					) )
-				),
-			) ) );
-
-		$meta_group->add_child( $social_group );
-		$meta_group->add_meta_box( 'Distribution', array( 'post' ) );
-
-		$meta_group->presave( array(
-				'social'         => array(
-					'twitter'    => array(
-						'share_text'      => 'This is my sample share text'
-						),
-					),
-			) );
-	}
 }

--- a/tests/php/test-fieldmanager-group.php
+++ b/tests/php/test-fieldmanager-group.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Tests the Fieldmanager Datasource Post
+ */
+class Test_Fieldmanager_Group extends WP_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+		Fieldmanager_Field::$debug = true;
+
+		$this->post = $this->factory->post->create_and_get( array(
+			'post_status' => 'draft',
+			'post_content' => rand_str(),
+			'post_title' => rand_str(),
+		) );
+	}
+
+	/**
+	 * Test what happens when setting and changing values in a nested repeatable group.
+	 */
+	public function test_repeat_subgroups() {
+		$base = new Fieldmanager_Group( array(
+			'name' => 'base_group',
+			'limit' => 0,
+			'children' => array(
+				'sub' => new Fieldmanager_Group( array(
+					'name' => 'sub',
+					'limit' => 0,
+					'children' => array(
+						'repeat' => new Fieldmanager_Textfield( array(
+							'limit' => 0,
+							'name' => 'repeat',
+						) ),
+					),
+				) ),
+			),
+		) );
+		$data = array(
+			array( 'sub' => array(
+				array( 'repeat' => array( 'a', 'b', 'c' ) ),
+				array( 'repeat' => array( '1', '2', '3' ) ),
+			) ),
+			array( 'sub' => array(
+				array( 'repeat' => array( '1', '2', '3', '4' ) ),
+			) ),
+		);
+		$base->add_meta_box( 'test meta box', $this->post )->save_to_post_meta( $this->post->ID, $data );
+		$saved_value = get_post_meta( $this->post->ID, 'base_group', true );
+
+		$this->assertEquals( 2, count( $saved_value ) );
+		$this->assertEquals( 2, count( $saved_value[0]['sub'] ) );
+		$this->assertEquals( 1, count( $saved_value[1]['sub'] ) );
+		$this->assertEquals( $data[0]['sub'][0]['repeat'], $saved_value[0]['sub'][0]['repeat'] );
+		$this->assertEquals( $data[0]['sub'][1]['repeat'], $saved_value[0]['sub'][1]['repeat'] );
+		$this->assertEquals( $data[1]['sub'][0]['repeat'], $saved_value[1]['sub'][0]['repeat'] );
+
+		$data = array(
+			array( 'sub' => array(
+				array( 'repeat' => array( '1', '2', '3', '4' ) ),
+			) ),
+			array( 'sub' => array(
+				array( 'repeat' => array( 'a', 'b', 'c' ) ),
+				array( 'repeat' => array( '1', '2', '3' ) ),
+			) ),
+		);
+		$base->add_meta_box( 'test meta box', $this->post )->save_to_post_meta( $this->post->ID, $data );
+		$saved_value = get_post_meta( $this->post->ID, 'base_group', true );
+
+		$this->assertEquals( 2, count( $saved_value ) );
+		$this->assertEquals( 1, count( $saved_value[0]['sub'] ) );
+		$this->assertEquals( 2, count( $saved_value[1]['sub'] ) );
+		$this->assertEquals( $data[0]['sub'][0]['repeat'], $saved_value[0]['sub'][0]['repeat'] );
+		$this->assertEquals( $data[1]['sub'][0]['repeat'], $saved_value[1]['sub'][0]['repeat'] );
+		$this->assertEquals( $data[1]['sub'][1]['repeat'], $saved_value[1]['sub'][1]['repeat'] );
+	}
+
+	/*
+	 * Test building and saving a nested group
+	 */
+	public function test_saving_nested_groups() {
+
+		$meta_group = new \Fieldmanager_Group( '', array(
+			'name'        => 'distribution',
+			'tabbed'      => true,
+			) );
+
+		$social_group = new \Fieldmanager_Group( 'Social', array(
+			'name'        => 'social',
+			) );
+		$social_group->add_child( new \Fieldmanager_Group( 'Twitter', array(
+			'name'                    => 'twitter',
+			'children'                => array(
+				'share_text'          => new \Fieldmanager_TextArea( 'Sharing Text', array(
+					'description'     => 'What text would you like the user to include in their tweet? (Defaults to title)',
+					'attributes'      => array(
+						'style'           => 'width:100%',
+						)
+					) )
+				),
+			) ) );
+
+		$meta_group->add_child( $social_group );
+		$meta_group->add_meta_box( 'Distribution', array( 'post' ) );
+
+		$meta_group->presave( array(
+				'social'         => array(
+					'twitter'    => array(
+						'share_text'      => 'This is my sample share text'
+						),
+					),
+			) );
+	}
+}


### PR DESCRIPTION
Fixed a bug where updating subgroups which resulted in a smaller set threw an error when attempting to preprocess empty padded values, which are passed to give the preprocessing a chance to run (see also #164).

Also moved `test_saving_nested_groups` out of the unrelated Datasource_Post class and into the new Group test class.
