### PR TITLE
fix tab css

### DIFF
--- a/css/fieldmanager-group-tabs.css
+++ b/css/fieldmanager-group-tabs.css
@@ -1,5 +1,11 @@
+.fm-tab-bar .fm-tab {
+	border: 1px solid transparent;
+}
+
 .fm-tab-bar .wp-tab-active {
 	background: #EDEDED;
+	border: 1px solid #dfdfdf;
+	border-bottom: 1px solid transparent;
 }
 
 .fm-wrapper div.fm-submenu {


### PR DESCRIPTION
The tab CSS is a bit buggy.
1. There is a white line below the active tab
2. The tabs jump by 1px when you switch between them

![image](https://cloud.githubusercontent.com/assets/494927/4736048/7e991f1e-59e8-11e4-8f48-f7777fb66eac.png)

This PR is just a fairly small CSS change that fixes these issues.
