### PR TITLE
Bug fixes for term datasource

### DIFF
--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -76,15 +76,20 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 		}
 
 		parent::__construct( $options );
-		if ( $this->only_save_to_taxonomy ) $this->taxonomy_save_to_terms = True;
 
-		// make post_tag and category sortable via term_order, if they're set as taxonomies, and if
-		// we're not using Fieldmanager storage
-		if ( $this->only_save_to_taxonomy && in_array( 'post_tag', $this->get_taxonomies() ) ) {
-			$wp_taxonomies['post_tag']->sort = True;
+		// Ensure that $taxonomy_save_to_terms is true if it needs to be
+		if ( $this->only_save_to_taxonomy ) {
+			$this->taxonomy_save_to_terms = true;
 		}
-		if ( $this->only_save_to_taxonomy && in_array( 'category', $this->get_taxonomies() ) ) {
-			$wp_taxonomies['category']->sort = True;
+
+		if ( $this->taxonomy_save_to_terms ) {
+			// Ensure that the taxonomies are sortable if we're not using FM
+			// storage
+			foreach ( $this->get_taxonomies() as $taxonomy ) {
+				if ( ! empty( $wp_taxonomies[ $taxonomy ] ) ) {
+					$wp_taxonomies[ $taxonomy ]->sort = true;
+				}
+			}
 		}
 	}
 
@@ -190,7 +195,7 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 			}
 			$this->save_taxonomy( $tax_values, $field->data_id );
 		}
-		if ( $this->only_save_to_taxonomy ) { 
+		if ( $this->only_save_to_taxonomy ) {
 			if ( empty( $values ) && ! ( $this->append_taxonomy ) ) {
 				$this->save_taxonomy( array(), $field->data_id );
 			}

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -203,7 +203,7 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	 * Sanitize a value
 	 */
 	public function presave( Fieldmanager_Field $field, $value, $current_value ) {
-		return empty( $value ) ? null : intval( $value );
+		return empty( $value ) ? $value : intval( $value );
 	}
 
 	/**

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -83,8 +83,7 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 		}
 
 		if ( $this->taxonomy_save_to_terms ) {
-			// Ensure that the taxonomies are sortable if we're not using FM
-			// storage
+			// Ensure that the taxonomies are sortable if we're not using FM storage.
 			foreach ( $this->get_taxonomies() as $taxonomy ) {
 				if ( ! empty( $wp_taxonomies[ $taxonomy ] ) ) {
 					$wp_taxonomies[ $taxonomy ]->sort = true;

--- a/tests/php/test-fieldmanager-datasource-term.php
+++ b/tests/php/test-fieldmanager-datasource-term.php
@@ -330,10 +330,8 @@ class Test_Fieldmanager_Datasource_Term extends WP_UnitTestCase {
 		// Create a custom taxonomy
 		register_taxonomy( $taxonomy, 'post' );
 
-		// Verify that tags, categories, and our custom tax are not sortable
+		// Verify that our custom taxonomy is not sortable
 		$this->assertTrue( empty( $wp_taxonomies[ $taxonomy ]->sort ) );
-		$this->assertTrue( empty( $wp_taxonomies['category']->sort ) );
-		$this->assertTrue( empty( $wp_taxonomies['post_tag']->sort ) );
 
 		new Fieldmanager_Autocomplete( array(
 			'name' => 'test_terms',
@@ -343,7 +341,9 @@ class Test_Fieldmanager_Datasource_Term extends WP_UnitTestCase {
 			) ),
 		) );
 
-		// Verify that the above datasource made our taxonomies sortable
+		// Verify that the above datasource made our taxonomy sortable. Also,
+		// ensure that tags and categories are now sortable (even though they
+		// may have already been due to code run elsewhere).
 		$this->assertTrue( $wp_taxonomies[ $taxonomy ]->sort );
 		$this->assertTrue( $wp_taxonomies['category']->sort );
 		$this->assertTrue( $wp_taxonomies['post_tag']->sort );


### PR DESCRIPTION
* Fix a data type issue introduced in core, because `null !== ''` (see #386 for further details; this resolves #386)
* Ensure any taxonomy used in a datasource, where the data is stored as a term relationship, is sortable