### PR TITLE
fixed misnamed class for Fieldmanager_Context_Page

### DIFF
--- a/php/context/class-fieldmanager-context-page.php
+++ b/php/context/class-fieldmanager-context-page.php
@@ -7,7 +7,7 @@
  * Use fieldmanager on the public-facing theme.
  * @package Fieldmanager_Datasource
  */
-class Fieldmanager_Context_Form extends Fieldmanager_Context {
+class Fieldmanager_Context_Page extends Fieldmanager_Context {
 
 	/**
 	 * @var Fieldmanager_Context_Page[]


### PR DESCRIPTION
I think this is going to be superseded by https://github.com/alleyinteractive/wordpress-fieldmanager/pull/157, but in the meantime I just want to fix this little bug so that I can update FM to the latest on an old project that uses `Fieldmanager_Context_Page`.