### PR TITLE
Add support for individual meta keys

### DIFF
--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -324,7 +324,6 @@ abstract class Fieldmanager_Field {
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->set_options( $label, $options );
-		add_filter( 'fm_submenu_presave_data', 'stripslashes_deep' );
 	}
 
 	/**

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -480,7 +480,7 @@ abstract class Fieldmanager_Field {
 		self::$global_seq++;
 
 		// Drop the fm-group class to hide inner box display if no label is set
-		if ( !( $this->field_class == 'group' && ( !isset( $this->label ) || empty( $this->label ) ) ) ) {
+		if ( !( $this->is_group() && ( !isset( $this->label ) || empty( $this->label ) ) ) ) {
 			$classes[] = 'fm-' . $this->field_class;
 		}
 
@@ -630,6 +630,15 @@ abstract class Fieldmanager_Field {
 			}
 		}
 		return $key;
+	}
+
+	/**
+	 * Is the current field a group?
+	 *
+	 * @return boolean True if yes, false if no.
+	 */
+	public function is_group() {
+		return 'group' == $this->field_class;
 	}
 
 	/**
@@ -850,7 +859,7 @@ abstract class Fieldmanager_Field {
 	public function add_another() {
 		$classes = array( 'fm-add-another', 'fm-' . $this->name . '-add-another', 'button-secondary' );
 		if ( empty( $this->add_more_label ) ) {
-			$this->add_more_label = 'group' == $this->field_class ? __( 'Add group', 'fieldmanager' ) : __( 'Add field', 'fieldmanager' );
+			$this->add_more_label = $this->is_group() ? __( 'Add group', 'fieldmanager' ) : __( 'Add field', 'fieldmanager' );
 		}
 		$out = '<div class="fm-add-another-wrapper">';
 		$out .= sprintf(

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -659,7 +659,7 @@ abstract class Fieldmanager_Field {
 	 * @return boolean True if yes, false if no.
 	 */
 	public function is_group() {
-		return 'group' == $this->field_class;
+		return $this instanceof Fieldmanager_Group;
 	}
 
 	/**

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -192,10 +192,10 @@ abstract class Fieldmanager_Field {
 
 	/**
 	 * Save the fields to their own keys (only works in some contexts). Default
-	 * is false.
+	 * is true.
 	 * @var boolean
 	 */
-	public $separate_keys = false;
+	public $serialize_data = true;
 
 	/**
 	 * @var Fieldmanager_Datasource

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -624,7 +624,7 @@ abstract class Fieldmanager_Field {
 		$key = $el->name;
 		while ( $el = $el->parent ) {
 			if ( $el->limit != 1 ) {
-				return false;
+				throw new FM_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with repeating parent elements', 'fieldmanager' ) );
 			}
 			if ( $el->add_to_prefix ) {
 				$key = "{$el->name}_{$key}";
@@ -641,11 +641,14 @@ abstract class Fieldmanager_Field {
 	public function presave_all( $values, $current_values ) {
 		if ( $this->limit == 1 && empty( $this->multiple ) ) {
 			$values = $this->presave_alter_values( array( $values ), array( $current_values ) );
-			if ( ! empty( $values ) )
+			if ( ! empty( $values ) ) {
 				$value = $this->presave( $values[0], $current_values );
-			else
+			} else {
 				$value = $values;
-			if ( !empty( $this->index ) ) $this->save_index( array( $value ), array( $current_values ) );
+			}
+			if ( !empty( $this->index ) ) {
+				$this->save_index( array( $value ), array( $current_values ) );
+			}
 			return $value;
 		}
 

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -185,10 +185,17 @@ abstract class Fieldmanager_Field {
 	public $skip_save = False;
 
 	/**
-	 * @var string
 	 * Save this field additionally to an index
+	 * @var boolean
 	 */
 	public $index = False;
+
+	/**
+	 * Save the fields to their own keys (only works in some contexts). Default
+	 * is false.
+	 * @var boolean
+	 */
+	public $separate_keys = false;
 
 	/**
 	 * @var Fieldmanager_Datasource
@@ -608,6 +615,25 @@ abstract class Fieldmanager_Field {
 	}
 
 	/**
+	 * Get the storage key for the form element.
+	 *
+	 * @return string
+	 */
+	public function get_element_key() {
+		$el = $this;
+		$key = $el->name;
+		while ( $el = $el->parent ) {
+			if ( $el->limit != 1 ) {
+				return false;
+			}
+			if ( $el->add_to_prefix ) {
+				$key = "{$el->name}_{$key}";
+			}
+		}
+		return $key;
+	}
+
+	/**
 	 * Presaves all elements in what could be a set of them, dispatches to $this->presave()
 	 * @input mixed[] $values
 	 * @return mixed[] sanitized values
@@ -785,7 +811,7 @@ abstract class Fieldmanager_Field {
 				$attr_str[] = sanitize_key( $attr );
 			} else{
 				$attr_str[] = sprintf( '%s="%s"', sanitize_key( $attr ), esc_attr( $val ) );
-			}		
+			}
 		}
 		return implode( ' ', $attr_str );
 	}

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -81,6 +81,10 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 	/**
 	 * Should the group name be included in the meta key prefix for separate
 	 * fields? Default is true.
+	 *
+	 * If false, Fieldmanager will not check for collisions among the meta keys
+	 * created for this group's fields and other registered fields.
+	 *
 	 * @var boolean
 	 */
 	public $add_to_prefix = true;

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -91,6 +91,16 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 	 */
 	protected $child_count = 0;
 
+	/**
+	 * Flag that this field has some descendant with $serialize_data => false.
+	 *
+	 * This field is set based its descendants, but you can deliberately set it
+	 * yourself if your situation is one where this cannot be determined
+	 * automatically (for instance, where descendants are added after the group
+	 * has been constructed).
+	 *
+	 * @var boolean
+	 */
 	public $has_unserialized_descendants = false;
 
 	/**
@@ -126,7 +136,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 			}
 
 			// Flag this group as having unserialized descendants to check invalid use of repeatables
-			if ( ! $element->serialize_data || ( $element->is_group() && $element->has_unserialized_descendants ) ) {
+			if ( ! $this->has_unserialized_descendants && ( ! $element->serialize_data || ( $element->is_group() && $element->has_unserialized_descendants ) ) ) {
 				$this->has_unserialized_descendants = true;
 			}
 
@@ -254,6 +264,11 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 	public function add_child( Fieldmanager_Field $child ) {
 		$child->parent = $this;
 		$this->children[ $child->name ] = $child;
+
+		// Catch errors when using serialize_data => false and index-> true
+		if ( ! $this->serialize_data && $child->index ) {
+			throw new FM_Developer_Exception( esc_html__( 'You cannot use `serialize_data => false` with `index => true`', 'fieldmanager' ) );
+		}
 	}
 
 	/**

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -79,6 +79,13 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 	public $group_is_empty = Null;
 
 	/**
+	 * Should the group name be included in the meta key prefix for separate
+	 * fields? Default is true.
+	 * @var boolean
+	 */
+	public $add_to_prefix = true;
+
+	/**
 	 * @var boolean
 	 * Iterator value for how many children we have rendered.
 	 */

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -107,6 +107,9 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 				throw new FM_Developer_Exception( esc_html__( 'Group child name conflict: ', 'fieldmanager' ) . $name . ' / ' . $element->name );
 			}
 			else if ( !$element->name ) $element->name = $name;
+
+			// Form a child-parent bond
+			$element->parent = $this;
 		}
 
 		// Add the tab JS and CSS if it is needed
@@ -223,6 +226,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 	 * @return void
 	 */
 	public function add_child( Fieldmanager_Field $child ) {
+		$child->parent = $this;
 		$this->children[ $child->name ] = $child;
 	}
 

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -94,8 +94,8 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 	/**
 	 * Flag that this field has some descendant with $serialize_data => false.
 	 *
-	 * This field is set based its descendants, but you can deliberately set it
-	 * yourself if your situation is one where this cannot be determined
+	 * This field is set based on its descendants, but you can deliberately set
+	 * it yourself if your situation is one where this cannot be determined
 	 * automatically (for instance, where descendants are added after the group
 	 * has been constructed).
 	 *
@@ -130,7 +130,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 				$element->name = $name;
 			}
 
-			// Catch errors when using serialize_data => false and index-> true
+			// Catch errors when using serialize_data => false and index => true
 			if ( ! $this->serialize_data && $element->index ) {
 				throw new FM_Developer_Exception( esc_html__( 'You cannot use `serialize_data => false` with `index => true`', 'fieldmanager' ) );
 			}

--- a/php/context/class-fieldmanager-context-post.php
+++ b/php/context/class-fieldmanager-context-post.php
@@ -238,14 +238,10 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 	 * @param array $data
 	 * @return void
 	 */
-<<<<<<< HEAD
 	public function save_to_post_meta( $post_id, $data = null ) {
-=======
-	public function save_to_post_meta( $post_id, $data ) {
 		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
 			return;
 		}
->>>>>>> master
 		$this->fm->data_id = $post_id;
 		$this->fm->data_type = 'post';
 

--- a/php/context/class-fieldmanager-context-post.php
+++ b/php/context/class-fieldmanager-context-post.php
@@ -39,17 +39,6 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 	 */
 	public $fm = null;
 
-	/**
-	 * Callbacks for manipulating data.
-	 * @var array
-	 */
-	public $data_callbacks = array(
-		'get'    => "get_post_meta",
-		'add'    => "add_post_meta",
-		'update' => "update_post_meta",
-		'delete' => "delete_post_meta",
-	);
-
 	/*
 	 * @var boolean
 	 */
@@ -256,6 +245,42 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 		$ret = wp_update_post( $args );
 		self::$doing_internal_update = false;
 		return $ret;
+	}
+
+	/**
+	 * Get post meta.
+	 *
+	 * @see get_post_meta().
+	 */
+	protected function get_data( $post_id, $meta_key, $single = false ) {
+		return get_post_meta( $post_id, $meta_key, $single );
+	}
+
+	/**
+	 * Add post meta.
+	 *
+	 * @see add_post_meta().
+	 */
+	protected function add_data( $post_id, $meta_key, $meta_value, $unique = false ) {
+		return add_post_meta( $post_id, $meta_key, $meta_value, $unique );
+	}
+
+	/**
+	 * Update post meta.
+	 *
+	 * @see update_post_meta().
+	 */
+	protected function update_data( $post_id, $meta_key, $meta_value, $data_prev_value = '' ) {
+		return update_post_meta( $post_id, $meta_key, $meta_value, $data_prev_value );
+	}
+
+	/**
+	 * Delete post meta.
+	 *
+	 * @see delete_post_meta().
+	 */
+	protected function delete_data( $post_id, $meta_key, $meta_value = '' ) {
+		return delete_post_meta( $post_id, $meta_key, $meta_value );
 	}
 
 }

--- a/php/context/class-fieldmanager-context-post.php
+++ b/php/context/class-fieldmanager-context-post.php
@@ -188,15 +188,15 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 		}
 
 		// Make sure the current user is authorized to save this post.
-		if( $_POST['post_type'] == 'post' ) {
-			if( !current_user_can( 'edit_post', $post_id ) ) {
+		if ( $_POST['post_type'] == 'post' ) {
+			if ( ! current_user_can( 'edit_post', $post_id ) ) {
 				$this->fm->_unauthorized_access( __( 'User cannot edit this post', 'fieldmanager' ) );
 				return;
 			}
 		}
 
 		// Make sure that our nonce field arrived intact.
-		if( !wp_verify_nonce( $_POST['fieldmanager-' . $this->fm->name . '-nonce'], 'fieldmanager-save-' . $this->fm->name ) ) {
+		if ( ! wp_verify_nonce( $_POST['fieldmanager-' . $this->fm->name . '-nonce'], 'fieldmanager-save-' . $this->fm->name ) ) {
 			$this->fm->_unauthorized_access( __( 'Nonce validation failed', 'fieldmanager' ) );
 		}
 
@@ -224,12 +224,14 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 	 * @return void
 	 */
 	public function save_to_post_meta( $post_id, $data ) {
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) return;
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+
 		$this->fm->data_id = $post_id;
 		$this->fm->data_type = 'post';
-		$current = get_post_meta( $this->fm->data_id, $this->fm->name, true );
-		$data = $this->fm->presave_all( $data, $current );
-		if ( !$this->fm->skip_save ) update_post_meta( $post_id, $this->fm->name, $data );
+
+		$this->_save( $data );
 	}
 
 }

--- a/php/context/class-fieldmanager-context-post.php
+++ b/php/context/class-fieldmanager-context-post.php
@@ -115,7 +115,7 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 		$this->fm->data_type = 'post';
 		$this->fm->data_id = $post->ID;
 
-		$this->_render_field();
+		$this->render_field();
 
 		// Check if any validation is required
 		$fm_validation = Fieldmanager_Util_Validation( 'post', 'post' );
@@ -202,7 +202,7 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 		// Verify nonce is present and valid. If present but not valid, this
 		// throws an exception, but if it's absent we can assume our data is
 		// not present.
-		if ( ! $this->_is_valid_nonce() ) {
+		if ( ! $this->is_valid_nonce() ) {
 			return;
 		}
 
@@ -245,7 +245,7 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 		$this->fm->data_id = $post_id;
 		$this->fm->data_type = 'post';
 
-		$this->_save( $data );
+		$this->save( $data );
 	}
 
 	/**

--- a/php/context/class-fieldmanager-context-post.php
+++ b/php/context/class-fieldmanager-context-post.php
@@ -40,6 +40,17 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 	public $fm = null;
 
 	/**
+	 * Callbacks for manipulating data.
+	 * @var array
+	 */
+	public $data_callbacks = array(
+		'get'    => "get_post_meta",
+		'add'    => "add_post_meta",
+		'update' => "update_post_meta",
+		'delete' => "delete_post_meta",
+	);
+
+	/**
 	 * Add a context to a fieldmanager
 	 * @param string $title
 	 * @param string|string[] $post_types
@@ -96,13 +107,10 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 	 * @return void.
 	 */
 	public function render_meta_box( $post, $form_struct = null ) {
-		$key = $this->fm->name;
-		$values = get_post_meta( $post->ID, $key );
-		$values = empty( $values ) ? Null : $values[0];
 		$this->fm->data_type = 'post';
 		$this->fm->data_id = $post->ID;
 
-		$this->_render_field( $values );
+		$this->_render_field();
 
 		// Check if any validation is required
 		$fm_validation = Fieldmanager_Util_Validation( 'post', 'post' );

--- a/php/context/class-fieldmanager-context-post.php
+++ b/php/context/class-fieldmanager-context-post.php
@@ -223,9 +223,6 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context {
 	 * @return void
 	 */
 	public function save_to_post_meta( $post_id, $data = null ) {
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-			return;
-		}
 		$this->fm->data_id = $post_id;
 		$this->fm->data_type = 'post';
 

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -119,8 +119,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 		?>
 		<fieldset class="inline-edit-col-left fm-quickedit" id="fm-quickedit-<?php echo esc_attr( $column_name ); ?>" data-fm-post-type="<?php echo esc_attr( $post_type ); ?>">
 			<div class="inline-edit-col">
-				<?php wp_nonce_field( 'fieldmanager-save-' . $this->fm->name, 'fieldmanager-' . $this->fm->name . '-nonce' ); ?>
-				<?php echo $this->fm->element_markup( $values ); ?>
+				<?php $this->_render_field( $values ); ?>
 			</div>
 		</fieldset>
 		<?php
@@ -168,8 +167,8 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 			return;
 		}
 
-		// Ensure that the nonce is set
-		if ( empty( $_POST['fieldmanager-' . $this->fm->name . '-nonce'] ) ) {
+		// Ensure that the nonce is set and valid
+		if ( ! $this->_is_valid_nonce() ) {
 			return;
 		}
 
@@ -181,13 +180,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 			}
 		}
 
-		// Make sure that our nonce field arrived intact
-		if( !wp_verify_nonce( $_POST['fieldmanager-' . $this->fm->name . '-nonce'], 'fieldmanager-save-' . $this->fm->name ) ) {
-			$this->fm->_unauthorized_access( __( 'Nonce validation failed', 'fieldmanager' ) );
-		}
-
-		$value = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : "";
-		$this->save_to_post_meta( $post_id, $value );
+		$this->save_to_post_meta( $post_id );
 	}
 
 	/**
@@ -196,7 +189,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 	 * @param array $data
 	 * @return void
 	 */
