### PR TITLE
Allow submenus of pages with query args

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -297,7 +297,8 @@ function fm_calculate_context() {
 		if ( ! empty( $_GET['page'] ) ) {
 			$page = sanitize_text_field( $_GET['page'] );
 
-			if ( isset( $plugin_page, $pagenow ) ) {
+			// Attempt to use the core page hooks to calculate the current context
+			if ( isset( $plugin_page, $pagenow ) && function_exists( 'get_plugin_page_hook' ) ) {
 				if ( ! empty( $typenow ) ) {
 					$fm_the_parent = $pagenow . '?post_type=' . $typenow;
 				} else {

--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -101,7 +101,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 					<input type="hidden" name="fm-options-action" value="<?php echo sanitize_title( $this->fm->name ) ?>" />
 					<?php $this->render_field( array( 'data' => $values ) ); ?>
 				</div>
-				<?php submit_button( $this->submit_button_label, 'submit', 'fm-submit' ) ?>
+				<?php submit_button( $this->submit_button_label, 'primary', 'fm-submit' ) ?>
 			</form>
 		</div>
 		<?php


### PR DESCRIPTION
**Important**: My concern about this PR is that I'm moving the FM context hooks from `init` to `admin_init` when `is_admin()`. This is to allow the admin codebase to load so we can use core functions to calculate the current page (`get_plugin_page_hook()`). This could cause an issue if someone is executing code between init:99 and admin_init:5 and expecting their Fieldmanager fields to be defined.

Unfortunately, I couldn't figure out a reasonable way to test this using phpunit. It depends on numerous admin hooks firing and scripts loading (e.g. menu.php loading, and initializing the admin menu), which simply doesn't happen when running phpunit.

Resolves #195.