### PR TITLE
Add term presave value filter

### DIFF
--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -148,6 +148,8 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 			$values = array( $values );
 		}
 
+		$values = apply_filters( 'fm_datasource_term_presave_alter_values', $values, $field, $current_values, $this );
+
 		// maybe we can create terms here.
 		if ( get_class( $field ) == 'Fieldmanager_Autocomplete' && !$field->exact_match && isset( $this->taxonomy ) ) {
 			foreach( $values as $i => $value ) {
@@ -190,7 +192,7 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 			}
 			$this->save_taxonomy( $tax_values, $field->data_id );
 		}
-		if ( $this->only_save_to_taxonomy ) { 
+		if ( $this->only_save_to_taxonomy ) {
 			if ( empty( $values ) && ! ( $this->append_taxonomy ) ) {
 				$this->save_taxonomy( array(), $field->data_id );
 			}


### PR DESCRIPTION
Add filter to Fieldmanager_Datasource_Term::presave_alter_values(), which allows themes and other plugins to filter the term values before they are saved.