-	public function save_to_post_meta( $post_id, $data ) {
+	public function save_to_post_meta( $post_id, $data = null ) {
 		$this->fm->data_id = $post_id;
 		$this->fm->data_type = 'post';
 

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -134,7 +134,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 		?>
 		<fieldset class="inline-edit-col-left fm-quickedit" id="fm-quickedit-<?php echo esc_attr( $column_name ); ?>" data-fm-post-type="<?php echo esc_attr( $post_type ); ?>">
 			<div class="inline-edit-col">
-				<?php $this->_render_field( array( 'data' => $values ) ); ?>
+				<?php $this->render_field( array( 'data' => $values ) ); ?>
 			</div>
 		</fieldset>
 		<?php
@@ -165,7 +165,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 		$this->fm->data_id = $post_id;
 		$post_type = get_post_type( $post_id );
 
-		return $this->add_quickedit_box( $column_name, $post_type, $this->_load() );
+		return $this->add_quickedit_box( $column_name, $post_type, $this->load() );
 	}
 
 	/**
@@ -192,7 +192,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 		}
 
 		// Ensure that the nonce is set and valid
-		if ( ! $this->_is_valid_nonce() ) {
+		if ( ! $this->is_valid_nonce() ) {
 			return;
 		}
 
@@ -217,7 +217,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 		$this->fm->data_id = $post_id;
 		$this->fm->data_type = 'post';
 
-		$this->_save( $data );
+		$this->save( $data );
 	}
 
 }

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -41,17 +41,6 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 	public $fm = '';
 
 	/**
-	 * Callbacks for manipulating data.
-	 * @var array
-	 */
-	public $data_callbacks = array(
-		'get'    => "get_post_meta",
-		'add'    => "add_post_meta",
-		'update' => "update_post_meta",
-		'delete' => "delete_post_meta",
-	);
-
-	/**
 	 * Add a context to a fieldmanager
 	 * @param string $title
 	 * @param string|string[] $post_types
@@ -218,6 +207,42 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 		$this->fm->data_type = 'post';
 
 		$this->save( $data );
+	}
+
+	/**
+	 * Get post meta.
+	 *
+	 * @see get_post_meta().
+	 */
+	protected function get_data( $post_id, $meta_key, $single = false ) {
+		return get_post_meta( $post_id, $meta_key, $single );
+	}
+
+	/**
+	 * Add post meta.
+	 *
+	 * @see add_post_meta().
+	 */
+	protected function add_data( $post_id, $meta_key, $meta_value, $unique = false ) {
+		return add_post_meta( $post_id, $meta_key, $meta_value, $unique );
+	}
+
+	/**
+	 * Update post meta.
+	 *
+	 * @see update_post_meta().
+	 */
+	protected function update_data( $post_id, $meta_key, $meta_value, $data_prev_value = '' ) {
+		return update_post_meta( $post_id, $meta_key, $meta_value, $data_prev_value );
+	}
+
+	/**
+	 * Delete post meta.
+	 *
+	 * @see delete_post_meta().
+	 */
+	protected function delete_data( $post_id, $meta_key, $meta_value = '' ) {
+		return delete_post_meta( $post_id, $meta_key, $meta_value );
 	}
 
 }

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -199,15 +199,8 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 	public function save_to_post_meta( $post_id, $data ) {
 		$this->fm->data_id = $post_id;
 		$this->fm->data_type = 'post';
-		$post = get_post( $post_id );
-		if ( $post->post_type = 'revision' && $post->post_parent != 0 ) {
-			$this->fm->data_id = $post->post_parent;
-		}
-		$current = get_post_meta( $this->fm->data_id, $this->fm->name, True );
-		$data = $this->fm->presave_all( $data, $current );
-		if ( !$this->fm->skip_save ) {
-			update_post_meta( $post_id, $this->fm->name, $data );
-		}
+
+		$this->_save( $data );
 	}
 
 }

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -41,6 +41,17 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 	public $fm = '';
 
 	/**
+	 * Callbacks for manipulating data.
+	 * @var array
+	 */
+	public $data_callbacks = array(
+		'get'    => "get_post_meta",
+		'add'    => "add_post_meta",
+		'update' => "update_post_meta",
+		'delete' => "delete_post_meta",
+	);
+
+	/**
 	 * Add a context to a fieldmanager
 	 * @param string $title
 	 * @param string|string[] $post_types
@@ -119,7 +130,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 		?>
 		<fieldset class="inline-edit-col-left fm-quickedit" id="fm-quickedit-<?php echo esc_attr( $column_name ); ?>" data-fm-post-type="<?php echo esc_attr( $post_type ); ?>">
 			<div class="inline-edit-col">
-				<?php $this->_render_field( $values ); ?>
+				<?php $this->_render_field( array( 'data' => $values ) ); ?>
 			</div>
 		</fieldset>
 		<?php

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -111,7 +111,9 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 	 * @return void
 	 */
 	public function manage_custom_columns( $column_name, $post_id ) {
-		if ( $column_name != $this->fm->name ) return;
+		if ( $column_name != $this->fm->name ) {
+			return;
+		}
 		$data = get_post_meta( $post_id, $this->fm->name, true );
 		$column_text = call_user_func( $this->column_display_callback, $post_id, $data );
 		echo $column_text;
@@ -126,7 +128,9 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 	 * @return void
 	 */
 	public function add_quickedit_box( $column_name, $post_type, $values = array() ) {
-		if ( $column_name != $this->fm->name ) return;
+		if ( $column_name != $this->fm->name ) {
+			return;
+		}
 		?>
 		<fieldset class="inline-edit-col-left fm-quickedit" id="fm-quickedit-<?php echo esc_attr( $column_name ); ?>" data-fm-post-type="<?php echo esc_attr( $post_type ); ?>">
 			<div class="inline-edit-col">
@@ -142,17 +146,26 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context {
 	 * @return string
 	 */
 	public function render_ajax_form() {
+		if ( ! isset( $_GET['action'], $_GET['post_id'], $_GET['column_name'] ) ) {
+			return;
+		}
+
 		if ( $_GET['action'] != 'fm_quickedit_render' ) {
 			return;
 		}
+
 		$column_name = sanitize_text_field( $_GET['column_name'] );
 		$post_id = intval( $_GET['post_id'] );
-		if ( $column_name != $this->fm->name ) return;
-		$values = get_post_meta( $post_id, $this->fm->name );
-		$values = empty( $values ) ? array() : $values[0];
+
+		if ( ! $post_id || $column_name != $this->fm->name ) {
+			return;
+		}
+
+		$this->fm->data_type = 'post';
+		$this->fm->data_id = $post_id;
 		$post_type = get_post_type( $post_id );
-		$markup = $this->add_quickedit_box( $column_name, $post_type, $values );
-		return $markup;
+
+		return $this->add_quickedit_box( $column_name, $post_type, $this->_load() );
 	}
 
 	/**

--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -52,17 +52,6 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context {
 	public $wp_option_autoload = False;
 
 	/**
-	 * Callbacks for manipulating data.
-	 * @var array
-	 */
-	public $data_callbacks = array(
-		'get'    => "get_option",
-		'add'    => "add_option",
-		'update' => "update_option",
-		'delete' => "delete_option",
-	);
-
-	/**
 	 * Create a submenu page out of a field
 	 * @param string $parent_slug
 	 * @param string $page_title
@@ -176,5 +165,41 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context {
 		} else {
 			return admin_url( 'admin.php?page=' . $this->menu_slug );
 		}
+	}
+
+	/**
+	 * Get option.
+	 *
+	 * @see get_option().
+	 */
+	protected function get_data( $data_id, $option_name, $single = false ) {
+		return get_option( $option_name, null );
+	}
+
+	/**
+	 * Add option.
+	 *
+	 * @see add_option().
+	 */
+	protected function add_data( $data_id, $option_name, $option_value, $unique = false ) {
+		return add_option( $option_name, $option_value, '', $this->wp_option_autoload ? 'yes' : 'no' );
+	}
+
+	/**
+	 * Update option.
+	 *
+	 * @see update_option().
+	 */
+	protected function update_data( $data_id, $option_name, $option_value, $option_prev_value = '' ) {
+		return update_option( $option_name, $option_value );
+	}
+
+	/**
+	 * Delete option.
+	 *
+	 * @see delete_option().
+	 */
+	protected function delete_data( $data_id, $option_name, $option_value = '' ) {
+		return delete_option( $option_name, $option_value );
 	}
 }

--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -52,6 +52,17 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context {
 	public $wp_option_autoload = False;
 
 	/**
+	 * Callbacks for manipulating data.
+	 * @var array
+	 */
+	public $data_callbacks = array(
+		'get'    => "get_option",
+		'add'    => "add_option",
+		'update' => "update_option",
+		'delete' => "delete_option",
+	);
+
+	/**
 	 * Create a submenu page out of a field
 	 * @param string $parent_slug
 	 * @param string $page_title
@@ -97,7 +108,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context {
 			<form method="POST" id="<?php echo esc_attr( $this->uniqid ) ?>">
 				<div class="fm-submenu-form-wrapper">
 					<input type="hidden" name="fm-options-action" value="<?php echo sanitize_title( $this->fm->name ) ?>" />
-					<?php $this->_render_field( $values ); ?>
+					<?php $this->_render_field( array( 'data' => $values ) ); ?>
 				</div>
 				<?php submit_button( $this->submit_button_label, 'submit', 'fm-submit' ) ?>
 			</form>

--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -114,7 +114,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context {
 	 * @return void
 	 */
 	public function handle_submenu_save() {
-		if ( empty( $_POST ) || empty( $_GET['page'] ) || $_GET['page'] != $this->menu_slug ) {
+		if ( empty( $_GET['page'] ) || $_GET['page'] != $this->menu_slug ) {
 			return;
 		}
 
@@ -124,6 +124,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context {
 		}
 
 		if ( ! current_user_can( $this->capability ) ) {
+			$this->fm->_unauthorized_access( __( 'Current user cannot edit this page', 'fieldmanager' ) );
 			return;
 		}
 

--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -111,7 +111,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context {
 			<form method="POST" id="<?php echo esc_attr( $this->uniqid ) ?>">
 				<div class="fm-submenu-form-wrapper">
 					<input type="hidden" name="fm-options-action" value="<?php echo sanitize_title( $this->fm->name ) ?>" />
-					<?php $this->_render_field( array( 'data' => $values ) ); ?>
+					<?php $this->render_field( array( 'data' => $values ) ); ?>
 				</div>
 				<?php submit_button( $this->submit_button_label, 'submit', 'fm-submit' ) ?>
 			</form>
@@ -133,7 +133,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context {
 		}
 
 		// Make sure that our nonce field arrived intact
-		if ( ! $this->_is_valid_nonce() ) {
+		if ( ! $this->is_valid_nonce() ) {
 			return;
 		}
 
@@ -152,7 +152,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context {
 		$this->fm->data_id = $this->fm->name;
 		$this->fm->data_type = 'options';
 		$current = get_option( $this->fm->name, null );
-		$data = $this->_prepare_data( $current, $data );
+		$data = $this->prepare_data( $current, $data );
 		$data = apply_filters( 'fm_submenu_presave_data', $data, $this );
 
 		if ( isset( $current ) ) {

--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -79,7 +79,10 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context {
 		$this->page_title = $page_title;
 		$this->capability = $capability;
 		$this->uniqid = $this->fm->get_element_id() . '_form';
-		if ( !$already_registered ) add_action( 'admin_menu', array( $this, 'register_submenu_page' ) );
+		if ( !$already_registered )  {
+			add_action( 'admin_menu', array( $this, 'register_submenu_page' ) );
+			add_filter( 'fm_submenu_presave_data', 'stripslashes_deep' );
+		}
 		add_action( 'admin_init', array( $this, 'handle_submenu_save' ) );
 	}
 

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -186,7 +186,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 			$label = '';
 		}
 
-		$field = $this->_render_field( array( 'echo' => false ) );
+		$field = $this->render_field( array( 'echo' => false ) );
 
 		// Create the markup and return it
 		return sprintf(
@@ -211,7 +211,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 		}
 
 		// Make sure that our nonce field arrived intact
-		if ( ! $this->_is_valid_nonce() ) {
+		if ( ! $this->is_valid_nonce() ) {
 			return;
 		}
 
@@ -238,7 +238,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 		$this->fm->data_type = 'term';
 		$this->current_taxonomy = $taxonomy;
 
-		$this->_save( $data );
+		$this->save( $data );
 	}
 
 	/**

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -162,19 +162,14 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 */
 	public function term_fields( $html_template, $taxonomy, $term = null ) {
 		// Make sure the user hasn't specified a field name we can't use
-		if ( in_array( $this->fm->name, $this->reserved_fields ) )
+		if ( in_array( $this->fm->name, $this->reserved_fields ) ) {
 			$this->fm->_invalid_definition( sprintf( __( 'The field name "%s" is reserved for WordPress on the term form.', 'fieldmanager' ), $this->fm->name ) );
-
-		// Check if there are any current values to retrieve
-		if ( isset( $term->term_id ) ) {
-			$term_meta = Fieldmanager_Util_Term_Meta();
-			$values = $term_meta->get_term_meta( $term->term_id, $taxonomy, $this->fm->name, true );
 		}
-		$values = empty( $values ) ? null : $values;
 
 		// Set the data type and ID
 		$this->fm->data_type = 'term';
 		$this->fm->data_id = is_object( $term ) ? $term->term_id : null;
+		$this->current_taxonomy = $taxonomy;
 
 		// Create the display label if one is set
 		if ( ! empty( $this->title ) ) {
@@ -187,7 +182,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 			$label = '';
 		}
 
-		$field = $this->_render_field( array( 'data' => $values, 'echo' => false ) );
+		$field = $this->_render_field( array( 'echo' => false ) );
 
 		// Create the markup and return it
 		return sprintf(
@@ -260,19 +255,19 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	}
 
 	protected function _get_meta( $term_id, $meta_key, $single = false ) {
-		fm_get_term_meta( $term_id, $this->current_taxonomy, $meta_key, $single );
+		return fm_get_term_meta( $term_id, $this->current_taxonomy, $meta_key, $single );
 	}
 
 	protected function _add_meta( $term_id, $meta_key, $meta_value, $unique = false ) {
-		fm_add_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value, $unique );
+		return fm_add_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value, $unique );
 	}
 
 	protected function _update_meta( $term_id, $meta_key, $meta_value, $meta_prev_value = '' ) {
-		fm_update_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value, $meta_prev_value );
+		return fm_update_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value, $meta_prev_value );
 	}
 
 	protected function _delete_meta( $term_id, $meta_key, $meta_value = '' ) {
-		fm_delete_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value );
+		return fm_delete_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value );
 	}
 
 }

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -210,15 +210,15 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 		if ( ! in_array( $taxonomy, $this->taxonomies ) )
 			return;
 
+		// Make sure that our nonce field arrived intact
+		if ( ! $this->_is_valid_nonce() ) {
+			return;
+		}
+
 		// Make sure the current user can save this post
 		$tax_obj = get_taxonomy( $taxonomy );
 		if( ! current_user_can( $tax_obj->cap->manage_terms ) ) {
 			$this->fm->_unauthorized_access( __( 'User cannot edit this term', 'fieldmanager' ) );
-			return;
-		}
-
-		// Make sure that our nonce field arrived intact
-		if ( ! $this->_is_valid_nonce() ) {
 			return;
 		}
 

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -72,7 +72,9 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 */
 	public function __construct( $title, $taxonomies, $show_on_add = true, $show_on_edit = true, $parent = '', $fm = null ) {
 		// Populate the list of taxonomies for which to add this meta box with the given settings
-		if ( !is_array( $taxonomies ) ) $taxonomies = array( $taxonomies );
+		if ( ! is_array( $taxonomies ) ) {
+			$taxonomies = array( $taxonomies );
+		}
 
 		// Set the class variables
 		$this->title = $title;
@@ -115,8 +117,9 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 */
 	public function add_term_fields( $taxonomy ) {
 		// If the parent is set, do nothing because we don't know what the parent term is yet
-		if ( ! empty( $this->parent ) )
+		if ( ! empty( $this->parent ) ) {
 			return;
+		}
 
 		// Create the HTML template for output
 		$html_template = '<div class="form-field">%s%s</div>';
@@ -138,8 +141,9 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 */
 	public function edit_term_fields( $term, $taxonomy ) {
 		// Check if this term's parent matches the specified term if it is set
-		if ( ! empty( $this->parent ) && $this->parent != $term->parent )
+		if ( ! empty( $this->parent ) && $this->parent != $term->parent ) {
 			return;
+		}
 
 		// Create the HTML template for output
 		$html_template = '<tr class="form-field"><th scope="row" valign="top">%s</th><td>%s</td></tr>';
@@ -202,8 +206,9 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 */
 	public function save_term_fields( $term_id, $tt_id, $taxonomy ) {
 		// Make sure this field is attached to the taxonomy being saved and this is the appropriate action
-		if ( ! in_array( $taxonomy, $this->taxonomies ) )
+		if ( ! in_array( $taxonomy, $this->taxonomies ) ) {
 			return;
+		}
 
 		// Make sure that our nonce field arrived intact
 		if ( ! $this->_is_valid_nonce() ) {
@@ -212,7 +217,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 
 		// Make sure the current user can save this post
 		$tax_obj = get_taxonomy( $taxonomy );
-		if( ! current_user_can( $tax_obj->cap->manage_terms ) ) {
+		if ( ! current_user_can( $tax_obj->cap->manage_terms ) ) {
 			$this->fm->_unauthorized_access( __( 'User cannot edit this term', 'fieldmanager' ) );
 			return;
 		}

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -212,7 +212,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 
 		// Make sure the current user can save this post
 		$tax_obj = get_taxonomy( $taxonomy );
-		if( !current_user_can( $tax_obj->cap->manage_terms ) ) {
+		if( ! current_user_can( $tax_obj->cap->manage_terms ) ) {
 			$this->fm->_unauthorized_access( __( 'User cannot edit this term', 'fieldmanager' ) );
 			return;
 		}

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -56,12 +56,6 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 */
 	private $current_taxonomy;
 
-	/**
-	 * Callbacks for manipulating data.
-	 * @var array
-	 */
-	public $data_callbacks = array();
-
 
 	/**
 	 * Add a context to a fieldmanager
@@ -100,13 +94,6 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 			// Also handle removing data when a term is deleted
 			add_action( 'delete_term', array( $this, 'delete_term_fields'), 10, 4 );
 		}
-
-		$this->data_callbacks = array(
-			'get'    => array( $this, 'get_meta' ),
-			'add'    => array( $this, 'add_meta' ),
-			'update' => array( $this, 'update_meta' ),
-			'delete' => array( $this, 'delete_meta' ),
-		);
 	}
 
 	/**
@@ -264,7 +251,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 *
 	 * @see Fieldmanager_Util_Term_Meta::get_term_meta()
 	 */
-	protected function get_meta( $term_id, $meta_key, $single = false ) {
+	protected function get_data( $term_id, $meta_key, $single = false ) {
 		return fm_get_term_meta( $term_id, $this->current_taxonomy, $meta_key, $single );
 	}
 
@@ -273,7 +260,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 *
 	 * @see Fieldmanager_Util_Term_Meta::add_term_meta()
 	 */
-	protected function add_meta( $term_id, $meta_key, $meta_value, $unique = false ) {
+	protected function add_data( $term_id, $meta_key, $meta_value, $unique = false ) {
 		return fm_add_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value, $unique );
 	}
 
@@ -282,7 +269,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 *
 	 * @see Fieldmanager_Util_Term_Meta::update_term_meta()
 	 */
-	protected function update_meta( $term_id, $meta_key, $meta_value, $meta_prev_value = '' ) {
+	protected function update_data( $term_id, $meta_key, $meta_value, $meta_prev_value = '' ) {
 		return fm_update_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value, $meta_prev_value );
 	}
 
@@ -291,7 +278,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 *
 	 * @see Fieldmanager_Util_Term_Meta::delete_term_meta()
 	 */
-	protected function delete_meta( $term_id, $meta_key, $meta_value = '' ) {
+	protected function delete_data( $term_id, $meta_key, $meta_value = '' ) {
 		return fm_delete_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value );
 	}
 

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -102,10 +102,10 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 		}
 
 		$this->data_callbacks = array(
-			'get'    => array( $this, '_get_meta' ),
-			'add'    => array( $this, '_add_meta' ),
-			'update' => array( $this, '_update_meta' ),
-			'delete' => array( $this, '_delete_meta' ),
+			'get'    => array( $this, 'get_meta' ),
+			'add'    => array( $this, 'add_meta' ),
+			'update' => array( $this, 'update_meta' ),
+			'delete' => array( $this, 'delete_meta' ),
 		);
 	}
 
@@ -259,19 +259,39 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 		$term_meta->delete_term_meta( $term_id, $taxonomy, $this->fm->name );
 	}
 
-	protected function _get_meta( $term_id, $meta_key, $single = false ) {
+	/**
+	 * Callback to get term meta for the given term ID and current taxonomy.
+	 *
+	 * @see Fieldmanager_Util_Term_Meta::get_term_meta()
+	 */
+	protected function get_meta( $term_id, $meta_key, $single = false ) {
 		return fm_get_term_meta( $term_id, $this->current_taxonomy, $meta_key, $single );
 	}
 
-	protected function _add_meta( $term_id, $meta_key, $meta_value, $unique = false ) {
+	/**
+	 * Callback to add term meta for the given term ID and current taxonomy.
+	 *
+	 * @see Fieldmanager_Util_Term_Meta::add_term_meta()
+	 */
+	protected function add_meta( $term_id, $meta_key, $meta_value, $unique = false ) {
 		return fm_add_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value, $unique );
 	}
 
-	protected function _update_meta( $term_id, $meta_key, $meta_value, $meta_prev_value = '' ) {
+	/**
+	 * Callback to update term meta for the given term ID and current taxonomy.
+	 *
+	 * @see Fieldmanager_Util_Term_Meta::update_term_meta()
+	 */
+	protected function update_meta( $term_id, $meta_key, $meta_value, $meta_prev_value = '' ) {
 		return fm_update_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value, $meta_prev_value );
 	}
 
-	protected function _delete_meta( $term_id, $meta_key, $meta_value = '' ) {
+	/**
+	 * Callback to delete term meta for the given term ID and current taxonomy.
+	 *
+	 * @see Fieldmanager_Util_Term_Meta::delete_term_meta()
+	 */
+	protected function delete_meta( $term_id, $meta_key, $meta_value = '' ) {
 		return fm_delete_term_meta( $term_id, $this->current_taxonomy, $meta_key, $meta_value );
 	}
 

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -56,6 +56,12 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 	 */
 	private $current_taxonomy;
 
+	/**
+	 * Callbacks for manipulating data.
+	 * @var array
+	 */
+	public $data_callbacks = array();
+
 
 	/**
 	 * Add a context to a fieldmanager
@@ -93,8 +99,12 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 			add_action( 'delete_term', array( $this, 'delete_term_fields'), 10, 4 );
 		}
 
-
-
+		$this->data_callbacks = array(
+			'get'    => array( $this, '_get_meta' ),
+			'add'    => array( $this, '_add_meta' ),
+			'update' => array( $this, '_update_meta' ),
+			'delete' => array( $this, '_delete_meta' ),
+		);
 	}
 
 	/**
@@ -177,7 +187,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 			$label = '';
 		}
 
-		$field = $this->_render_field( $values, false );
+		$field = $this->_render_field( array( 'data' => $values, 'echo' => false ) );
 
 		// Create the markup and return it
 		return sprintf(
@@ -228,12 +238,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context {
 		$this->fm->data_type = 'term';
 		$this->current_taxonomy = $taxonomy;
 
-		$this->_save( $data, array(
-			'get'    => array( $this, '_get_meta' ),
-			'add'    => array( $this, '_add_meta' ),
-			'update' => array( $this, '_update_meta' ),
-			'delete' => array( $this, '_delete_meta' ),
-		) );
+		$this->_save( $data );
 	}
 
 	/**

--- a/php/context/class-fieldmanager-context-user.php
+++ b/php/context/class-fieldmanager-context-user.php
@@ -65,7 +65,7 @@ class Fieldmanager_Context_User extends Fieldmanager_Context {
 			echo '<h3>' . esc_html( $this->title ) . '</h3>';
 		}
 		echo '<div class="fm-user-form-wrapper">';
-		$this->_render_field();
+		$this->render_field();
 		echo '</div>';
 
 		// Check if any validation is required
@@ -79,7 +79,7 @@ class Fieldmanager_Context_User extends Fieldmanager_Context {
 	 * @param int $user_id
 	 */
 	public function save_user_form( $user_id ) {
-		if ( ! $this->_is_valid_nonce() ) {
+		if ( ! $this->is_valid_nonce() ) {
 			return;
 		}
 
@@ -100,6 +100,6 @@ class Fieldmanager_Context_User extends Fieldmanager_Context {
 		$this->fm->data_id = $user_id;
 		$this->fm->data_type = 'user';
 
-		$this->_save( $data );
+		$this->save( $data );
 	}
 }

--- a/php/context/class-fieldmanager-context-user.php
+++ b/php/context/class-fieldmanager-context-user.php
@@ -16,17 +16,6 @@ class Fieldmanager_Context_User extends Fieldmanager_Context {
 	public $title;
 
 	/**
-	 * Callbacks for manipulating data.
-	 * @var array
-	 */
-	public $data_callbacks = array(
-		'get'    => "get_user_meta",
-		'add'    => "add_user_meta",
-		'update' => "update_user_meta",
-		'delete' => "delete_user_meta",
-	);
-
-	/**
 	 * Add fieldmanager to user form
 	 * @param string $title
 	 * @param Fieldmanager_Field $fm
@@ -101,5 +90,41 @@ class Fieldmanager_Context_User extends Fieldmanager_Context {
 		$this->fm->data_type = 'user';
 
 		$this->save( $data );
+	}
+
+	/**
+	 * Get user meta.
+	 *
+	 * @see get_user_meta().
+	 */
+	protected function get_data( $user_id, $meta_key, $single = false ) {
+		return get_user_meta( $user_id, $meta_key, $single );
+	}
+
+	/**
+	 * Add user meta.
+	 *
+	 * @see add_user_meta().
+	 */
+	protected function add_data( $user_id, $meta_key, $meta_value, $unique = false ) {
+		return add_user_meta( $user_id, $meta_key, $meta_value, $unique );
+	}
+
+	/**
+	 * Update user meta.
+	 *
+	 * @see update_user_meta().
+	 */
+	protected function update_data( $user_id, $meta_key, $meta_value, $data_prev_value = '' ) {
+		return update_user_meta( $user_id, $meta_key, $meta_value, $data_prev_value );
+	}
+
+	/**
+	 * Delete user meta.
+	 *
+	 * @see delete_user_meta().
+	 */
+	protected function delete_data( $user_id, $meta_key, $meta_value = '' ) {
+		return delete_user_meta( $user_id, $meta_key, $meta_value );
 	}
 }

--- a/php/context/class-fieldmanager-context-user.php
+++ b/php/context/class-fieldmanager-context-user.php
@@ -62,7 +62,7 @@ class Fieldmanager_Context_User extends Fieldmanager_Context {
 		$this->fm->data_type = 'user';
 
 		if ( !empty( $this->title ) ) {
-			echo '<h3>' . $this->title . '</h3>';
+			echo '<h3>' . esc_html( $this->title ) . '</h3>';
 		}
 		echo '<div class="fm-user-form-wrapper">';
 		$this->_render_field();

--- a/php/context/class-fieldmanager-context-user.php
+++ b/php/context/class-fieldmanager-context-user.php
@@ -67,10 +67,6 @@ class Fieldmanager_Context_User extends Fieldmanager_Context {
 	 * @param int $user_id
 	 */
 	public function save_user_form( $user_id ) {
-		if ( empty( $_POST ) ) {
-			return;
-		}
-
 		if ( ! $this->_is_valid_nonce() ) {
 			return;
 		}

--- a/php/context/class-fieldmanager-context-user.php
+++ b/php/context/class-fieldmanager-context-user.php
@@ -10,10 +10,21 @@
 class Fieldmanager_Context_User extends Fieldmanager_Context {
 
 	/**
-	 * @var string
 	 * Group Title
+	 * @var string
 	 */
 	public $title;
+
+	/**
+	 * Callbacks for manipulating data.
+	 * @var array
+	 */
+	public $data_callbacks = array(
+		'get'    => "get_user_meta",
+		'add'    => "add_user_meta",
+		'update' => "update_user_meta",
+		'delete' => "delete_user_meta",
+	);
 
 	/**
 	 * Add fieldmanager to user form
@@ -47,13 +58,14 @@ class Fieldmanager_Context_User extends Fieldmanager_Context {
 	 * @return void
 	 */
 	public function render_user_form( $user ) {
-		$values = get_user_meta( $user->ID, $this->fm->name );
-		$values = empty( $values ) ? null : $values[0];
+		$this->fm->data_id = $user->ID;
+		$this->fm->data_type = 'user';
+
 		if ( !empty( $this->title ) ) {
 			echo '<h3>' . $this->title . '</h3>';
 		}
 		echo '<div class="fm-user-form-wrapper">';
-		$this->_render_field( $values );
+		$this->_render_field();
 		echo '</div>';
 
 		// Check if any validation is required

--- a/php/context/class-fieldmanager-context-user.php
+++ b/php/context/class-fieldmanager-context-user.php
@@ -68,12 +68,10 @@ class Fieldmanager_Context_User extends Fieldmanager_Context {
 	 *
 	 * @param  int $user_id
 	 */
-	public function save_to_user_meta( $user_id, $value ) {
+	public function save_to_user_meta( $user_id, $data ) {
 		$this->fm->data_id = $user_id;
 		$this->fm->data_type = 'user';
-		$current = get_user_meta( $user_id, $this->fm->name, true );
-		$data = $this->fm->presave_all( $value, $current );
-		$data = apply_filters( 'fm_user_presave_data', $data, $this->fm );
-		update_user_meta( $user_id, $this->fm->name, $data );
+
+		$this->_save( $data );
 	}
 }

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -61,7 +61,7 @@ abstract class Fieldmanager_Context {
 	 */
 	protected function _prepare_data( $old_value = null, $new_value = null, $fm = null ) {
 		if ( null === $new_value ) {
-			$new_value = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : "";
+			$new_value = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : '';
 		}
 		if ( null === $fm ) {
 			$fm = $this->fm;
@@ -104,6 +104,9 @@ abstract class Fieldmanager_Context {
 		if ( $this->fm->serialize_data ) {
 			$this->_save_field( $this->fm, $data, $this->fm->data_id );
 		} else {
+			if ( null === $data ) {
+				$data = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : '';
+			}
 			$this->_save_walk_children( $this->fm, $data, $this->fm->data_id );
 		}
 	}

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -45,7 +45,7 @@ abstract class Fieldmanager_Context {
 	 *
 	 * @return boolean
 	 */
-	protected function _is_valid_nonce() {
+	protected function is_valid_nonce() {
 		if ( empty( $_POST['fieldmanager-' . $this->fm->name . '-nonce'] ) ) {
 			return false;
 		}
@@ -66,7 +66,7 @@ abstract class Fieldmanager_Context {
 	 * @param  object $fm Optional. The Fieldmanager field to prepare.
 	 * @return mixed The filtered and sanitized value, safe to save.
 	 */
-	protected function _prepare_data( $old_value = null, $new_value = null, $fm = null ) {
+	protected function prepare_data( $old_value = null, $new_value = null, $fm = null ) {
 		if ( null === $fm ) {
 			$fm = $this->fm;
 		}
@@ -92,8 +92,8 @@ abstract class Fieldmanager_Context {
 	 * }
 	 * @return string if $args['echo'] == false.
 	 */
-	protected function _render_field( $args = array() ) {
-		$data = array_key_exists( 'data', $args ) ? $args['data'] : $this->_load();
+	protected function render_field( $args = array() ) {
+		$data = array_key_exists( 'data', $args ) ? $args['data'] : $this->load();
 		$echo = isset( $args['echo'] ) ? $args['echo'] : true;
 
 		$nonce = wp_nonce_field( 'fieldmanager-save-' . $this->fm->name, 'fieldmanager-' . $this->fm->name . '-nonce', true, false );
@@ -111,17 +111,17 @@ abstract class Fieldmanager_Context {
 	 *
 	 * @param mixed $data Data to save. Should be raw, e.g. POST data.
 	 */
-	protected function _save( $data = null ) {
+	protected function save( $data = null ) {
 		// Reset the save keys in the event this context instance is saved twice
 		$this->save_keys = array();
 
 		if ( $this->fm->serialize_data ) {
-			$this->_save_field( $this->fm, $data, $this->fm->data_id );
+			$this->save_field( $this->fm, $data, $this->fm->data_id );
 		} else {
 			if ( null === $data ) {
 				$data = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : '';
 			}
-			$this->_save_walk_children( $this->fm, $data, $this->fm->data_id );
+			$this->save_walk_children( $this->fm, $data, $this->fm->data_id );
 		}
 	}
 
@@ -131,7 +131,7 @@ abstract class Fieldmanager_Context {
 	 * @param  object $field Fieldmanager field.
 	 * @param  mixed $data Data to save.
 	 */
-	protected function _save_field( $field, $data ) {
+	protected function save_field( $field, $data ) {
 		$field->data_id = $this->fm->data_id;
 		$field->data_type = $this->fm->data_type;
 
@@ -142,7 +142,7 @@ abstract class Fieldmanager_Context {
 		}
 
 		$current = call_user_func( $this->data_callbacks['get'], $this->fm->data_id, $field->get_element_key(), $field->serialize_data );
-		$data = $this->_prepare_data( $current, $data, $field );
+		$data = $this->prepare_data( $current, $data, $field );
 		if ( ! $field->skip_save ) {
 			if ( $field->serialize_data ) {
 				call_user_func( $this->data_callbacks['update'], $this->fm->data_id, $field->get_element_key(), $data );
@@ -161,13 +161,13 @@ abstract class Fieldmanager_Context {
 	 * @param  object $field Fieldmanager field.
 	 * @param  mixed $data Data to save.
 	 */
-	protected function _save_walk_children( $field, $data ) {
+	protected function save_walk_children( $field, $data ) {
 		if ( $field->serialize_data || ! $field->is_group() ) {
-			$this->_save_field( $field, $data );
+			$this->save_field( $field, $data );
 		} else {
 			foreach ( $field->children as $child ) {
 				if ( isset( $data[ $child->name ] ) ) {
-					$this->_save_walk_children( $child, $data[ $child->name ] );
+					$this->save_walk_children( $child, $data[ $child->name ] );
 				}
 			}
 		}
@@ -179,11 +179,11 @@ abstract class Fieldmanager_Context {
 	 *
 	 * @return mixed The loaded data.
 	 */
-	protected function _load() {
+	protected function load() {
 		if ( $this->fm->serialize_data ) {
-			return $this->_load_field( $this->fm, $this->fm->data_id );
+			return $this->load_field( $this->fm, $this->fm->data_id );
 		} else {
-			return $this->_load_walk_children( $this->fm, $this->fm->data_id );
+			return $this->load_walk_children( $this->fm, $this->fm->data_id );
 		}
 	}
 
@@ -193,7 +193,7 @@ abstract class Fieldmanager_Context {
 	 * @param  object $field The Fieldmanager field for which to load data.
 	 * @return mixed Data stored for that field in this context.
 	 */
-	protected function _load_field( $field ) {
+	protected function load_field( $field ) {
 		$data = call_user_func( $this->data_callbacks['get'], $this->fm->data_id, $field->get_element_key() );
 		if ( $field->serialize_data ) {
 			return empty( $data ) ? null : reset( $data );
@@ -209,13 +209,13 @@ abstract class Fieldmanager_Context {
 	 * @return mixed Data stored for a singular field with serialized data, or
 	 *               array of data for a groups's children.
 	 */
-	protected function _load_walk_children( $field ) {
+	protected function load_walk_children( $field ) {
 		if ( $field->serialize_data || ! $field->is_group() ) {
-			return $this->_load_field( $field );
+			return $this->load_field( $field );
 		} else {
 			$return = array();
 			foreach ( $field->children as $child ) {
-				$return[ $child->name ] = $this->_load_walk_children( $child );
+				$return[ $child->name ] = $this->load_walk_children( $child );
 			}
 			return $return;
 		}

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -114,7 +114,7 @@ abstract class Fieldmanager_Context {
 			} else {
 				call_user_func( $this->data_callbacks['delete'], $field->data_id, $field->get_element_key() );
 				foreach ( $data as $value ) {
-					call_user_func( $this->data_callbacks['add'], $field->data_id, $field->get_element_key(), $data );
+					call_user_func( $this->data_callbacks['add'], $field->data_id, $field->get_element_key(), $value );
 				}
 			}
 		}

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -2,24 +2,80 @@
 /**
  * @package Fieldmanager_Context
  */
- 
+
 /**
  * Base class for context
  * @package Fieldmanager_Context
  */
 abstract class Fieldmanager_Context {
-	
+
 	/**
 	 * @var Fieldmanager_Field
 	 * The base field associated with this context
 	 */
 	public $fm = Null;
-	
+
 	/**
 	 * @var string
 	 * Unique ID of the form. Used for forms that are not built into WordPress.
 	 */
 	public $uniqid;
+
+
+	/**
+	 * Check if the nonce is valid. Returns false if the nonce is missing and
+	 * throws an exception if it's invalid. If all goes well, returns true.
+	 *
+	 * @return boolean
+	 */
+	protected function _is_valid_nonce() {
+		if ( empty( $_POST['fieldmanager-' . $this->fm->name . '-nonce'] ) ) {
+			return false;
+		}
+
+		if ( ! wp_verify_nonce( $_POST['fieldmanager-' . $this->fm->name . '-nonce'], 'fieldmanager-save-' . $this->fm->name ) ) {
+			$this->fm->_unauthorized_access( __( 'Nonce validation failed', 'fieldmanager' ) );
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Prepare the data for saving.
+	 *
+	 * @param  mixed $old_value Optional. The previous value.
+	 * @param  mixed $new_value Optional. The new value for the field.
+	 * @return mixed The filtered and sanitized value, safe to save.
+	 */
+	protected function _prepare_data( $old_value = null, $new_value = null ) {
+		if ( null === $new_value ) {
+			$new_value = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : "";
+		}
+		$new_value = apply_filters( "fm_context_before_presave_data", $new_value, $old_value, $this );
+		$data = $this->fm->presave_all( $new_value, $old_value );
+		return apply_filters( "fm_context_after_presave_data", $data, $old_value, $this );
+	}
+
+
+	/**
+	 * Render the field.
+	 *
+	 * @param  mixed $values Optional. The existing data to display with the
+	 *                       field.
+	 * @param  boolean $echo Optional. Output the data or return it. Defaults
+	 *                       to true (to output the data).
+	 * @return string if $echo = false.
+	 */
+	protected function _render_field( $values = null, $echo = true ) {
+		$nonce = wp_nonce_field( 'fieldmanager-save-' . $this->fm->name, 'fieldmanager-' . $this->fm->name . '-nonce', true, false );
+		$field = $this->fm->element_markup( $values );
+		if ( $echo ) {
+			echo $nonce . $field;
+		} else {
+			return $nonce . $field;
+		}
+	}
 
 
 	/**
@@ -35,7 +91,7 @@ abstract class Fieldmanager_Context {
 	 *     @type string $delete Callback to delete data.
 	 * }
 	 */
-	protected function _save( $data, $callbacks = null ) {
+	protected function _save( $data = null, $callbacks = null ) {
 		if ( ! $callbacks ) {
 			$callbacks = array(
 				'get'    => "get_{$this->fm->data_type}_meta",
@@ -47,8 +103,8 @@ abstract class Fieldmanager_Context {
 
 		$current = call_user_func( $callbacks['get'], $this->fm->data_id, $this->fm->name, true );
 
-		$data = $this->fm->presave_all( $data, $current );
-		$data = apply_filters( 'fm_' . $this->fm->data_type . '_presave_data', $data, $this->fm );
+		// if $data is null, this will get it from $_POST
+		$data = $this->_prepare_data( $current, $data );
 
 		if ( ! $this->fm->skip_save ) {
 			call_user_func( $callbacks['update'], $this->fm->data_id, $this->fm->name, $data );

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -127,7 +127,7 @@ abstract class Fieldmanager_Context {
 	}
 
 	protected function _save_walk_children( $field, $data, $object_id ) {
-		if ( $field->serialize_data || 'group' != $field->field_class ) {
+		if ( $field->serialize_data || $field->is_group() ) {
 			$this->_save_field( $field, $data, $object_id );
 		} else {
 			foreach ( $field->children as $child ) {
@@ -160,7 +160,7 @@ abstract class Fieldmanager_Context {
 	}
 
 	protected function _load_walk_children( $field, $object_id ) {
-		if ( $field->serialize_data || 'group' != $field->field_class ) {
+		if ( $field->serialize_data || $field->is_group() ) {
 			return $this->_load_field( $field, $object_id );
 		} else {
 			$return = array();

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -127,7 +127,7 @@ abstract class Fieldmanager_Context {
 	}
 
 	protected function _save_walk_children( $field, $data, $object_id ) {
-		if ( $field->serialize_data || $field->is_group() ) {
+		if ( $field->serialize_data || ! $field->is_group() ) {
 			$this->_save_field( $field, $data, $object_id );
 		} else {
 			foreach ( $field->children as $child ) {
@@ -160,7 +160,7 @@ abstract class Fieldmanager_Context {
 	}
 
 	protected function _load_walk_children( $field, $object_id ) {
-		if ( $field->serialize_data || $field->is_group() ) {
+		if ( $field->serialize_data || ! $field->is_group() ) {
 			return $this->_load_field( $field, $object_id );
 		} else {
 			$return = array();

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -82,15 +82,19 @@ abstract class Fieldmanager_Context {
 	/**
 	 * Render the field.
 	 *
-	 * @param  mixed $values Optional. The existing data to display with the
-	 *                       field.
-	 * @param  boolean $echo Optional. Output the data or return it. Defaults
-	 *                       to true (to output the data).
-	 * @return string if $echo = false.
+	 * @param array $args {
+	 *     Optional. Arguments to adjust the rendering behavior.
+	 *
+	 *     @type mixed $data The existing data to display with the field. If
+	 *                       absent, data will be loaded using
+	 *                       Fieldmanager_Context::_load().
+	 *     @type boolean $echo Output if true, return if false. Default is true.
+	 * }
+	 * @return string if $args['echo'] == false.
 	 */
 	protected function _render_field( $args = array() ) {
 		$data = array_key_exists( 'data', $args ) ? $args['data'] : $this->_load();
-		$echo = array_key_exists( 'echo', $args ) ? $args['echo'] : true;
+		$echo = isset( $args['echo'] ) ? $args['echo'] : true;
 
 		$nonce = wp_nonce_field( 'fieldmanager-save-' . $this->fm->name, 'fieldmanager-' . $this->fm->name . '-nonce', true, false );
 		$field = $this->fm->element_markup( $data );

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -21,4 +21,37 @@ abstract class Fieldmanager_Context {
 	 */
 	public $uniqid;
 
+
+	/**
+	 * Handle saving data for any context.
+	 *
+	 * @param mixed $data Data to save. Should be raw, e.g. POST data.
+	 * @param array $callbacks {
+	 *     Callback functions for data storage manipulation.
+	 *
+	 *     @type string $get Callback to get data.
+	 *     @type string $add Callback to add data.
+	 *     @type string $update Callback to update data.
+	 *     @type string $delete Callback to delete data.
+	 * }
+	 */
+	protected function _save( $data, $callbacks = null ) {
+		if ( ! $callbacks ) {
+			$callbacks = array(
+				'get'    => "get_{$this->fm->data_type}_meta",
+				'add'    => "add_{$this->fm->data_type}_meta",
+				'update' => "update_{$this->fm->data_type}_meta",
+				'delete' => "delete_{$this->fm->data_type}_meta",
+			);
+		}
+
+		$current = call_user_func( $callbacks['get'], $this->fm->data_id, $this->fm->name, true );
+
+		$data = $this->fm->presave_all( $data, $current );
+		$data = apply_filters( 'fm_' . $this->fm->data_type . '_presave_data', $data, $this->fm );
+
+		if ( ! $this->fm->skip_save ) {
+			call_user_func( $callbacks['update'], $this->fm->data_id, $this->fm->name, $data );
+		}
+	}
 }

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -63,14 +63,15 @@ abstract class Fieldmanager_Context {
 	 *
 	 * @param  mixed $old_value Optional. The previous value.
 	 * @param  mixed $new_value Optional. The new value for the field.
+	 * @param  object $fm Optional. The Fieldmanager field to prepare.
 	 * @return mixed The filtered and sanitized value, safe to save.
 	 */
 	protected function _prepare_data( $old_value = null, $new_value = null, $fm = null ) {
-		if ( null === $new_value ) {
-			$new_value = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : '';
-		}
 		if ( null === $fm ) {
 			$fm = $this->fm;
+		}
+		if ( null === $new_value ) {
+			$new_value = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : '';
 		}
 		$new_value = apply_filters( "fm_context_before_presave_data", $new_value, $old_value, $this );
 		$data = $fm->presave_all( $new_value, $old_value );
@@ -120,6 +121,12 @@ abstract class Fieldmanager_Context {
 		}
 	}
 
+	/**
+	 * Save a single field.
+	 *
+	 * @param  object $field Fieldmanager field.
+	 * @param  mixed $data Data to save.
+	 */
 	protected function _save_field( $field, $data ) {
 		$field->data_id = $this->fm->data_id;
 		$field->data_type = $this->fm->data_type;
@@ -144,6 +151,12 @@ abstract class Fieldmanager_Context {
 		}
 	}
 
+	/**
+	 * Walk group children to save when serialize_data => false.
+	 *
+	 * @param  object $field Fieldmanager field.
+	 * @param  mixed $data Data to save.
+	 */
 	protected function _save_walk_children( $field, $data ) {
 		if ( $field->serialize_data || ! $field->is_group() ) {
 			$this->_save_field( $field, $data );
@@ -159,6 +172,8 @@ abstract class Fieldmanager_Context {
 
 	/**
 	 * Handle loading data for any context.
+	 *
+	 * @return mixed The loaded data.
 	 */
 	protected function _load() {
 		if ( $this->fm->serialize_data ) {
@@ -168,6 +183,12 @@ abstract class Fieldmanager_Context {
 		}
 	}
 
+	/**
+	 * Load a single field.
+	 *
+	 * @param  object $field The Fieldmanager field for which to load data.
+	 * @return mixed Data stored for that field in this context.
+	 */
 	protected function _load_field( $field ) {
 		$data = call_user_func( $this->data_callbacks['get'], $this->fm->data_id, $field->get_element_key() );
 		if ( $field->serialize_data ) {
@@ -177,6 +198,13 @@ abstract class Fieldmanager_Context {
 		}
 	}
 
+	/**
+	 * Walk group children to load when serialize_data => false.
+	 *
+	 * @param  object $field Fieldmanager field for which to load data.
+	 * @return mixed Data stored for a singular field with serialized data, or
+	 *               array of data for a groups's children.
+	 */
 	protected function _load_walk_children( $field ) {
 		if ( $field->serialize_data || ! $field->is_group() ) {
 			return $this->_load_field( $field );

--- a/tests/php/test-fieldmanager-autocomplete-field.php
+++ b/tests/php/test-fieldmanager-autocomplete-field.php
@@ -2,7 +2,9 @@
 
 /**
  * Tests the Fieldmanager Autocomplete Field
- * @group fields
+ *
+ * @group field
+ * @group autocomplete
  */
 class Test_Fieldmanager_Autocomplete_Field extends WP_UnitTestCase {
 

--- a/tests/php/test-fieldmanager-checkbox-field.php
+++ b/tests/php/test-fieldmanager-checkbox-field.php
@@ -4,6 +4,7 @@
  * Tests the Fieldmanager Checkbox
  *
  * @group field
+ * @group checkbox
  */
 class Test_Fieldmanager_Checkbox_Field extends WP_UnitTestCase {
 

--- a/tests/php/test-fieldmanager-context-post.php
+++ b/tests/php/test-fieldmanager-context-post.php
@@ -4,6 +4,7 @@
  * Tests the Post context
  *
  * @group context
+ * @group post
  */
 class Test_Fieldmanager_Context_Post extends WP_UnitTestCase {
 	public function setUp() {

--- a/tests/php/test-fieldmanager-context-quickedit.php
+++ b/tests/php/test-fieldmanager-context-quickedit.php
@@ -97,6 +97,23 @@ class Test_Fieldmanager_Context_Quickedit extends WP_UnitTestCase {
 		) );
 	}
 
+	private function _get_html_for( $field, $test_data = null ) {
+		ob_start();
+		$context = $this->_get_context( $field );
+		if ( $test_data ) {
+			$context->save_to_post_meta( $this->post_id, $test_data );
+		}
+		$get = $_GET;
+		$_GET = array(
+			'action'      => 'fm_quickedit_render',
+			'post_id'     => $this->post_id,
+			'column_name' => $field->name,
+		);
+		$context->render_ajax_form();
+		$_GET = $get;
+		return ob_get_clean();
+	}
+
 	public function test_context_render() {
 		$base = $this->_get_elements();
 		$context = $this->_get_context( $base );
@@ -140,5 +157,126 @@ class Test_Fieldmanager_Context_Quickedit extends WP_UnitTestCase {
 
 	public function _quickedit_column( $post_id, $data ) {
 		return ! empty( $data['text'] ) ? $data['text'] : 'not set';
+	}
+
+	public function test_unserialize_data_single_field() {
+		$base = new Fieldmanager_TextField( array(
+			'name'           => 'base_field',
+			'limit'          => 0,
+			'serialize_data' => false,
+		) );
+		$html = $this->_get_html_for( $base );
+		$this->assertContains( 'name="base_field[0]"', $html );
+		$this->assertNotContains( 'name="base_field[3]"', $html );
+
+		$data = array( rand_str(), rand_str(), rand_str() );
+		$html = $this->_get_html_for( $base, $data );
+		$this->assertEquals( $data, get_post_meta( $this->post_id, 'base_field' ) );
+		$this->assertContains( 'name="base_field[3]"', $html );
+		$this->assertContains( 'value="' . $data[0] . '"', $html );
+		$this->assertContains( 'value="' . $data[1] . '"', $html );
+		$this->assertContains( 'value="' . $data[2] . '"', $html );
+		$this->assertNotContains( 'name="base_field[4]"', $html );
+	}
+
+	public function test_unserialize_data_single_field_sorting() {
+		$item_1 = rand_str();
+		$item_2 = rand_str();
+		$item_3 = rand_str();
+		$base = new Fieldmanager_TextField( array(
+			'name'           => 'base_field',
+			'limit'          => 0,
+			'serialize_data' => false,
+		) );
+
+		// Test as 1, 2, 3
+		$data = array( $item_1, $item_2, $item_3 );
+		$html = $this->_get_html_for( $base, $data );
+		$this->assertEquals( $data, get_post_meta( $this->post_id, 'base_field' ) );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[0\][^>]+value="' . $item_1 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[1\][^>]+value="' . $item_2 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_3 . '"/', $html );
+
+		// Reorder and test as 3, 1, 2
+		$data = array( $item_3, $item_1, $item_2 );
+		$html = $this->_get_html_for( $base, $data );
+		$this->assertEquals( $data, get_post_meta( $this->post_id, 'base_field' ) );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[0\][^>]+value="' . $item_3 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[1\][^>]+value="' . $item_1 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_2 . '"/', $html );
+	}
+
+	public function test_unserialize_data_tabbed() {
+		$base = new Fieldmanager_Group( array(
+			'name'           => 'base_group',
+			'tabbed'         => true,
+			'serialize_data' => false,
+			'add_to_prefix'  => false,
+			'children'       => array(
+				'tab-1' => new Fieldmanager_Group( array(
+					'label'          => 'Tab One',
+					'serialize_data' => false,
+					'add_to_prefix'  => false,
+					'children'       => array(
+						'test_text' => new Fieldmanager_TextField( 'Text Field' ),
+					)
+				) ),
+				'tab-2' => new Fieldmanager_Group( array(
+					'label'          => 'Tab Two',
+					'serialize_data' => false,
+					'add_to_prefix'  => false,
+					'children'       => array(
+						'test_textarea' => new Fieldmanager_TextArea( 'TextArea' ),
+					)
+				) ),
+			)
+		) );
+		$data = array(
+			'tab-1' => array(
+				'test_text' => rand_str()
+			),
+			'tab-2' => array(
+				'test_textarea' => rand_str()
+			),
+		);
+
+		$html = $this->_get_html_for( $base, $data );
+		$this->assertEquals( $data['tab-1']['test_text'], get_post_meta( $this->post_id, 'test_text', true ) );
+		$this->assertEquals( $data['tab-2']['test_textarea'], get_post_meta( $this->post_id, 'test_textarea', true ) );
+		$this->assertContains( 'name="base_group[tab-1][test_text]"', $html );
+		$this->assertContains( 'value="' . $data['tab-1']['test_text'] . '"', $html );
+		$this->assertContains( 'name="base_group[tab-2][test_textarea]"', $html );
+		$this->assertContains( '>' . $data['tab-2']['test_textarea'] . '</textarea>', $html );
+	}
+
+	public function test_unserialize_data_mixed_depth() {
+		$base = new Fieldmanager_Group( array(
+			'name'           => 'base_group',
+			'serialize_data' => false,
+			'children'       => array(
+				'test_text' => new Fieldmanager_TextField,
+				'test_group' => new Fieldmanager_Group( array(
+					'serialize_data' => false,
+					'children'       => array(
+						'deep_text' => new Fieldmanager_TextArea,
+					)
+				) ),
+			)
+		) );
+
+		$data = array(
+			'test_text' => rand_str(),
+			'test_group' => array(
+				'deep_text' => rand_str()
+			),
+		);
+
+		$html = $this->_get_html_for( $base, $data );
+		$this->assertEquals( $data['test_text'], get_post_meta( $this->post_id, 'base_group_test_text', true ) );
+		$this->assertEquals( $data['test_group']['deep_text'], get_post_meta( $this->post_id, 'base_group_test_group_deep_text', true ) );
+		$this->assertContains( 'name="base_group[test_text]"', $html );
+		$this->assertContains( 'value="' . $data['test_text'] . '"', $html );
+		$this->assertContains( 'name="base_group[test_group][deep_text]"', $html );
+		$this->assertContains( '>' . $data['test_group']['deep_text'] . '</textarea>', $html );
 	}
 }

--- a/tests/php/test-fieldmanager-context-quickedit.php
+++ b/tests/php/test-fieldmanager-context-quickedit.php
@@ -160,6 +160,9 @@ class Test_Fieldmanager_Context_Quickedit extends WP_UnitTestCase {
 		return ! empty( $data['text'] ) ? $data['text'] : 'not set';
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_single_field() {
 		$base = new Fieldmanager_TextField( array(
 			'name'           => 'base_field',
@@ -180,6 +183,9 @@ class Test_Fieldmanager_Context_Quickedit extends WP_UnitTestCase {
 		$this->assertNotContains( 'name="base_field[4]"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_single_field_sorting() {
 		$item_1 = rand_str();
 		$item_2 = rand_str();
@@ -207,6 +213,9 @@ class Test_Fieldmanager_Context_Quickedit extends WP_UnitTestCase {
 		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_2 . '"/', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_tabbed() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -250,6 +259,9 @@ class Test_Fieldmanager_Context_Quickedit extends WP_UnitTestCase {
 		$this->assertContains( '>' . $data['tab-2']['test_textarea'] . '</textarea>', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_mixed_depth() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',

--- a/tests/php/test-fieldmanager-context-quickedit.php
+++ b/tests/php/test-fieldmanager-context-quickedit.php
@@ -4,6 +4,7 @@
  * Tests the Quickedit context
  *
  * @group context
+ * @group quickedit
  */
 class Test_Fieldmanager_Context_Quickedit extends WP_UnitTestCase {
 	public function setUp() {

--- a/tests/php/test-fieldmanager-context-submenu.php
+++ b/tests/php/test-fieldmanager-context-submenu.php
@@ -80,8 +80,9 @@ class Test_Fieldmanager_Context_Submenu extends WP_UnitTestCase {
 		$html = $this->get_html( $context, $name );
 
 		$this->build_post( $html, $name );
-		$_POST['fieldmanager-edit_meta_fields-nonce'] = '';
-		$context->save_submenu_data();
+		$_GET['page'] = $name;
+		$_POST["fieldmanager-{$name}-nonce"] = 'abc123';
+		$context->handle_submenu_save();
 	}
 
 	public function test_urls() {

--- a/tests/php/test-fieldmanager-context-submenu.php
+++ b/tests/php/test-fieldmanager-context-submenu.php
@@ -2,6 +2,9 @@
 
 /**
  * Tests submenu forms/pages
+ *
+ * @group context
+ * @group submenu
  */
 class Test_Fieldmanager_Context_Submenu extends WP_UnitTestCase {
 

--- a/tests/php/test-fieldmanager-context-term.php
+++ b/tests/php/test-fieldmanager-context-term.php
@@ -4,6 +4,7 @@
  * Tests the Post context
  *
  * @group context
+ * @group term
  */
 class Test_Fieldmanager_Context_Term extends WP_UnitTestCase {
 	public $current_user;

--- a/tests/php/test-fieldmanager-context-term.php
+++ b/tests/php/test-fieldmanager-context-term.php
@@ -6,9 +6,14 @@
  * @group context
  */
 class Test_Fieldmanager_Context_Term extends WP_UnitTestCase {
+	public $current_user;
+
 	public function setUp() {
 		parent::setUp();
 		Fieldmanager_Field::$debug = TRUE;
+
+		$this->current_user = get_current_user_id();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
 
 		$this->taxonomy = 'category';
 		$term = wp_insert_term( 'test', $this->taxonomy );
@@ -17,6 +22,13 @@ class Test_Fieldmanager_Context_Term extends WP_UnitTestCase {
 
 		// reload as proper object
 		$this->term = get_term( $this->term_id, $this->taxonomy );
+	}
+
+	public function tearDown() {
+		if ( get_current_user_id() != $this->current_user ) {
+			wp_delete_user( get_current_user_id() );
+		}
+		wp_set_current_user( $this->current_user );
 	}
 
 	/**
@@ -130,9 +142,6 @@ class Test_Fieldmanager_Context_Term extends WP_UnitTestCase {
 	}
 
 	public function test_programmatic_save_terms() {
-		$current_user = get_current_user_id();
-		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
-
 		$base = $this->_get_elements();
 		$base->add_term_form( 'test meta box', $this->taxonomy );
 
@@ -143,7 +152,5 @@ class Test_Fieldmanager_Context_Term extends WP_UnitTestCase {
 		wp_update_term( $term['term_id'], $this->taxonomy, array( 'name' => 'Alley' ) );
 		$updated_term = get_term( $term['term_id'], $this->taxonomy );
 		$this->assertEquals( 'Alley', $updated_term->name );
-
-		wp_set_current_user( $current_user );
 	}
 }

--- a/tests/php/test-fieldmanager-context-term.php
+++ b/tests/php/test-fieldmanager-context-term.php
@@ -172,6 +172,9 @@ class Test_Fieldmanager_Context_Term extends WP_UnitTestCase {
 		$this->assertEquals( 'Alley', $updated_term->name );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_single_field() {
 		$base = new Fieldmanager_TextField( array(
 			'name'           => 'base_field',
@@ -192,6 +195,9 @@ class Test_Fieldmanager_Context_Term extends WP_UnitTestCase {
 		$this->assertNotContains( 'name="base_field[4]"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_single_field_sorting() {
 		$item_1 = rand_str();
 		$item_2 = rand_str();
@@ -219,6 +225,9 @@ class Test_Fieldmanager_Context_Term extends WP_UnitTestCase {
 		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_2 . '"/', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_tabbed() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -262,6 +271,9 @@ class Test_Fieldmanager_Context_Term extends WP_UnitTestCase {
 		$this->assertContains( '>' . $data['tab-2']['test_textarea'] . '</textarea>', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_mixed_depth() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',

--- a/tests/php/test-fieldmanager-context-user.php
+++ b/tests/php/test-fieldmanager-context-user.php
@@ -133,6 +133,9 @@ class Test_Fieldmanager_Context_User extends WP_UnitTestCase {
 		$this->assertEquals( array( 'editor' ), $user->roles );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_single_field() {
 		$base = new Fieldmanager_TextField( array(
 			'name'           => 'base_field',
@@ -153,6 +156,9 @@ class Test_Fieldmanager_Context_User extends WP_UnitTestCase {
 		$this->assertNotContains( 'name="base_field[4]"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_single_field_sorting() {
 		$item_1 = rand_str();
 		$item_2 = rand_str();
@@ -180,6 +186,9 @@ class Test_Fieldmanager_Context_User extends WP_UnitTestCase {
 		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_2 . '"/', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_tabbed() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -223,6 +232,9 @@ class Test_Fieldmanager_Context_User extends WP_UnitTestCase {
 		$this->assertContains( '>' . $data['tab-2']['test_textarea'] . '</textarea>', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_mixed_depth() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',

--- a/tests/php/test-fieldmanager-context-user.php
+++ b/tests/php/test-fieldmanager-context-user.php
@@ -4,6 +4,7 @@
  * Tests the User context
  *
  * @group context
+ * @group user
  */
 class Test_Fieldmanager_Context_User extends WP_UnitTestCase {
 	public function setUp() {

--- a/tests/php/test-fieldmanager-context-user.php
+++ b/tests/php/test-fieldmanager-context-user.php
@@ -74,6 +74,16 @@ class Test_Fieldmanager_Context_User extends WP_UnitTestCase {
 		) );
 	}
 
+	private function _get_html_for( $field, $test_data = null ) {
+		ob_start();
+		$context = $field->add_user_form( 'test meta box' );
+		if ( $test_data ) {
+			$context->save_to_user_meta( $this->user_id, $test_data );
+		}
+		$context->render_user_form( $this->user );
+		return ob_get_clean();
+	}
+
 	public function test_context_render() {
 		$base = $this->_get_elements();
 		ob_start();
@@ -120,5 +130,126 @@ class Test_Fieldmanager_Context_User extends WP_UnitTestCase {
 		$user = new WP_User( $user_id );
 
 		$this->assertEquals( array( 'editor' ), $user->roles );
+	}
+
+	public function test_unserialize_data_single_field() {
+		$base = new Fieldmanager_TextField( array(
+			'name'           => 'base_field',
+			'limit'          => 0,
+			'serialize_data' => false,
+		) );
+		$html = $this->_get_html_for( $base );
+		$this->assertContains( 'name="base_field[0]"', $html );
+		$this->assertNotContains( 'name="base_field[3]"', $html );
+
+		$data = array( rand_str(), rand_str(), rand_str() );
+		$html = $this->_get_html_for( $base, $data );
+		$this->assertEquals( $data, get_user_meta( $this->user_id, 'base_field' ) );
+		$this->assertContains( 'name="base_field[3]"', $html );
+		$this->assertContains( 'value="' . $data[0] . '"', $html );
+		$this->assertContains( 'value="' . $data[1] . '"', $html );
+		$this->assertContains( 'value="' . $data[2] . '"', $html );
+		$this->assertNotContains( 'name="base_field[4]"', $html );
+	}
+
+	public function test_unserialize_data_single_field_sorting() {
+		$item_1 = rand_str();
+		$item_2 = rand_str();
+		$item_3 = rand_str();
+		$base = new Fieldmanager_TextField( array(
+			'name'           => 'base_field',
+			'limit'          => 0,
+			'serialize_data' => false,
+		) );
+
+		// Test as 1, 2, 3
+		$data = array( $item_1, $item_2, $item_3 );
+		$html = $this->_get_html_for( $base, $data );
+		$this->assertEquals( $data, get_user_meta( $this->user_id, 'base_field' ) );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[0\][^>]+value="' . $item_1 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[1\][^>]+value="' . $item_2 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_3 . '"/', $html );
+
+		// Reorder and test as 3, 1, 2
+		$data = array( $item_3, $item_1, $item_2 );
+		$html = $this->_get_html_for( $base, $data );
+		$this->assertEquals( $data, get_user_meta( $this->user_id, 'base_field' ) );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[0\][^>]+value="' . $item_3 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[1\][^>]+value="' . $item_1 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_2 . '"/', $html );
+	}
+
+	public function test_unserialize_data_tabbed() {
+		$base = new Fieldmanager_Group( array(
+			'name'           => 'base_group',
+			'tabbed'         => true,
+			'serialize_data' => false,
+			'add_to_prefix'  => false,
+			'children'       => array(
+				'tab-1' => new Fieldmanager_Group( array(
+					'label'          => 'Tab One',
+					'serialize_data' => false,
+					'add_to_prefix'  => false,
+					'children'       => array(
+						'test_text' => new Fieldmanager_TextField( 'Text Field' ),
+					)
+				) ),
+				'tab-2' => new Fieldmanager_Group( array(
+					'label'          => 'Tab Two',
+					'serialize_data' => false,
+					'add_to_prefix'  => false,
+					'children'       => array(
+						'test_textarea' => new Fieldmanager_TextArea( 'TextArea' ),
+					)
+				) ),
+			)
+		) );
+		$data = array(
+			'tab-1' => array(
+				'test_text' => rand_str()
+			),
+			'tab-2' => array(
+				'test_textarea' => rand_str()
+			),
+		);
+
+		$html = $this->_get_html_for( $base, $data );
+		$this->assertEquals( $data['tab-1']['test_text'], get_user_meta( $this->user_id, 'test_text', true ) );
+		$this->assertEquals( $data['tab-2']['test_textarea'], get_user_meta( $this->user_id, 'test_textarea', true ) );
+		$this->assertContains( 'name="base_group[tab-1][test_text]"', $html );
+		$this->assertContains( 'value="' . $data['tab-1']['test_text'] . '"', $html );
+		$this->assertContains( 'name="base_group[tab-2][test_textarea]"', $html );
+		$this->assertContains( '>' . $data['tab-2']['test_textarea'] . '</textarea>', $html );
+	}
+
+	public function test_unserialize_data_mixed_depth() {
+		$base = new Fieldmanager_Group( array(
+			'name'           => 'base_group',
+			'serialize_data' => false,
+			'children'       => array(
+				'test_text' => new Fieldmanager_TextField,
+				'test_group' => new Fieldmanager_Group( array(
+					'serialize_data' => false,
+					'children'       => array(
+						'deep_text' => new Fieldmanager_TextArea,
+					)
+				) ),
+			)
+		) );
+
+		$data = array(
+			'test_text' => rand_str(),
+			'test_group' => array(
+				'deep_text' => rand_str()
+			),
+		);
+
+		$html = $this->_get_html_for( $base, $data );
+		$this->assertEquals( $data['test_text'], get_user_meta( $this->user_id, 'base_group_test_text', true ) );
+		$this->assertEquals( $data['test_group']['deep_text'], get_user_meta( $this->user_id, 'base_group_test_group_deep_text', true ) );
+		$this->assertContains( 'name="base_group[test_text]"', $html );
+		$this->assertContains( 'value="' . $data['test_text'] . '"', $html );
+		$this->assertContains( 'name="base_group[test_group][deep_text]"', $html );
+		$this->assertContains( '>' . $data['test_group']['deep_text'] . '</textarea>', $html );
 	}
 }

--- a/tests/php/test-fieldmanager-datasource-post.php
+++ b/tests/php/test-fieldmanager-datasource-post.php
@@ -4,6 +4,7 @@
  * Tests the Fieldmanager Datasource Post
  *
  * @group datasource
+ * @group post
  */
 class Test_Fieldmanager_Datasource_Post extends WP_UnitTestCase {
 

--- a/tests/php/test-fieldmanager-datasource-term.php
+++ b/tests/php/test-fieldmanager-datasource-term.php
@@ -4,6 +4,7 @@
  * Tests the Fieldmanager Datasource Term
  *
  * @group datasource
+ * @group term
  */
 class Test_Fieldmanager_Datasource_Term extends WP_UnitTestCase {
 

--- a/tests/php/test-fieldmanager-datepicker-field.php
+++ b/tests/php/test-fieldmanager-datepicker-field.php
@@ -4,6 +4,7 @@
  * Tests the Fieldmanager Datepicker Field
  *
  * @group field
+ * @group datepicker
  */
 class Test_Fieldmanager_Datepicker_Field extends WP_UnitTestCase {
 

--- a/tests/php/test-fieldmanager-group.php
+++ b/tests/php/test-fieldmanager-group.php
@@ -4,6 +4,7 @@
  * Tests the Fieldmanager Datasource Post
  *
  * @group field
+ * @group group
  */
 class Test_Fieldmanager_Group extends WP_UnitTestCase {
 

--- a/tests/php/test-fieldmanager-group.php
+++ b/tests/php/test-fieldmanager-group.php
@@ -140,6 +140,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 			) );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_group_render() {
 		$args = array(
 			'name'           => 'base_group',
@@ -165,6 +168,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		$this->assertContains( 'name="base_group[test_htmlfield]"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_group_render_with_data() {
 		$args = array(
 			'name'           => 'base_group',
@@ -218,6 +224,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		$this->assertContains( 'name="base_group[test_htmlfield]"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_group_save() {
 		$args = array(
 			'name'           => 'base_group',
@@ -244,6 +253,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		$this->assertEquals( $data['test_htmlfield'], get_post_meta( $this->post_id, 'test_htmlfield', true ) );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_deep_group_no_prefix() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -288,6 +300,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		$this->assertContains( 'value="' . $data['level2']['level3']['level4']['field'] . '"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_deep_group_no_prefix_repeatable_field() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -346,6 +361,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		$this->assertContains( 'value="' . $data['level2']['level3']['level4']['field_two'][2] . '"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_mid_group_prefix() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -387,6 +405,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		$this->assertContains( 'value="' . $data['level2']['level3']['level4']['field'] . '"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_mid_group_serialize() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -425,6 +446,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		$this->assertContains( 'value="' . $data['level2']['level3']['level4']['field'] . '"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_tabbed() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -469,6 +493,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		$this->assertContains( '>' . $data['tab-2']['test_textarea'] . '</textarea>', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_mixed() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -500,6 +527,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		$this->assertContains( '>' . $data['test_group']['text'] . '</textarea>', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_mixed_depth() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -533,6 +563,7 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @group serialize_data
 	 * @expectedException FM_Developer_Exception
 	 */
 	public function test_unserialize_data_repeatable_group() {
@@ -548,6 +579,7 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @group serialize_data
 	 * @expectedException FM_Developer_Exception
 	 */
 	public function test_unserialize_data_repeatable_parent() {
@@ -567,6 +599,7 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @group serialize_data
 	 * @expectedException FM_Developer_Exception
 	 */
 	public function test_unserialize_data_repeatable_distant_ancestor() {
@@ -594,6 +627,7 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @group serialize_data
 	 * @expectedException FM_Developer_Exception
 	 */
 	public function test_unserialize_data_indexed_field() {
@@ -609,6 +643,9 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		) );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_no_name_conflict() {
 		$base = new Fieldmanager_Group( array(
 			'name'           => 'base_group',
@@ -638,6 +675,7 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @group serialize_data
 	 * @expectedException FM_Developer_Exception
 	 */
 	public function test_unserialize_data_name_conflict() {

--- a/tests/php/test-fieldmanager-group.php
+++ b/tests/php/test-fieldmanager-group.php
@@ -608,4 +608,62 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 			),
 		) );
 	}
+
+	public function test_unserialize_data_no_name_conflict() {
+		$base = new Fieldmanager_Group( array(
+			'name'           => 'base_group',
+			'serialize_data' => false,
+			'add_to_prefix'  => false,
+			'children'       => array(
+				'test_text' => new Fieldmanager_TextField,
+				'test_group' => new Fieldmanager_Group( array(
+					'serialize_data' => false,
+					'children'       => array(
+						'test_text' => new Fieldmanager_TextArea,
+					)
+				) ),
+			)
+		) );
+
+		$data = array(
+			'test_text' => rand_str(),
+			'test_group' => array(
+				'test_text' => rand_str()
+			),
+		);
+
+		$base->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post_id, $data );
+		$this->assertEquals( $data['test_text'], get_post_meta( $this->post_id, 'test_text', true ) );
+		$this->assertEquals( $data['test_group']['test_text'], get_post_meta( $this->post_id, 'test_group_test_text', true ) );
+	}
+
+	/**
+	 * @expectedException FM_Developer_Exception
+	 */
+	public function test_unserialize_data_name_conflict() {
+		$base = new Fieldmanager_Group( array(
+			'name'           => 'base_group',
+			'serialize_data' => false,
+			'add_to_prefix'  => false,
+			'children'       => array(
+				'test_text' => new Fieldmanager_TextField,
+				'test_group' => new Fieldmanager_Group( array(
+					'serialize_data' => false,
+					'add_to_prefix'  => false,
+					'children'       => array(
+						'test_text' => new Fieldmanager_TextArea,
+					)
+				) ),
+			)
+		) );
+
+		$data = array(
+			'test_text' => rand_str(),
+			'test_group' => array(
+				'test_text' => rand_str()
+			),
+		);
+
+		$base->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post_id, $data );
+	}
 }

--- a/tests/php/test-fieldmanager-group.php
+++ b/tests/php/test-fieldmanager-group.php
@@ -531,4 +531,81 @@ class Test_Fieldmanager_Group extends WP_UnitTestCase {
 		$this->assertContains( 'name="base_group[test_group][deep_text]"', $html );
 		$this->assertContains( '>' . $data['test_group']['deep_text'] . '</textarea>', $html );
 	}
+
+	/**
+	 * @expectedException FM_Developer_Exception
+	 */
+	public function test_unserialize_data_repeatable_group() {
+		new Fieldmanager_Group( array(
+			'name'           => 'parent',
+			'serialize_data' => false,
+			'limit'          => 0,
+			'children'       => array(
+				'child_1' => new Fieldmanager_TextField,
+				'child_2' => new Fieldmanager_Textarea,
+			),
+		) );
+	}
+
+	/**
+	 * @expectedException FM_Developer_Exception
+	 */
+	public function test_unserialize_data_repeatable_parent() {
+		new Fieldmanager_Group( array(
+			'name'     => 'grandparent',
+			'limit'    => 0,
+			'children' => array(
+				'parent' => new Fieldmanager_Group( array(
+					'serialize_data' => false,
+					'children'       => array(
+						'child_1' => new Fieldmanager_TextField,
+						'child_2' => new Fieldmanager_Textarea,
+					),
+				) ),
+			),
+		) );
+	}
+
+	/**
+	 * @expectedException FM_Developer_Exception
+	 */
+	public function test_unserialize_data_repeatable_distant_ancestor() {
+		new Fieldmanager_Group( array(
+			'name'     => 'gggp',
+			'limit'    => 0,
+			'children' => array(
+				'ggp' => new Fieldmanager_Group( array(
+					'children' => array(
+						'grandparent' => new Fieldmanager_Group( array(
+							'children' => array(
+								'parent' => new Fieldmanager_Group( array(
+									'serialize_data' => false,
+									'children'       => array(
+										'child_1' => new Fieldmanager_TextField,
+										'child_2' => new Fieldmanager_Textarea,
+									),
+								) ),
+							),
+						) ),
+					),
+				) ),
+			),
+		) );
+	}
+
+	/**
+	 * @expectedException FM_Developer_Exception
+	 */
+	public function test_unserialize_data_indexed_field() {
+		new Fieldmanager_Group( array(
+			'name'           => 'parent',
+			'serialize_data' => false,
+			'children'       => array(
+				'child_1' => new Fieldmanager_TextField,
+				'child_2' => new Fieldmanager_Textarea( array(
+					'index' => true,
+				) ),
+			),
+		) );
+	}
 }

--- a/tests/php/test-fieldmanager-richtextarea-field.php
+++ b/tests/php/test-fieldmanager-richtextarea-field.php
@@ -4,6 +4,7 @@
  * Tests the Fieldmanager RichTextArea Field
  *
  * @group field
+ * @group richtextarea
  */
 class Test_Fieldmanager_RichTextArea_Field extends WP_UnitTestCase {
 

--- a/tests/php/test-fieldmanager-richtextarea-field.php
+++ b/tests/php/test-fieldmanager-richtextarea-field.php
@@ -3,7 +3,7 @@
 /**
  * Tests the Fieldmanager RichTextArea Field
  *
- * @group richtextarea
+ * @group field
  */
 class Test_Fieldmanager_RichTextArea_Field extends WP_UnitTestCase {
 

--- a/tests/php/test-fieldmanager-term-meta.php
+++ b/tests/php/test-fieldmanager-term-meta.php
@@ -6,12 +6,23 @@
  * @group util
  */
 class Test_Fieldmanager_Term_Meta extends WP_UnitTestCase {
+	public $current_user;
 
 	public function setUp() {
 		parent::setUp();
 		Fieldmanager_Field::$debug = true;
 
+		$this->current_user = get_current_user_id();
+		wp_set_current_user( $this->factory->user->create( array( 'role' => 'administrator' ) ) );
+
 		$this->term = $this->factory->category->create_and_get( array( 'name' => rand_str() ) );
+	}
+
+	public function tearDown() {
+		if ( get_current_user_id() != $this->current_user ) {
+			wp_delete_user( get_current_user_id() );
+		}
+		wp_set_current_user( $this->current_user );
 	}
 
 	/**

--- a/tests/php/test-fieldmanager-term-meta.php
+++ b/tests/php/test-fieldmanager-term-meta.php
@@ -4,6 +4,7 @@
  * Tests the Fieldmanager Term Meta
  *
  * @group util
+ * @group term
  */
 class Test_Fieldmanager_Term_Meta extends WP_UnitTestCase {
 	public $current_user;

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -932,4 +932,26 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_1 . '"/', $html );
 	}
 
+	public function test_unserialize_data_limit_1_no_impact() {
+		$base = new Fieldmanager_TextField( array(
+			'name'           => 'base_field',
+			'serialize_data' => false,
+		) );
+		$data = rand_str();
+		$base->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post_id, $data );
+
+		$this->assertEquals( $data, get_post_meta( $this->post_id, 'base_field', true ) );
+	}
+
+	/**
+	 * @expectedException FM_Developer_Exception
+	 */
+	public function test_unserialize_data_single_field_index() {
+		new Fieldmanager_TextField( array(
+			'name'           => 'test',
+			'limit'          => 0,
+			'serialize_data' => false,
+			'index'          => true,
+		) );
+	}
 }

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -747,7 +747,18 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 				array( 'text' => 'e' ),
 			)
 		);
-		$str = $this->_get_html_for_extra_element_args( array( 'limit' => 3 ), $test_data_too_many );
+
+		$field = new Fieldmanager_Group( array(
+			'name' => 'base_group',
+			'children' => array(
+				'test_element' => new Fieldmanager_Group( array(
+					'limit' => 3,
+					'children' => array( 'text' => new Fieldmanager_TextField( false ) ),
+				) )
+			)
+		) );
+		$context = $field->add_meta_box( 'test meta box', $this->post );
+		$context->save_to_post_meta( $this->post_id, $test_data_too_many );
 	}
 
 	public function test_attributes(){
@@ -759,6 +770,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 				'data-UPPER' => 'lower'
 			)
 		) );
+		ob_start();
 		$fm->add_meta_box( 'Test RichTextArea', 'post' )->render_meta_box( $this->post, array() );
 		$html = ob_get_clean();
 

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -830,7 +830,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertContains( $description_html, $html );
 	}
 
-	public function test_serialize_data_single_field_render() {
+	public function test_unserialize_data_single_field_render() {
 		$args = array(
 			'name'  => 'base_field',
 			'limit' => 0,
@@ -852,7 +852,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertNotContains( 'name="base_field[1]"', $html );
 	}
 
-	public function test_serialize_data_single_field_render_with_data() {
+	public function test_unserialize_data_single_field_render_with_data() {
 		$args = array(
 			'name'  => 'base_field',
 			'limit' => 0,
@@ -881,7 +881,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertNotContains( 'name="base_field[4]"', $html );
 	}
 
-	public function test_serialize_data_single_field_save() {
+	public function test_unserialize_data_single_field_save() {
 		$base = new Fieldmanager_TextField( array(
 			'name'           => 'base_field',
 			'limit'          => 0,
@@ -891,117 +891,6 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$base->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post_id, $data );
 
 		$this->assertEquals( $data, get_post_meta( $this->post_id, 'base_field' ) );
-	}
-
-	public function test_serialize_data_group_render() {
-		$args = array(
-			'name'           => 'base_group',
-			'children'       => array(
-				'test_basic' => new Fieldmanager_TextField(),
-				'test_htmlfield' => new Fieldmanager_Textarea( array(
-					'sanitize' => 'wp_kses_post',
-				) ),
-			)
-		);
-
-		$base = new Fieldmanager_Group( $args );
-		$html = $this->_get_html_for( $base );
-		$this->assertRegExp( '/<input[^>]+type="hidden"[^>]+name="fieldmanager-base_group-nonce"/', $html );
-		$this->assertContains( 'name="base_group[test_basic]"', $html );
-		$this->assertContains( 'name="base_group[test_htmlfield]"', $html );
-
-		// Using serialize_data => false shouldn't change anything
-		$base = new Fieldmanager_Group( array_merge( $args, array( 'serialize_data' => false ) ) );
-		$html = $this->_get_html_for( $base );
-		$this->assertRegExp( '/<input[^>]+type="hidden"[^>]+name="fieldmanager-base_group-nonce"/', $html );
-		$this->assertContains( 'name="base_group[test_basic]"', $html );
-		$this->assertContains( 'name="base_group[test_htmlfield]"', $html );
-	}
-
-	public function test_serialize_data_group_render_with_data() {
-		$args = array(
-			'name'           => 'base_group',
-			'children'       => array(
-				'test_basic' => new Fieldmanager_TextField(),
-				'test_htmlfield' => new Fieldmanager_Textarea( array(
-					'sanitize' => 'wp_kses_post',
-				) ),
-			)
-		);
-		$data = array(
-			'test_basic'     => rand_str(),
-			'test_htmlfield' => rand_str()
-		);
-
-		update_post_meta( $this->post_id, 'base_group', $data );
-		$base = new Fieldmanager_Group( $args );
-		$html = $this->_get_html_for( $base );
-		$this->assertRegExp( '/<input[^>]+type="hidden"[^>]+name="fieldmanager-base_group-nonce"/', $html );
-		$this->assertContains( 'name="base_group[test_basic]"', $html );
-		$this->assertContains( 'value="' . $data['test_basic'] . '"', $html );
-		$this->assertContains( 'name="base_group[test_htmlfield]"', $html );
-		$this->assertContains( ">{$data['test_htmlfield']}</textarea>", $html );
-		delete_post_meta( $this->post_id, 'base_group' );
-
-		// Using serialize_data => false requires a different data storage
-		foreach ( $data as $meta_key => $meta_value ) {
-			add_post_meta( $this->post_id, "base_group_{$meta_key}", $meta_value );
-		}
-		$base = new Fieldmanager_Group( array_merge( $args, array( 'serialize_data' => false ) ) );
-		$html = $this->_get_html_for( $base );
-		$this->assertRegExp( '/<input[^>]+type="hidden"[^>]+name="fieldmanager-base_group-nonce"/', $html );
-		$this->assertContains( 'name="base_group[test_basic]"', $html );
-		$this->assertContains( 'value="' . $data['test_basic'] . '"', $html );
-		$this->assertContains( 'name="base_group[test_htmlfield]"', $html );
-		$this->assertContains( ">{$data['test_htmlfield']}</textarea>", $html );
-		foreach ( $data as $meta_key => $meta_value ) {
-			delete_post_meta( $this->post_id, "base_group_{$meta_key}" );
-		}
-
-		// Here, we'll set 'add_to_prefix' => false so the group name is not
-		// included in the meta keys.
-		foreach ( $data as $meta_key => $meta_value ) {
-			add_post_meta( $this->post_id, $meta_key, $meta_value );
-		}
-		$base = new Fieldmanager_Group( array_merge( $args, array( 'serialize_data' => false, 'add_to_prefix' => false ) ) );
-		$html = $this->_get_html_for( $base );
-		$this->assertRegExp( '/<input[^>]+type="hidden"[^>]+name="fieldmanager-base_group-nonce"/', $html );
-		$this->assertContains( 'name="base_group[test_basic]"', $html );
-		$this->assertContains( 'value="' . $data['test_basic'] . '"', $html );
-		$this->assertContains( 'name="base_group[test_htmlfield]"', $html );
-		foreach ( $data as $meta_key => $meta_value ) {
-			delete_post_meta( $this->post_id, $meta_key );
-		}
-	}
-
-	public function test_serialize_data_group_save() {
-		$args = array(
-			'name'           => 'base_group',
-			'serialize_data' => false,
-			'children'       => array(
-				'test_basic' => new Fieldmanager_TextField(),
-				'test_htmlfield' => new Fieldmanager_Textarea( array(
-					'sanitize' => 'wp_kses_post',
-				) ),
-			)
-		);
-		$data = array(
-			'test_basic'     => rand_str(),
-			'test_htmlfield' => rand_str()
-		);
-		delete_post_meta( $this->post_id, 'base_group_test_basic' );
-		delete_post_meta( $this->post_id, 'base_group_test_htmlfield' );
-		$base = new Fieldmanager_Group( $args );
-		$base->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post_id, $data );
-		$this->assertEquals( $data['test_basic'], get_post_meta( $this->post_id, 'base_group_test_basic', true ) );
-		$this->assertEquals( $data['test_htmlfield'], get_post_meta( $this->post_id, 'base_group_test_htmlfield', true ) );
-
-		delete_post_meta( $this->post_id, 'test_basic' );
-		delete_post_meta( $this->post_id, 'test_htmlfield' );
-		$base = new Fieldmanager_Group( array_merge( $args, array( 'add_to_prefix' => false ) ) );
-		$base->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post_id, $data );
-		$this->assertEquals( $data['test_basic'], get_post_meta( $this->post_id, 'test_basic', true ) );
-		$this->assertEquals( $data['test_htmlfield'], get_post_meta( $this->post_id, 'test_htmlfield', true ) );
 	}
 
 }

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -830,6 +830,9 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertContains( $description_html, $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_single_field_render() {
 		$args = array(
 			'name'  => 'base_field',
@@ -852,6 +855,9 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertNotContains( 'name="base_field[1]"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_single_field_render_with_data() {
 		$args = array(
 			'name'  => 'base_field',
@@ -881,6 +887,9 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertNotContains( 'name="base_field[4]"', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_single_field_save() {
 		$base = new Fieldmanager_TextField( array(
 			'name'           => 'base_field',
@@ -893,6 +902,9 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertEquals( $data, get_post_meta( $this->post_id, 'base_field' ) );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_single_field_sorting() {
 		$item_1 = rand_str();
 		$item_2 = rand_str();
@@ -932,6 +944,9 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_1 . '"/', $html );
 	}
 
+	/**
+	 * @group serialize_data
+	 */
 	public function test_unserialize_data_limit_1_no_impact() {
 		$base = new Fieldmanager_TextField( array(
 			'name'           => 'base_field',
@@ -944,6 +959,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * @group serialize_data
 	 * @expectedException FM_Developer_Exception
 	 */
 	public function test_unserialize_data_single_field_index() {

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -969,6 +969,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 			'serialize_data' => false,
 			'index'          => true,
 		) );
+	}
 
 	public function test_removing_item_from_repeatable() {
 		$field = new Fieldmanager_Textfield( array(

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -893,4 +893,43 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertEquals( $data, get_post_meta( $this->post_id, 'base_field' ) );
 	}
 
+	public function test_unserialize_data_single_field_sorting() {
+		$item_1 = rand_str();
+		$item_2 = rand_str();
+		$item_3 = rand_str();
+		$base = new Fieldmanager_TextField( array(
+			'name'           => 'base_field',
+			'limit'          => 0,
+			'serialize_data' => false,
+		) );
+		$context = $base->add_meta_box( 'test meta box', 'post' );
+
+		// Test as 1, 2, 3
+		$data = array( $item_1, $item_2, $item_3 );
+		$context->save_to_post_meta( $this->post_id, $data );
+		$html = $this->_get_html_for( $base );
+		$this->assertEquals( $data, get_post_meta( $this->post_id, 'base_field' ) );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[0\][^>]+value="' . $item_1 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[1\][^>]+value="' . $item_2 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_3 . '"/', $html );
+
+		// Reorder and test as 3, 1, 2
+		$data = array( $item_3, $item_1, $item_2 );
+		$context->save_to_post_meta( $this->post_id, $data );
+		$this->assertEquals( $data, get_post_meta( $this->post_id, 'base_field' ) );
+		$html = $this->_get_html_for( $base );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[0\][^>]+value="' . $item_3 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[1\][^>]+value="' . $item_1 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_2 . '"/', $html );
+
+		// Reorder and test as 2, 3, 1
+		$data = array( $item_2, $item_3, $item_1 );
+		$context->save_to_post_meta( $this->post_id, $data );
+		$this->assertEquals( $data, get_post_meta( $this->post_id, 'base_field' ) );
+		$html = $this->_get_html_for( $base );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[0\][^>]+value="' . $item_2 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[1\][^>]+value="' . $item_3 . '"/', $html );
+		$this->assertRegExp( '/<input[^>]+name="base_field\[2\][^>]+value="' . $item_1 . '"/', $html );
+	}
+
 }


### PR DESCRIPTION
This PR is a work in progress and aims to resolve #14.

## Overview

This update adds an option `$serialize_data` to `Fieldmanager_Field` to specify if that element should store its data serialized (the default) or unserialized (that is, using individual meta keys). This can be applied to a single repeating field, where the field is stored with duplicate keys, or to a group where each child gets its own key. In the case of a group, the field is prefixed with the group's name and an underscore. This update adds another option `$add_to_prefix` to `Fieldmanager_Group` allowing you the choice of whether or not to add that group's name to the prefix (`true` by default), which means you can completely separate your data structure from its presentation.

Groups can be nested any number of levels deep, and Fieldmanager will walk the nest until it finds either a group with `$serialize_data = true` or it finds a field. In other words, you can have a field nested within three groups, and still that field can have its own key. Again, you can choose individually which group's name will be prepended to the meta key. You can also mix-and-match depths, which is to say that you can have group with four children: three fields and another group, where the subgroup has two fields. You can set it such that the three top-level fields get their own keys, and the subgroup gets its own key with its children serialized, _or_ you can set it such the subgroup's fields each have their own keys too (making it so that all five fields have their own keys). While this may seem like a ridiculous edge case, it's entirely likely that you would want a group to work this if it has a tabbed group within it (see example 5 below).

The main area where this doesn't work is where a field's ancestor has a limit != 1. The only way to support such a structure would be to save to meta keys like `group_0_field`, `group_1_field`, etc., which would not be sustainable and it would be difficult and inefficient to work with in code. In every situation where an ancestor's limit != 1, it's much better to use serialized data.

Lastly, the submenu context does not support this at this time. I don't see the use case for it, but could be convinced otherwise.

## TODOS

* [x] repeating field where each iteration has its own key
* [x] groups where each child field has its own key (key name is {group}_{field})
* [x] groups where each child field has its own key without the group prefix
* [x] nth-level superfluous group which should be ignored in key prefixing
* [x] group within a group ... within a group where the fields to have their own keys
* [x] tabbed group where the fields have their own keys
* [x] group with one or more fields plus one or more groups
* [x] Add to all contexts (except submenu)
* [x] Add unit tests for sortable field using its own key
* [x] Error handling: incorrectly register a field with separate keys within a repeating group
* [x] Error handling: set `'serialize_data' => false` AND `'index' => true`
* [x] Error handling: register two fields using unserialized meta (at different depths or maybe in different FM fields) with the same name


## Examples

1. Repeating field where each iteration has its own key:
	```php
	$fm = new Fieldmanager_Textfield( array(
		'name'           => 'repeating_text_field',
		'limit'          => 0,
		'serialize_data' => false,
	) );
	$fm->add_meta_box( 'Repeating Standalone Text Field', 'post' );
	```

2. Groups where each child field has its own key (key name is {group}_{field}):
	```php
	$fm = new Fieldmanager_Group( array(
		'name'           => 'meta_fields',
		'serialize_data' => false,
		'children'       => array(
			'text'     => new Fieldmanager_Textfield( 'Text Field' ),
			'textarea' => new Fieldmanager_TextArea( 'TextArea' ),
			'checkbox' => new Fieldmanager_Checkbox( 'Checkbox' ),
		)
	) );
	$fm->add_meta_box( 'Single-Level Group', 'post' );
	```

3. Groups where each child field has its own key without the group prefix:
	```php
	$fm = new Fieldmanager_Group( array(
		'name'           => 'meta_fields',
		'serialize_data' => false,
		'add_to_prefix'  => false,
		'children'       => array(
			'text'     => new Fieldmanager_Textfield( 'Text Field' ),
			'textarea' => new Fieldmanager_TextArea( 'TextArea' ),
			'checkbox' => new Fieldmanager_Checkbox( 'Checkbox' ),
		)
	) );
	$fm->add_meta_box( 'Single-Level Group', 'post' );
	```

4. Tabbed group where the fields have their own keys:
	```php
	$fm = new Fieldmanager_Group( array(
		'name'           => 'tabbed_meta_fields',
		'tabbed'         => true,
		'serialize_data' => false,
		'add_to_prefix'  => false,
		'children'       => array(
			'tab-1' => new Fieldmanager_Group( array(
				'label'          => 'Tab One',
				'serialize_data' => false,
				'add_to_prefix'  => false,
				'children'       => array(
					'text' => new Fieldmanager_Textfield( 'Text Field' ),
				)
			) ),
			'tab-2' => new Fieldmanager_Group( array(
				'label'          => 'Tab Two',
				'serialize_data' => false,
				'add_to_prefix'  => false,
				'children'       => array(
					'textarea' => new Fieldmanager_TextArea( 'TextArea' ),
					'media'    => new Fieldmanager_Media( 'Media File' ),
				)
			) ),
		)
	) );
	$fm->add_meta_box( 'Tabbed Group', 'post' );
	```

5. Tabbed group within a group, where all fields have their own keys. This will save data to four meta keys: `title`, `text`, `textarea`, and `media`. All of the groups are ignored except in presentation.
	```php
	$fm = new Fieldmanager_Group( array(
		'name'           => 'base_group',
		'serialize_data' => false,
		'add_to_prefix'  => false,
		'children'       => array(
			'title' => new Fieldmanager_TextField( 'Title' ),
			'tabs' => new Fieldmanager_Group( array(
				'tabbed'         => true,
				'serialize_data' => false,
				'add_to_prefix'  => false,
				'children'       => array(
					'tab-1' => new Fieldmanager_Group( array(
						'label'          => 'Tab One',
						'serialize_data' => false,
						'add_to_prefix'  => false,
						'children'       => array(
							'text' => new Fieldmanager_Textfield( 'Text Field' ),
						)
					) ),
					'tab-2' => new Fieldmanager_Group( array(
						'label'          => 'Tab Two',
						'serialize_data' => false,
						'add_to_prefix'  => false,
						'children'       => array(
							'textarea' => new Fieldmanager_TextArea( 'TextArea' ),
							'media'    => new Fieldmanager_Media( 'Media File' ),
						)
					) ),
				)
			) )
		)
	) );
	$fm->add_meta_box( 'Tabbed Subgroup', 'post' );
	```

6. A group with a child field and a subgroup, each with their own keys, where the subgroup does use serialized data. Here, the stored meta keys will be `'meta_fields_text'` and `'meta_fields_subgroup'`.
	```php
	$fm = new Fieldmanager_Group( array(
		'name'           => 'meta_fields',
		'serialize_data' => false,
		'children'       => array(
			'text'     => new Fieldmanager_Textfield( 'Text Field' ),
			'subgroup' => new Fieldmanager_Group( array(
				'children'       => array(
					'text'     => new Fieldmanager_Textfield( 'Text Field' ),
					'textarea' => new Fieldmanager_TextArea( 'TextArea' ),
					'checkbox' => new Fieldmanager_Checkbox( 'Checkbox' ),
				),
			) ),
		),
	) );
	$fm->add_meta_box( 'Multi-Level Groups', 'post' );
	```