### PR TITLE
Add a label to the term meta post type

### DIFF
--- a/php/util/class-fieldmanager-util-term-meta.php
+++ b/php/util/class-fieldmanager-util-term-meta.php
@@ -54,18 +54,18 @@ class Fieldmanager_Util_Term_Meta {
 	 * @return void
 	 */
 	public function create_content_type() {
-		$args = array(
-			'public' => false,
-			'publicly_queryable' => false,
+		register_post_type( $this->post_type, array(
+			'public'              => false,
+			'publicly_queryable'  => false,
 			'exclude_from_search' => false,
-			'query_var' => $this->post_type,
-			'rewrite' => false,
-			'show_ui' => false,
-			'capability_type' => 'post',
-			'hierarchical' => true,
-			'has_archive' => false
-		);
-		register_post_type( $this->post_type, $args );
+			'query_var'           => $this->post_type,
+			'rewrite'             => false,
+			'show_ui'             => false,
+			'capability_type'     => 'post',
+			'hierarchical'        => true,
+			'has_archive'         => false,
+			'label'               => __( 'Fieldmanager Term Metadata', 'fieldmanager' ),
+		) );
 	}
 
 	/**


### PR DESCRIPTION
Although this post type is private, the label still appears on the Export page, because `$can_export` is not false, and it might appear elsewhere.

Without its own label, the post type is labeled "Pages."