### PR TITLE
Use <h1> for submenu headings

### DIFF
--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -94,7 +94,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 				<div class="updated success"><p><?php esc_html_e( 'Options updated', 'fieldmanager' ); ?></p></div>
 			<?php endif ?>
 
-			<h2><?php echo esc_html( $this->page_title ) ?></h2>
+			<h1><?php echo esc_html( $this->page_title ) ?></h1>
 
 			<form method="POST" id="<?php echo esc_attr( $this->uniqid ) ?>">
 				<div class="fm-submenu-form-wrapper">

--- a/tests/php/test-fieldmanager-context-submenu.php
+++ b/tests/php/test-fieldmanager-context-submenu.php
@@ -29,7 +29,7 @@ class Test_Fieldmanager_Context_Submenu extends WP_UnitTestCase {
 		$context = $this->get_context( $name );
 		$html = $this->get_html( $context, $name );
 
-		$this->assertContains( '<h2>Tools Meta Fields</h2>', $html );
+		$this->assertContains( '<h1>Tools Meta Fields</h1>', $html );
 		$this->assertRegExp( '/<input type="hidden"[^>]+name="fieldmanager-' . $name . '-nonce"/', $html );
 		$this->assertRegExp( '/<input[^>]+type="text"[^>]+name="' . $name . '\[name\]"[^>]+value=""/', $html );
 		$this->assertRegExp( '/<input[^>]+type="text"[^>]+name="' . $name . '\[email\]"[^>]+value=""/', $html );


### PR DESCRIPTION
See https://make.wordpress.org/core/2015/07/31/headings-in-admin-screens-change-in-wordpress-4-3/. Fixes #383.