### PR TITLE
Adding custom args to autcomplete ajax requests

### DIFF
--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -25,13 +25,23 @@ fm.autocomplete = {
 				}
 				if ( $el.data( 'action' ) ) {
 					ac_params.source = function( request, response ) {
+						// Check for custom args
+						var custom_args = $el.data( 'customArgs' );
+						var custom_data = '';
+						if ( 'undefined' !== typeof custom_args && null !== custom_args ) {
+							var custom_result = $el.triggerHandler( $el.data( 'customArgs' ) );
+							if ( 'undefined' !== typeof custom_result && null !== custom_result ) {
+								custom_data = custom_result;
+							}
+						}
+						
 						$.post( ajaxurl, {
 							action: $el.data( 'action' ),
 							fm_context: $el.data( 'context' ),
 							fm_subcontext: $el.data( 'subcontext' ),
 							fm_autocomplete_search: request.term,
 							fm_search_nonce: fm_search.nonce,
-							fm_custom_args: $el.triggerHandler( $el.data( 'customArgs' ) )
+							fm_custom_args: custom_data
 						}, function( result ) {
 							response( result );
 						} );

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -25,14 +25,16 @@ fm.autocomplete = {
 				}
 				if ( $el.data( 'action' ) ) {
 					ac_params.source = function( request, response ) {
-						$.post( ajaxurl, {
+						var args = {
 							action: $el.data( 'action' ),
 							fm_context: $el.data( 'context' ),
 							fm_subcontext: $el.data( 'subcontext' ),
 							fm_autocomplete_search: request.term,
 							fm_search_nonce: fm_search.nonce,
 							fm_custom_args: $el.triggerHandler( $el.data( 'customArgs' ) )
-						}, function( result ) {
+						};
+						console.log( args );
+						$.post( ajaxurl, args, function( result ) {
 							response( result );
 						} );
 					};

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -26,10 +26,10 @@ fm.autocomplete = {
 				if ( $el.data( 'action' ) ) {
 					ac_params.source = function( request, response ) {
 						// Check for custom args
-						var custom_args = $el.data( 'customArgs' );
+						var custom_args_js_event = $el.data( 'customArgsJsEvent' );
 						var custom_data = '';
-						if ( 'undefined' !== typeof custom_args && null !== custom_args ) {
-							var custom_result = $el.triggerHandler( custom_args );
+						if ( 'undefined' !== typeof custom_args_js_event && null !== custom_args_js_event ) {
+							var custom_result = $el.triggerHandler( custom_args_js_event );
 							if ( 'undefined' !== typeof custom_result && null !== custom_result ) {
 								custom_data = custom_result;
 							}

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -25,16 +25,14 @@ fm.autocomplete = {
 				}
 				if ( $el.data( 'action' ) ) {
 					ac_params.source = function( request, response ) {
-						var args = {
+						$.post( ajaxurl, {
 							action: $el.data( 'action' ),
 							fm_context: $el.data( 'context' ),
 							fm_subcontext: $el.data( 'subcontext' ),
 							fm_autocomplete_search: request.term,
 							fm_search_nonce: fm_search.nonce,
 							fm_custom_args: $el.triggerHandler( $el.data( 'customArgs' ) )
-						};
-						console.log( args );
-						$.post( ajaxurl, args, function( result ) {
+						}, function( result ) {
 							response( result );
 						} );
 					};

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -30,7 +30,8 @@ fm.autocomplete = {
 							fm_context: $el.data( 'context' ),
 							fm_subcontext: $el.data( 'subcontext' ),
 							fm_autocomplete_search: request.term,
-							fm_search_nonce: fm_search.nonce
+							fm_search_nonce: fm_search.nonce,
+							fm_custom_args: $el.triggerHandler( $el.data( 'customArgs' ) )
 						}, function( result ) {
 							response( result );
 						} );

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -29,7 +29,7 @@ fm.autocomplete = {
 						var custom_args = $el.data( 'customArgs' );
 						var custom_data = '';
 						if ( 'undefined' !== typeof custom_args && null !== custom_args ) {
-							var custom_result = $el.triggerHandler( $el.data( 'customArgs' ) );
+							var custom_result = $el.triggerHandler( custom_args );
 							if ( 'undefined' !== typeof custom_result && null !== custom_result ) {
 								custom_data = custom_result;
 							}

--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -32,6 +32,12 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 	 * The function signature should be query_callback( $match, $args );
 	 */
 	public $query_callback = Null;
+	
+	/**
+	 * @var string
+	 * Javascript trigger to handle adding custom args
+	 */
+	public $custom_args = Null;
 
 	/**
 	 * @var boolean
@@ -110,9 +116,10 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 		}
 
 		$element = sprintf(
-			'<input class="fm-autocomplete fm-element fm-incrementable" type="text" id="%s" value="%s" %s />',
+			'<input class="fm-autocomplete fm-element fm-incrementable" type="text" id="%s" value="%s"%s %s />',
 			esc_attr( $this->get_element_id() ),
 			esc_attr( $display_value ),
+			( ! empty( $this->custom_args ) ) ? ' data-custom-args="' . esc_attr( $this->custom_args ) . '"' : '',
 			$this->get_element_attributes()
 		);
 

--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -37,7 +37,7 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 	 * @var string
 	 * Javascript trigger to handle adding custom args
 	 */
-	public $custom_args = Null;
+	public $custom_args_js_event = Null;
 
 	/**
 	 * @var boolean
@@ -119,7 +119,7 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 			'<input class="fm-autocomplete fm-element fm-incrementable" type="text" id="%s" value="%s"%s %s />',
 			esc_attr( $this->get_element_id() ),
 			esc_attr( $display_value ),
-			( ! empty( $this->custom_args ) ) ? ' data-custom-args="' . esc_attr( $this->custom_args ) . '"' : '',
+			( ! empty( $this->custom_args_js_event ) ) ? ' data-custom-args-js-event="' . esc_attr( $this->custom_args_js_event ) . '"' : '',
 			$this->get_element_attributes()
 		);
 

--- a/php/datasource/class-fieldmanager-datasource-post.php
+++ b/php/datasource/class-fieldmanager-datasource-post.php
@@ -11,7 +11,7 @@ class Fieldmanager_Datasource_Post extends Fieldmanager_Datasource {
 
     /**
      * Supply a function which returns a list of posts; takes one argument,
-     * a possible fragement
+     * a possible fragment
      */
     public $query_callback = Null;
 

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -10,12 +10,6 @@
 class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 
 	/**
-     * Supply a function which returns a list of terms; takes one argument,
-     * a possible fragment
-     */
-    public $query_callback = Null;
-
-	/**
 	 * @var string|array
 	 * Taxonomy name or array of taxonomy names
 	 */
@@ -113,7 +107,6 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 		$unique_key .= json_encode( $this->get_taxonomies() );
 		$unique_key .= (string) $this->taxonomy_hierarchical;
 		$unique_key .= (string) $this->taxonomy_hierarchical_depth;
-		$unique_key .= (string) $this->query_callback;
 		return 'fm_datasource_term_' . crc32( $unique_key );
 	}
 
@@ -247,9 +240,6 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	 * @return array[] data entries for options
 	 */
 	public function get_items( $fragment = Null ) {
-		if ( is_callable( $this->query_callback ) ) {
-            return call_user_func( $this->query_callback, $fragment );
-        }
 
 		// If taxonomy_hierarchical is set, assemble recursive term list, then bail out.
 		if ( $this->taxonomy_hierarchical ) {

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -10,6 +10,12 @@
 class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 
 	/**
+     * Supply a function which returns a list of terms; takes one argument,
+     * a possible fragment
+     */
+    public $query_callback = Null;
+
+	/**
 	 * @var string|array
 	 * Taxonomy name or array of taxonomy names
 	 */
@@ -107,6 +113,7 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 		$unique_key .= json_encode( $this->get_taxonomies() );
 		$unique_key .= (string) $this->taxonomy_hierarchical;
 		$unique_key .= (string) $this->taxonomy_hierarchical_depth;
+		$unique_key .= (string) $this->query_callback;
 		return 'fm_datasource_term_' . crc32( $unique_key );
 	}
 
@@ -240,6 +247,9 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	 * @return array[] data entries for options
 	 */
 	public function get_items( $fragment = Null ) {
+		if ( is_callable( $this->query_callback ) ) {
+            return call_user_func( $this->query_callback, $fragment );
+        }
 
 		// If taxonomy_hierarchical is set, assemble recursive term list, then bail out.
 		if ( $this->taxonomy_hierarchical ) {

--- a/php/datasource/class-fieldmanager-datasource-user.php
+++ b/php/datasource/class-fieldmanager-datasource-user.php
@@ -11,7 +11,7 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
 
     /**
      * Supply a function which returns a list of users; takes one argument,
-     * a possible fragement
+     * a possible fragment
      */
     public $query_callback = Null;
 


### PR DESCRIPTION
This adds a new parameter called `custom_args` that lets you create a handler that can append arbitrary data to an AJAX request. The assumption is that if you wanted to use it in a query, you would also implement your own `query_callback` for the datasources that support that. It's otherwise harmless and ignored.