### PR TITLE
Fix incorrect HTML

### DIFF
--- a/php/class-fieldmanager-textarea.php
+++ b/php/class-fieldmanager-textarea.php
@@ -36,7 +36,7 @@ class Fieldmanager_TextArea extends Fieldmanager_Field {
 	 */
 	public function form_element( $value = '' ) {
 		return sprintf(
-			'<textarea class="fm-element" name="%s" id="%s" %s />%s</textarea>',
+			'<textarea class="fm-element" name="%s" id="%s" %s >%s</textarea>',
 			esc_attr( $this->get_form_name() ),
 			esc_attr( $this->get_element_id() ),
 			$this->get_element_attributes(),


### PR DESCRIPTION
The opening textarea tag is self-closing which it shouldn't be.

I think the browser is probably clever enough to handle this in most situations - but I'm trying to do something a little crazy and build underscore templates from fieldmanager fields - and this is breaking things.
