### PR TITLE
Only check user capability when attempting to save user meta

### DIFF
--- a/php/datasource/class-fieldmanager-datasource-user.php
+++ b/php/datasource/class-fieldmanager-datasource-user.php
@@ -123,12 +123,13 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
             $value = array( $value );
         }
         foreach ( $value as $i => $v ) {
-            $value[$i] = intval( $v );
-            if( !current_user_can( $this->capability, $v ) ) {
-                wp_die( esc_html( sprintf( __( 'Tried to refer to user "%s" which current user cannot edit.', 'fieldmanager' ), $v ) ) );
-            }
-            if ( $this->reciprocal ) {
-                add_user_meta( $v, $this->reciprocal, $field->data_id );
+            $value[$i] = $this->sanitize_value( $v );
+            if ( $this->reciprocal && 'ID' == $this->store_property ) {
+                if( current_user_can( $this->capability, $v ) ) {
+                    add_user_meta( $v, $this->reciprocal, $field->data_id );
+                }   else {
+                    wp_die( esc_html( sprintf( __( 'Tried to refer to user "%s" which current user cannot edit.', 'fieldmanager' ), $v ) ) );
+                }
             }
         }
         return $return_single ? $value[0] : $value;


### PR DESCRIPTION
Checking it all the time means users can't be a data source when the
user doesn't have `list_users`