### PR TITLE
Fix repeatable media field preview sizes

### DIFF
--- a/js/media/fieldmanager-media.js
+++ b/js/media/fieldmanager-media.js
@@ -37,7 +37,7 @@ $( document ).on( 'click', '.fm-media-button', function( event ) {
 	fm_media_frame[ $el.attr('id') ].on( 'select', function() {
 		// Grab the selected attachment.
 		var attachment = fm_media_frame[ $el.attr('id') ].state().get('selection').first().attributes;
-		props = { size: fm_preview_size[ $el.attr('id') ] || 'thumbnail' };
+		props = { size: $el.data('preview-size') || 'thumbnail' };
 		props = wp.media.string.props( props, attachment );
 		props.align = 'none';
 		props.link = 'custom';

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -48,22 +48,22 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 	 * @var string
 	 * Static variable so we only load media JS once
 	 */
-	public static $has_registered_media = False;
+	public static $has_registered_media = false;
 
 	/**
 	 * Construct default attributes
 	 * @param string $label
 	 * @param array $options
 	 */
-	public function __construct( $label, $options = array() ) {
+	public function __construct( $label = '', $options = array() ) {
 		$this->button_label       = __( 'Attach a File', 'fieldmanager' );
 		$this->modal_button_label = __( 'Select Attachment', 'fieldmanager' );
 		$this->modal_title        = __( 'Choose an Attachment', 'fieldmanager' );
 
 		add_action( 'admin_print_scripts', array( $this, 'admin_print_scripts' ) );
-		if ( !self::$has_registered_media ) {
-			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), '1.0.2' );
-			self::$has_registered_media = True;
+		if ( ! self::$has_registered_media ) {
+			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), '1.0.3' );
+			self::$has_registered_media = true;
 		}
 		parent::__construct( $label, $options );
 	}
@@ -112,19 +112,15 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 			$preview = '';
 		}
 		return sprintf(
-			'<input type="button" class="fm-media-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" />
+			'<input type="button" class="fm-media-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" data-preview-size="%6$s" />
 			<input type="hidden" name="%2$s" value="%4$s" class="fm-element fm-media-id" />
-			<div class="media-wrapper">%5$s</div>
-			<script type="text/javascript">
-			var fm_preview_size = fm_preview_size || [];
-			fm_preview_size["%1$s"]=%6$s;
-			</script>',
+			<div class="media-wrapper">%5$s</div>',
 			esc_attr( $this->get_element_id() ),
 			esc_attr( $this->get_form_name() ),
 			esc_attr( $this->button_label ),
 			esc_attr( $value ),
 			$preview,
-			json_encode( $this->preview_size ),
+			esc_attr( $this->preview_size ),
 			esc_attr( $this->modal_title ),
 			esc_attr( $this->modal_button_label )
 		);

--- a/tests/php/test-fieldmanager-media-field.php
+++ b/tests/php/test-fieldmanager-media-field.php
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * Tests the Fieldmanager Media Field
+ *
+ * @group field
+ * @group media
+ */
+class Test_Fieldmanager_Media_Field extends WP_UnitTestCase {
+
+	protected $post;
+
+	public function setUp() {
+		parent::setUp();
+		Fieldmanager_Field::$debug = TRUE;
+
+		// insert a post
+		$this->post = $this->factory->post->create_and_get( array( 'post_title' => rand_str(), 'post_date' => '2009-07-01 00:00:00' ) );
+	}
+
+	public function test_basic_render() {
+		$args = array(
+			'name' => 'test_media',
+			'button_label' => rand_str(),
+			'modal_button_label' => rand_str(),
+			'modal_title' => rand_str(),
+			'preview_size' => rand_str(),
+		);
+		$fm = new Fieldmanager_Media( $args );
+
+		ob_start();
+		$fm->add_meta_box( 'Test Media', 'post' )->render_meta_box( $this->post, array() );
+		$html = ob_get_clean();
+		$this->assertRegExp(
+			sprintf(
+				'#<input type="button" class="[^"]*fm-media-button[^>]+value="%s" data-choose="%s" data-update="%s" data-preview-size="%s" />#',
+				$args['button_label'],
+				$args['modal_title'],
+				$args['modal_button_label'],
+				$args['preview_size']
+			),
+			$html
+		);
+		$this->assertRegExp( '#<input type="hidden" name="test_media" value="" class="fm-element fm-media-id" />#', $html );
+		$this->assertRegExp( '#<div class="media-wrapper"></div>#', $html );
+	}
+
+	public function test_basic_save() {
+		$test_data = 3335444;
+		$fm = new Fieldmanager_Media( array( 'name' => 'test_media' ) );
+
+		$fm->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post->ID, $test_data );
+		$saved_data = get_post_meta( $this->post->ID, 'test_media', true );
+		$this->assertEquals( $test_data, $saved_data );
+	}
+}

--- a/tests/php/test-fieldmanager-script-loading.php
+++ b/tests/php/test-fieldmanager-script-loading.php
@@ -21,6 +21,9 @@ class Test_Fieldmanager_Script_Loading extends WP_UnitTestCase {
 		$GLOBALS['wp_scripts'] = new WP_Scripts();
 		$GLOBALS['wp_scripts']->default_version = get_bloginfo( 'version' );
 
+		// Media will only try to register a script once, so hack around that.
+		Fieldmanager_Media::$has_registered_media = false;
+
 		// Instantiate field classes that register scripts.
 		new Fieldmanager_Autocomplete( 'Test', array( 'datasource' => new Fieldmanager_Datasource_Post ) );
 		new Fieldmanager_Datepicker( 'Test' );


### PR DESCRIPTION
This fixes a bug where repeatable media fields would show the wrong preview size for newly-created fields. Also, adds basic unit tests for rendering and saving.