### PR TITLE
Remove errant "0" from ajax response in quickedit context

### DIFF
--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -155,7 +155,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 		$post_type = get_post_type( $post_id );
 
 		$this->add_quickedit_box( $column_name, $post_type, $this->load() );
-        exit;
+		exit;
 	}
 
 	/**

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -154,7 +154,8 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 		$this->fm->data_id = $post_id;
 		$post_type = get_post_type( $post_id );
 
-		return $this->add_quickedit_box( $column_name, $post_type, $this->load() );
+		$this->add_quickedit_box( $column_name, $post_type, $this->load() );
+        exit;
 	}
 
 	/**


### PR DESCRIPTION
This fixes the issue described in #341. 

Exiting after outputting the desired ajax response prevents WordPress from spitting out its ugly zeroes.
