### PR TITLE
fix missing fm-element class for textfields

### DIFF
--- a/templates/textfield.php
+++ b/templates/textfield.php
@@ -1,5 +1,5 @@
 <input
-	class="<?php echo $this->field_class; ?>"
+	class="fm-element <?php echo $this->field_class; ?>"
 	type="text"
 	name="<?php echo $this->get_form_name(); ?>"
 	id="<?php echo $this->get_element_id(); ?>"


### PR DESCRIPTION
See issue https://github.com/alleyinteractive/wordpress-fieldmanager/issues/208
