### PR TITLE
Define `fm_preview_sizes` var as object, not array

### DIFF
--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -116,7 +116,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 			<input type="hidden" name="%2$s" value="%4$s" class="fm-element fm-media-id" />
 			<div class="media-wrapper">%5$s</div>
 			<script type="text/javascript">
-			var fm_preview_size = fm_preview_size || [];
+			var fm_preview_size = fm_preview_size || {};
 			fm_preview_size["%1$s"]=%6$s;
 			</script>',
 			esc_attr( $this->get_element_id() ),


### PR DESCRIPTION
Since the properties on it are set as named properties, not by numeric
indexes, this variable needs to be defined as an object, or attempts to
set or read it's properties will fail.

See #387