### PR TITLE
Allow users to restrict media type on Fieldmanager_Media

### DIFF
--- a/js/media/fieldmanager-media.js
+++ b/js/media/fieldmanager-media.js
@@ -22,10 +22,10 @@ $( document ).on( 'click', '.fm-media-button', function( event ) {
 		return;
 	}
 
-	// If media type has been restricted, make sure the library only shows that
+	// If mime type has been restricted, make sure the library only shows that
 	// type.
-	if ( $el.data( 'type' ) && 'all' !== $el.data( 'type' ) ) {
-		library.type = $el.data( 'type' );
+	if ( $el.data( 'mime-type' ) && 'all' !== $el.data( 'mime-type' ) ) {
+		library.type = $el.data( 'mime-type' );
 	}
 
 	// Create the media frame.
@@ -43,17 +43,17 @@ $( document ).on( 'click', '.fm-media-button', function( event ) {
 		}
 	});
 
-	// If media type has been restricted, make sure the library doesn't autoselect
-	// an uploaded file if it's the wrong media type
-	if ( $el.data( 'type' ) && 'all' !== $el.data( 'type' ) ) {
+	// If mime type has been restricted, make sure the library doesn't autoselect
+	// an uploaded file if it's the wrong mime type
+	if ( $el.data( 'mime-type' ) && 'all' !== $el.data( 'mime-type' ) ) {
 		// This event is only fired when a file is uploaded.
 		// @see {wp.media.controller.Library:uploading()}
 		fm_media_frame[ $el.attr('id') ].on( 'library:selection:add', function() {
 			// Get the Selection object and the currently selected attachment.
 			var selection = fm_media_frame[ $el.attr('id') ].state().get('selection'),
 				attachment = selection.first();
-			// If the media type is wrong, deselect the file.
-			if ( attachment.attributes.type !== $el.data( 'type' ) ) {
+			// If the mime type is wrong, deselect the file.
+			if ( attachment.attributes.type !== $el.data( 'mime-type' ) ) {
 				selection.remove(attachment);
 			}
 		});

--- a/js/media/fieldmanager-media.js
+++ b/js/media/fieldmanager-media.js
@@ -12,7 +12,8 @@ $( document ).on( 'click', '.media-wrapper a', function( event ){
 	$(this).closest('.media-wrapper').siblings('.fm-media-button').click();
 } );
 $( document ).on( 'click', '.fm-media-button', function( event ) {
-	var $el = $(this);
+	var $el = $(this),
+		library = {};
 	event.preventDefault();
 
 	// If the media frame already exists, reopen it.
@@ -21,8 +22,17 @@ $( document ).on( 'click', '.fm-media-button', function( event ) {
 		return;
 	}
 
+	// If media type has been restricted, make sure the library only shows that
+	// type.
+	if ( $el.data( 'type' ) && 'all' !== $el.data( 'type' ) ) {
+		library.type = $el.data( 'type' );
+	}
+
 	// Create the media frame.
 	fm_media_frame[ $el.attr('id') ] = wp.media({
+		// Set the library attributes.
+		library: library,
+
 		// Set the title of the modal.
 		title: $el.data('choose'),
 
@@ -32,6 +42,22 @@ $( document ).on( 'click', '.fm-media-button', function( event ) {
 			text: $el.data('update'),
 		}
 	});
+
+	// If media type has been restricted, make sure the library doesn't autoselect
+	// an uploaded file if it's the wrong media type
+	if ( $el.data( 'type' ) && 'all' !== $el.data( 'type' ) ) {
+		// This event is only fired when a file is uploaded.
+		// @see {wp.media.controller.Library:uploading()}
+		fm_media_frame[ $el.attr('id') ].on( 'library:selection:add', function() {
+			// Get the Selection object and the currently selected attachment.
+			var selection = fm_media_frame[ $el.attr('id') ].state().get('selection'),
+				attachment = selection.first();
+			// If the media type is wrong, deselect the file.
+			if ( attachment.attributes.type !== $el.data( 'type' ) ) {
+				selection.remove(attachment);
+			}
+		});
+	}
 
 	// When an image is selected, run a callback.
 	fm_media_frame[ $el.attr('id') ].on( 'select', function() {

--- a/js/media/fieldmanager-media.js
+++ b/js/media/fieldmanager-media.js
@@ -49,6 +49,14 @@ $( document ).on( 'click', '.fm-media-button', function( event ) {
 		// This event is only fired when a file is uploaded.
 		// @see {wp.media.controller.Library:uploading()}
 		fm_media_frame[ $el.attr('id') ].on( 'library:selection:add', function() {
+			// This event gets fired for every frame that has ever been created on
+			// the current page, which causes errors. We only care about the visible
+			// frame. Also, FM can change the ID of buttons, which means some older
+			// frames may no longer be valid.
+			if ( 'undefined' === typeof fm_media_frame[ $el.attr('id') ] || ! fm_media_frame[ $el.attr('id') ].$el.is(':visible') ) {
+				return;
+			}
+
 			// Get the Selection object and the currently selected attachment.
 			var selection = fm_media_frame[ $el.attr('id') ].state().get('selection'),
 				attachment = selection.first();

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -46,10 +46,11 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 
 	/**
 	 * @var string
-	 * What media types are available to choose from.
-	 * Must be a string, and can be any of "all", "image", "audio", or "video".
+	 * What mime types are available to choose from.
+	 * Valid options are "all" or a partial or full mimetype (e.g. "image" or
+	 * "application/pdf").
 	 */
-	public $media_type = 'all';
+	public $mime_type = 'all';
 
 	/**
 	 * @var boolean
@@ -119,7 +120,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 			$preview = '';
 		}
 		return sprintf(
-			'<input type="button" class="fm-media-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" data-type="%9$s" />
+			'<input type="button" class="fm-media-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" data-mime-type="%9$s" />
 			<input type="hidden" name="%2$s" value="%4$s" class="fm-element fm-media-id" />
 			<div class="media-wrapper">%5$s</div>
 			<script type="text/javascript">
@@ -134,7 +135,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 			json_encode( $this->preview_size ),
 			esc_attr( $this->modal_title ),
 			esc_attr( $this->modal_button_label ),
-			esc_attr( $this->media_type )
+			esc_attr( $this->mime_type )
 		);
 	}
 

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -46,6 +46,13 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 
 	/**
 	 * @var string
+	 * What media types are available to choose from.
+	 * Must be a string, and can be any of "all", "image", "audio", or "video".
+	 */
+	public $media_type = 'all';
+
+	/**
+	 * @var boolean
 	 * Static variable so we only load media JS once
 	 */
 	public static $has_registered_media = False;
@@ -112,7 +119,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 			$preview = '';
 		}
 		return sprintf(
-			'<input type="button" class="fm-media-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" />
+			'<input type="button" class="fm-media-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" data-type="%9$s" />
 			<input type="hidden" name="%2$s" value="%4$s" class="fm-element fm-media-id" />
 			<div class="media-wrapper">%5$s</div>
 			<script type="text/javascript">
@@ -126,7 +133,8 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 			$preview,
 			json_encode( $this->preview_size ),
 			esc_attr( $this->modal_title ),
-			esc_attr( $this->modal_button_label )
+			esc_attr( $this->modal_button_label ),
+			esc_attr( $this->media_type )
 		);
 	}
 

--- a/tests/php/test-fieldmanager-media-field.php
+++ b/tests/php/test-fieldmanager-media-field.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Tests the Fieldmanager Media Field
+ *
+ * @group field
+ * @group media
+ */
+class Test_Fieldmanager_Media_Field extends WP_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+		Fieldmanager_Field::$debug = TRUE;
+
+		$this->post_id = $this->factory->post->create( array( 'post_title' => rand_str(), 'post_date' => '2009-07-01 00:00:00' ) );
+		$this->post = get_post( $this->post_id );
+	}
+
+	public function test_mime_type() {
+		$args = array(
+			'name'      => 'test_media',
+			'mime_type' => 'image',
+		);
+
+		$fm = new Fieldmanager_Media( $args );
+		ob_start();
+		$fm->add_meta_box( 'Test Media', 'post' )->render_meta_box( $this->post, array() );
+		$html = ob_get_clean();
+		$this->assertRegExp( '/<input[^>]+type=[\'"]button[\'"][^>]+data-mime-type=[\'"]image[\'"]/', $html );
+	}
+}


### PR DESCRIPTION
This commit adds a "media_type" parameter on the Fieldmanager_Media object, which allows developers to restrict the media type for the Media Library that is opened. Valid options are "all", "image", "audio", or "video".