### PR TITLE
Allow post_type to be in url for submenu pages

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -295,6 +295,11 @@ function fm_calculate_context() {
 		if ( ! empty( $_GET['page'] ) ) {
 			$page = sanitize_text_field( $_GET['page'] );
 			$submenus = _fieldmanager_registry( 'submenus' );
+
+			if ( isset( $_GET['post_type'] ) && post_type_exists( $_GET['post_type'] ) ) {
+				$script .= '?post_type=' . $_GET['post_type'];
+			}
+
 			if ( $submenus ) {
 				foreach ( $submenus as $submenu ) {
 					if ( $script == $submenu[0] || ( 'admin.php' == $script && $page == $submenu[4] ) ) {

--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -101,7 +101,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 					<input type="hidden" name="fm-options-action" value="<?php echo sanitize_title( $this->fm->name ) ?>" />
 					<?php $this->render_field( array( 'data' => $values ) ); ?>
 				</div>
-				<?php submit_button( $this->submit_button_label, 'submit', 'fm-submit' ) ?>
+				<?php submit_button( $this->submit_button_label, 'primary', 'fm-submit' ) ?>
 			</form>
 		</div>
 		<?php

--- a/tests/php/test-fieldmanager-calculate-context.php
+++ b/tests/php/test-fieldmanager-calculate-context.php
@@ -1,46 +1,82 @@
 <?php
 /**
  * Tests for calculating the Fieldmanager context of a request.
+ *
+ * @group context
  */
 class Test_Fieldmanager_Calculate_Context extends WP_UnitTestCase {
+	protected $screen, $self, $get, $submenus;
 
-	/**
-	 * Test context calculations for submenus.
-	 */
-	public function test_submenu_contexts() {
-		$screen   = get_current_screen();
-		$self     = isset( $_SERVER['PHP_SELF'] ) ? $_SERVER['PHP_SELF'] : null;
-		$page     = isset( $_GET['page'] ) ? $_GET['page'] : null;
-		$submenus = _fieldmanager_registry( 'submenus' );
+	public function setUp() {
+		$this->screen    = get_current_screen();
+		$this->self      = isset( $_SERVER['PHP_SELF'] ) ? $_SERVER['PHP_SELF'] : null;
+		$this->get       = $_GET;
+		$this->submenus  = _fieldmanager_registry( 'submenus' );
 
 		_fieldmanager_registry( 'submenus', array() );
 
 		// Spoof is_admin().
 		set_current_screen( 'dashboard-user' );
+	}
 
-		// Submenu of a default WordPress menu.
-		$options_submenu = rand_str();
-		fm_register_submenu_page( $options_submenu, 'options-general.php', 'Options' );
-		$_SERVER['PHP_SELF'] = '/options-general.php';
-		$_GET['page'] = $options_submenu;
-		$this->assertEquals( array( 'submenu', $options_submenu ), fm_calculate_context() );
+	public function tearDown( $value = null ) {
+		$GLOBALS['current_screen'] = $this->screen;
+		$_SERVER['PHP_SELF']       = $this->self;
+		$_GET                      = $this->get;
+		_fieldmanager_registry( 'submenus', $this->submenus );
+	}
 
-		// Submenu of a custom menu.
-		$custom_menu_submenu = rand_str();
-		fm_register_submenu_page( $custom_menu_submenu, rand_str(), 'Custom' );
-		$_SERVER['PHP_SELF'] = '/admin.php';
-		$_GET['page'] = $custom_menu_submenu;
-		$this->assertEquals( array( 'submenu', $custom_menu_submenu ), fm_calculate_context() );
+	/**
+	 * Provide data for test_submenu_contexts.
+	 *
+	 * @see https://phpunit.de/manual/4.7/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers
+	 *
+	 * @return array
+	 */
+	public function submenu_context_args() {
+		return array(
+			// Core WordPress Menus
+			array( 'index.php' ),
+			array( 'edit.php' ),
+			array( 'upload.php' ),
+			array( 'edit-comments.php' ),
+			array( 'themes.php' ),
+			array( 'plugins.php' ),
+			array( 'users.php' ),
+			array( 'tools.php' ),
+			array( 'options-general.php' ),
 
-		// Submenu that Fieldmanager didn't register.
+			// Submenu with another query arg
+			array( 'edit.php?post_type=page' ),
+
+			// Submenu of a custom menu.
+			array( rand_str(), '/admin.php' ),
+		);
+	}
+
+	/**
+	 * Test context calculations for submenus.
+	 *
+	 * @dataProvider submenu_context_args
+	 */
+	public function test_submenu_contexts( $parent, $php_self = null ) {
+		$submenu = rand_str();
+		fm_register_submenu_page( $submenu, $parent, 'Submenu Page' );
+		$_SERVER['PHP_SELF'] = $php_self ? $php_self : '/' . parse_url( $parent, PHP_URL_PATH );
+		$query = parse_url( $parent, PHP_URL_QUERY );
+		if ( ! empty( $query ) ) {
+			parse_str( $query, $_GET );
+		}
+		$_GET['page'] = $submenu;
+		$this->assertEquals( array( 'submenu', $submenu ), fm_calculate_context() );
+	}
+
+	/**
+	 * Test a submenu that Fieldmanager didn't register.
+	 */
+	public function test_non_fm_submenu() {
 		$_SERVER['PHP_SELF'] = '/themes.php';
 		$_GET['page'] = rand_str();
 		$this->assertEquals( array( null, null ), fm_calculate_context() );
-
-		$GLOBALS['current_screen'] = $screen;
-		$_SERVER['PHP_SELF']       = $self;
-		$_GET['page']              = $page;
-		_fieldmanager_registry( 'submenus', $submenus );
 	}
-
 }


### PR DESCRIPTION
A simpler alternative to #368. This _only_ supports post_type as a second query arg in the URL, but as far as I can tell, that's all core supports as well.

Resolves #195