### PR TITLE
Fix for serializable wp_filters

### DIFF
--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -60,19 +60,25 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 		$this->modal_button_label = __( 'Select Attachment', 'fieldmanager' );
 		$this->modal_title        = __( 'Choose an Attachment', 'fieldmanager' );
 
-		add_action( 'admin_print_scripts', function() {
-			$post = get_post();
-			$args = array();
-			if ( isset( $post ) && $post->ID ) {
-				$args['post'] = $post->ID;
-			}
-			wp_enqueue_media( $args ); // generally on post pages this will not have an impact.
-		} );
+		add_action( 'admin_print_scripts', array( $this, 'admin_print_scripts' ) );
 		if ( !self::$has_registered_media ) {
 			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), '1.0.1' );
 			self::$has_registered_media = True;
 		}
 		parent::__construct( $label, $options );
+	}
+
+	/**
+	 * Hook into admin_print_scripts action to enqueue the media for the current
+	 * post
+	 */
+	public function admin_print_scripts() {
+		$post = get_post();
+		$args = array();
+		if ( isset( $post ) && $post->ID ) {
+			$args['post'] = $post->ID;
+		}
+		wp_enqueue_media( $args ); // generally on post pages this will not have an impact.
 	}
 
 	/**


### PR DESCRIPTION
`Fieldmanager_Media::__construct()` was defining an action as a closure, which makes it so that `wp_filters` isn't serializable. This pull request moves the action into a class function instead.