### PR TITLE
Media field: trigger change event after updating/removing hidden field value

### DIFF
--- a/js/media/fieldmanager-media.js
+++ b/js/media/fieldmanager-media.js
@@ -3,7 +3,7 @@ var fm_media_frame = [];
 
 $( document ).on( 'click', '.fm-media-remove', function(e) {
 	e.preventDefault();
-	$(this).parents( '.fm-item.fm-media' ).find( '.fm-media-id' ).val( 0 );
+	$(this).parents( '.fm-item.fm-media' ).find( '.fm-media-id' ).val( 0 ).change();
 	$(this).parents( '.fm-item.fm-media' ).find( '.media-wrapper' ).html( '' );
 });
 
@@ -43,7 +43,7 @@ $( document ).on( 'click', '.fm-media-button', function( event ) {
 		props.link = 'custom';
 		props.linkUrl = '#';
 		props.caption = '';
-		$el.parent().find('.fm-media-id').val( attachment.id );
+		$el.parent().find('.fm-media-id').val( attachment.id ).change();
 		if ( attachment.type == 'image' ) {
 			props.url = props.src;
 			var preview = 'Uploaded file:<br />';


### PR DESCRIPTION
It would be useful if a change event were triggered when a file/media field changes the value of the hidden inuput.

This replicates the event that would fire were a user to change the field value.

This is a pretty edge case requirement - but i'm using the fieldmanager fields to live update a preview, and currently it is not easy to detect whether this value has changed. By triggering this event manually, I can listen for this and update my preview in exactly the same way that I do with standard input fields.

I understand that my use case isn't really standard, however I think this is a fairly small change that makes sense to add. 