### PR TITLE
preserve order for ajax autocomplete requests

### DIFF
--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -32,11 +32,7 @@ fm.autocomplete = {
 							fm_autocomplete_search: request.term,
 							fm_search_nonce: fm_search.nonce
 						}, function( result ) {
-							var results = JSON.parse( result );
-							if ( $.type( results ) == 'object' ) {
-								response( fm.autocomplete.prepare_options( results ) );
-							}
-							else response( [] );
+							response( result );
 						} );
 					};
 				} else if ( $el.data( 'options' ) ) {

--- a/php/datasource/class-fieldmanager-datasource.php
+++ b/php/datasource/class-fieldmanager-datasource.php
@@ -132,22 +132,36 @@ class Fieldmanager_Datasource {
 	}
 
 	/**
+	 * Format items for use in AJAX.
+	 *
+	 * @param string|null $fragment to search
+	 */
+	public function get_items_for_ajax( $fragment = null ) {
+		$items = $this->get_items( $fragment );
+		$return = array();
+
+		foreach ( $items as $id => $label ) {
+			$return[] = array( 'label' => $label, 'value' => $id );
+		}
+
+		return $return;
+	}
+
+	/**
 	 * AJAX callback to find posts
 	 * @return void, causes process to exit.
 	 */
 	public function autocomplete_search() {
 		// Check the nonce before we do anything
 		check_ajax_referer( 'fm_search_nonce', 'fm_search_nonce' );
-		$items = $this->get_items( sanitize_text_field( $_POST['fm_autocomplete_search'] ) );
+		$items = $this->get_items_for_ajax( sanitize_text_field( $_POST['fm_autocomplete_search'] ) );
 
 		// See if any results were returned and return them as an array
-		if ( !empty( $items ) ) {
-			echo json_encode( $items ); exit;
+		if ( ! empty( $items ) ) {
+			wp_send_json( $items );
 		} else {
-			echo "0";
+			wp_send_json( 0 );
 		}
-
-		die();
 	}
 
 	/**

--- a/tests/php/test-fieldmanager-autocomplete-field.php
+++ b/tests/php/test-fieldmanager-autocomplete-field.php
@@ -13,6 +13,12 @@ class Test_Fieldmanager_Autocomplete_Field extends WP_UnitTestCase {
 		$this->post_id = $this->factory->post->create( array( 'post_title' => rand_str(), 'post_date' => '2009-07-01 00:00:00' ) );
 		$this->post = get_post( $this->post_id );
 
+		$this->data_posts = array(
+			$this->factory->post->create_and_get( array( 'post_title' => 'test ' . rand_str(), 'post_date' => '2009-07-02 00:00:00' ) ),
+			$this->factory->post->create_and_get( array( 'post_title' => 'test ' . rand_str(), 'post_date' => '2009-07-03 00:00:00' ) ),
+			$this->factory->post->create_and_get( array( 'post_title' => 'test ' . rand_str(), 'post_date' => '2009-07-04 00:00:00' ) ),
+		);
+
 		$this->custom_datasource = new Fieldmanager_Datasource( array(
 			'options' => array( 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' )
 		) );
@@ -37,6 +43,25 @@ class Test_Fieldmanager_Autocomplete_Field extends WP_UnitTestCase {
 		$fm->add_meta_box( 'Test Autocomplete', 'post' )->render_meta_box( $this->post, array() );
 		$html = ob_get_clean();
 		$this->assertRegExp( '/<input[^>]+type=[\'"]text[\'"][^>]+value=[\'"]' . $args['default_value'] . '[\'"]/', $html );
+	}
+
+	public function test_ajax() {
+		$datasource = new Fieldmanager_Datasource_Post();
+
+		$fm = new Fieldmanager_Autocomplete( array(
+			'name' => 'test_autocomplete',
+			'datasource' => $datasource,
+		) );
+
+		$items = $datasource->get_items_for_ajax( 'test' );
+
+		$this->assertSame( 3, count( $items ) );
+
+		// we expect them to be returned in reverse chronological order
+		// could have created the samples in that order but this seems more explicit...
+		$this->assertSame( $this->data_posts[2]->ID, $items[0]['value'] );
+		$this->assertSame( $this->data_posts[1]->ID, $items[1]['value'] );
+		$this->assertSame( $this->data_posts[0]->ID, $items[2]['value'] );
 	}
 
 }


### PR DESCRIPTION
Previously, having js parse the json response was destructive because the JS object isn't ordered (it seemed in practice to be ordered by key). Rather than return an associative array and then reformat into an array in the JS, this change does the reformatting on the backend.
