### PR TITLE
Update draggable-bin so field name can have '-bin'

### DIFF
--- a/js/fieldmanager-draggablepost.js
+++ b/js/fieldmanager-draggablepost.js
@@ -33,7 +33,7 @@
 	function populateHiddenElements() {
 		$('.post-bin').each(function(i) {
 			var post_ids = [];
-			var input_name = $(this).attr('id').replace('-bin', '');
+			var input_name = $(this).attr('id').replace(/-bin$/g, '');
 			$(this).find('.draggable-post').each(function(i) {
 				post_ids.push($(this).attr('post_id'));
 			});


### PR DESCRIPTION
The input hidden element for draggable posts is linked by the id of the wrapper.

```
$field = new Fieldmanager_DraggablePost(array(
    'name' => 'dragged-posts',
    'repositories' => array(
        /* arguments */
    ),
    'bins' => array(
        'post-bins' => 'Bins'
    ),
));
```

The javascript fails because "post-bins-bin".replace('-bin', '') returns "posts-bin" and not the id of the input 'post-bins'.  This patch makes sure it's only replaces -bin at the end of the id.
