### PR TITLE
Submenu contexts for custom menus; submenu context test

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -282,7 +282,7 @@ function fm_calculate_context() {
 	if ( is_admin() ) {
 		$script = substr( $_SERVER['PHP_SELF'], strrpos( $_SERVER['PHP_SELF'], '/' ) + 1 );
 
-		/**
+		/*
 		 * Calculate a submenu context.
 		 *
 		 * For submenus of the default WordPress menus, the submenu's parent

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -362,7 +362,7 @@ function _fm_add_submenus() {
 		call_user_func_array( 'add_submenu_page', $s );
 	}
 }
-add_action( 'admin_menu', '_fm_add_submenus' );
+add_action( 'admin_menu', '_fm_add_submenus', 15 );
 
 /**
  * Sanitize multi-line text

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -251,7 +251,7 @@ function fm_get_context() {
 	if ( $calculated_context ) {
 		return $calculated_context;
 	} else {
-		$context_context = fm_calculate_context();
+		$calculated_context = fm_calculate_context();
 		return $calculated_context;
 	}
 }

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -334,18 +334,38 @@ function fm_match_context( $context, $type = null ) {
 }
 
 /**
- * Trigger the action for a given context
- * @uses fm_get_context()
+ * Fire an action for the current Fieldmanager context, if it exists.
+ *
+ * @see fm_calculate_context() for detail about the values that determine the
+ *     name of the action. Two actions are defined, but only one at most fires.
  */
 function fm_trigger_context_action() {
 	$calculated_context = fm_get_context();
-	$action = 'fm_' . $calculated_context[0];
-	if ( $calculated_context[1] ) {
-		$action .= '_' . $calculated_context[1];
+	if ( empty( $calculated_context ) ) {
+		return;
 	}
-	do_action( $action );
-}
 
+	$context = $calculated_context[0];
+	if ( $type = $calculated_context[1] ) {
+		/**
+		 * Fires when a specific Fieldmanager context and type load.
+		 *
+		 * The dynamic portions of the hook name, $context and $type, refer to
+		 * the values returned by fm_calculate_context(). For example, the Edit
+		 * screen for the Page post type would fire "fm_post_page".
+		 */
+		do_action( "fm_{$context}_{$type}" );
+	} else {
+		/**
+		 * Fires when a specific Fieldmanager context, but not type, loads.
+		 *
+		 * The dynamic portion of the hook name, $context, refers to the first
+		 * value returned by fm_calculate_context(). For example, the Edit User
+		 * screen would fire "fm_user".
+		 */
+		do_action( "fm_{$context}" );
+	}
+}
 add_action( 'init', 'fm_trigger_context_action', 99 );
 
 /**

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -187,26 +187,48 @@ function _fieldmanager_registry( $var, $val = NULL ) {
 /**
  * Get the context for triggers and pattern matching.
  *
- * This function is crucial for performance. It prevents the unnecessary initialization of FM classes,
- * and the unnecessary loading of CSS and Javascript.
+ * This function is crucial for performance. It prevents the unnecessary
+ * initialization of FM classes, and the unnecessary loading of CSS and
+ * JavaScript.
  *
- * You can't use this function to determine whether or not a context 'Form' will be displayed, since
- * it can be used anywhere. We would love to use get_current_screen(), but it's not available in
- * some POST actions, and generally not available early enough in the init process.
+ * @see fm_calculate_context() for detail about the returned array values.
  *
- * This is a function to watch closely as WordPress changes, since it relies on paths and variables.
- *
- * @return string[] [$context, $type]
+ * @return array Contextual information for the current request.
  */
 function fm_get_context() {
 	static $calculated_context;
 
 	if ( $calculated_context ) {
 		return $calculated_context;
+	} else {
+		return fm_calculate_context();
 	}
+}
 
-	if ( is_admin() ) { // safe to use at any point in the load process, and better than URL matching.
-
+/**
+ * Calculate contextual information for the current request.
+ *
+ * You can't use this function to determine whether or not a context "form" will
+ * be displayed, since it can be used anywhere. We would love to use
+ * get_current_screen(), but it's not available in some POST actions, and
+ * generally not available early enough in the init process.
+ *
+ * This is a function to watch closely as WordPress changes, since it relies on
+ * paths and variables.
+ *
+ * @return array {
+ *     Array of context information.
+ *
+ *     @type  string|null A Fieldmanager context of "post", "quickedit", "term",
+ *                        "submenu", or "user", or null if one isn't found.
+ *     @type  string|null A "type" dependent on the context. For "post" and
+ *                        "quickedit", the post type. For "term", the taxonomy.
+ *                        For "submenu", the group name. For all others, null.
+ * }
+ */
+function fm_calculate_context() {
+	// Safe to use at any point in the load process, and better than URL matching.
+	if ( is_admin() ) {
 		$script = substr( $_SERVER['PHP_SELF'], strrpos( $_SERVER['PHP_SELF'], '/' ) + 1 );
 
 		/**
@@ -283,6 +305,7 @@ function fm_get_context() {
 	if ( empty( $calculated_context ) ) {
 		$calculated_context = array( null, null );
 	}
+
 	return $calculated_context;
 }
 

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -209,14 +209,23 @@ function fm_get_context() {
 
 		$script = substr( $_SERVER['PHP_SELF'], strrpos( $_SERVER['PHP_SELF'], '/' ) + 1 );
 
-		// context = submenu
-		if ( !empty( $_GET['page'] ) ) {
+		/**
+		 * Calculate a submenu context.
+		 *
+		 * For submenus of the default WordPress menus, the submenu's parent
+		 * slug should match the requested script. For submenus of custom menu
+		 * pages, where "admin.php" is the requested script but not the parent
+		 * slug, the submenu's slug should match the GET request.
+		 *
+		 * @see fm_register_submenu_page() for detail about $submenu array values.
+		 */
+		if ( ! empty( $_GET['page'] ) ) {
+			$page = sanitize_text_field( $_GET['page'] );
 			$submenus = _fieldmanager_registry( 'submenus' );
 			if ( $submenus ) {
 				foreach ( $submenus as $submenu ) {
-					if ( $script == $submenu[0] ) {
-						$calculated_context = array( 'submenu', sanitize_text_field( $_GET['page'] ) );
-						return $calculated_context;
+					if ( $script == $submenu[0] || ( 'admin.php' == $script && $page == $submenu[4] ) ) {
+						return array( 'submenu', sanitize_text_field( $page ) );
 					}
 				}
 			}

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -201,7 +201,8 @@ function fm_get_context() {
 	if ( $calculated_context ) {
 		return $calculated_context;
 	} else {
-		return fm_calculate_context();
+		$context_context = fm_calculate_context();
+		return $calculated_context;
 	}
 }
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -25,7 +25,6 @@ tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
 
 require $_tests_dir . '/includes/bootstrap.php';
 
-
 /**
  * Is the current version of WordPress at least ... ?
  *

--- a/tests/php/test-fieldmanager-calculate-context.php
+++ b/tests/php/test-fieldmanager-calculate-context.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Tests for calculating the Fieldmanager context of a request.
+ */
+class Test_Fieldmanager_Calculate_Context extends WP_UnitTestCase {
+
+	/**
+	 * Test context calculations for submenus.
+	 */
+	public function test_submenu_contexts() {
+		$screen   = get_current_screen();
+		$self     = isset( $_SERVER['PHP_SELF'] ) ? $_SERVER['PHP_SELF'] : null;
+		$page     = isset( $_GET['page'] ) ? $_GET['page'] : null;
+		$submenus = _fieldmanager_registry( 'submenus' );
+
+		_fieldmanager_registry( 'submenus', array() );
+
+		// Spoof is_admin().
+		set_current_screen( 'dashboard-user' );
+
+		// Submenu of a default WordPress menu.
+		$options_submenu = rand_str();
+		fm_register_submenu_page( $options_submenu, 'options-general.php', 'Options' );
+		$_SERVER['PHP_SELF'] = '/options-general.php';
+		$_GET['page'] = $options_submenu;
+		$this->assertEquals( array( 'submenu', $options_submenu ), fm_calculate_context() );
+
+		// Submenu of a custom menu.
+		$custom_menu_submenu = rand_str();
+		fm_register_submenu_page( $custom_menu_submenu, rand_str(), 'Custom' );
+		$_SERVER['PHP_SELF'] = '/admin.php';
+		$_GET['page'] = $custom_menu_submenu;
+		$this->assertEquals( array( 'submenu', $custom_menu_submenu ), fm_calculate_context() );
+
+		// Submenu that Fieldmanager didn't register.
+		$_SERVER['PHP_SELF'] = '/themes.php';
+		$_GET['page'] = rand_str();
+		$this->assertEquals( array( null, null ), fm_calculate_context() );
+
+		$GLOBALS['current_screen'] = $screen;
+		$_SERVER['PHP_SELF']       = $self;
+		$_GET['page']              = $page;
+		_fieldmanager_registry( 'submenus', $submenus );
+	}
+
+}


### PR DESCRIPTION
There are a few parts to this PR:

* 2f0d1d8, which makes sure that all FM submenus hooked at priority 10 are added
* b7c2645, which is the attempted fix for #260 
* bab112d and 982adfe, which introduce a function and tests for calculating the FM context
* 87434f1, which stops `fm_trigger_context_action()` from firing an action of `fm_`