### PR TITLE
Display If: Match the checked value on load

### DIFF
--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -168,8 +168,12 @@ $( document ).ready( function () {
 		var src = $( this ).data( 'display-src' );
 		var values = $( this ).data( 'display-value' ).split( ',' );
 		var trigger = $( this ).siblings( '.fm-' + src + '-wrapper' ).find( '.fm-element' );
+		var val = trigger.val();
+		if ( trigger.is( ':radio' ) && trigger.filter( ':checked' ).length ) {
+			val = trigger.filter( ':checked' ).val();
+		}
 		trigger.addClass( 'display-trigger' );
-		if ( !match_value( values, trigger.val() ) ) {
+		if ( !match_value( values, val ) ) {
 			$( this ).hide();
 		}
 	} );


### PR DESCRIPTION
For radio buttons `trigger.val();` returns the first element’s value, not the checked element’s value. This PR adds a check to see if there is a checked value when the trigger initializes.

#264 has a related check for checkboxes.