### PR TITLE
Remove term meta rewrite rules

### DIFF
--- a/php/util/class-fieldmanager-util-term-meta.php
+++ b/php/util/class-fieldmanager-util-term-meta.php
@@ -56,7 +56,8 @@ class Fieldmanager_Util_Term_Meta {
 	 */
 	public function create_content_type() {
 		register_post_type( $this->post_type, array(
-			'label' => __( 'Fieldmanager Term Metadata', 'fieldmanager' ),
+			'rewrite' => false,
+			'label'   => __( 'Fieldmanager Term Metadata', 'fieldmanager' ),
 		) );
 	}
 


### PR DESCRIPTION
After #319, the term meta post type falls back to the default `rewrite => true`, which generates unused (I think) rewrite rules.