### PR TITLE
Adjustments to "Display If" with checkboxes

### DIFF
--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -166,12 +166,16 @@ $( document ).ready( function () {
 	// Initializes triggers to conditionally hide or show fields
 	$( '.display-if' ).each( function() {
 		var src = $( this ).data( 'display-src' );
-		var values = $( this ).data( 'display-value' ).split( ',' );
+		var values = $( this ).data( 'display-value' ).toString().split( ',' );
 		var trigger = $( this ).siblings( '.fm-' + src + '-wrapper' ).find( '.fm-element' );
 		var val = trigger.val();
 		if ( trigger.is( ':radio' ) && trigger.filter( ':checked' ).length ) {
 			val = trigger.filter( ':checked' ).val();
 		}
+		if ( trigger.is( ':checkbox' ) ) {
+			val = trigger.filter( ':checked' ).val();
+		}
+
 		trigger.addClass( 'display-trigger' );
 		if ( !match_value( values, val ) ) {
 			$( this ).hide();
@@ -180,20 +184,22 @@ $( document ).ready( function () {
 
 	// Controls the trigger to show or hide fields
 	$( document ).on( 'change', '.display-trigger', function() {
-		var val = $( this ).val().split(',');
+		var val = $( this ).val().toString().split(',');
 		var name = $( this ).attr('name');
-		$( this ).closest( '.fm-wrapper' ).siblings().each( function() {
-			if ( $( this ).hasClass( 'display-if' ) ) {
-				if( name.match( $( this ).data( 'display-src' ) ) != null ) {
-					if ( match_value( $( this ).data( 'display-value' ).split( ',' ), val ) ) {
-						$( this ).show();
-					} else {
-						$( this ).hide();
+		if (name != undefined || name != null) {
+			$( this ).closest( '.fm-wrapper' ).siblings().each( function() {
+				if ( $( this ).hasClass( 'display-if' ) ) {
+					if( name.match( $( this ).data( 'display-src' ) ) != null ) {
+						if ( match_value( $( this ).data( 'display-value' ).toString().split( ',' ), val ) ) {
+							$( this ).show();
+						} else {
+							$( this ).hide();
+						}
+						$( this ).trigger( 'fm_displayif_toggle' );
 					}
-					$( this ).trigger( 'fm_displayif_toggle' );
 				}
-			}
-		} );
+			} );
+		}
 	} );
 
 	init_label_macros();

--- a/php/class-fieldmanager-checkbox.php
+++ b/php/class-fieldmanager-checkbox.php
@@ -43,7 +43,7 @@ class Fieldmanager_Checkbox extends Fieldmanager_Field {
 	 */
 	public function form_element( $value = NULL ) {
 		return sprintf(
-			'<input type="hidden" name="%1$s" value="%6$s" /><input class="fm-element" type="checkbox" name="%1$s" value="%2$s" %3$s %4$s id="%5$s" />',
+			'<input type="hidden" name="%1$s" value="%6$s" /><input class="fm-element" type="checkbox" name="%1$s" value="%2$s" %3$s %4$s id="%5$s" onclick="jQuery(this).val(this.checked ? 1 : 0)"/>',
 			esc_attr( $this->get_form_name() ),
 			esc_attr( (string) $this->checked_value ),
 			$this->get_element_attributes(),


### PR DESCRIPTION
I have a field group with 7 fields. The first is a checkbox and the others are text and autocomplete fields. 

I want the checkbox to be visible and the other 6 fields to be hidden unless the checkbox is clicked. 

The code I have to register the fields is as follows: 

```
$field_group = new FieldManager_Group(
			array(
				'name' => 'featured_authors',
				'label' => __( 'Featured Authors', 'mason' ),
				'children' => array(
					'enabled' => new Fieldmanager_Checkbox(
						array(
							'label' => __( 'Check to Enable Featured Authors for this section (Note: All 3 Authors must be set in order for this feature to display)', 'mason' ),
							'inline_label' => true,
							'label_after_element' => true
						)
					),
					'author_1' => new Fieldmanager_Autocomplete(
						array(
							'label' => __( 'Author 1 Username: (enter author username)', 'mason' ),
							'datasource' => new Fieldmanager_Datasource(
								array(
									'options' => $co_authors_list
								)
							),
							'display_if' => array(
								'src' => 'enabled',
								'value' => 1
							)
						)
					),
					'author_1_tagline' => new Fieldmanager_TextField(
						array(
							'label' => __( 'Author 1 Tag Line', 'mason' ),
							'display_if' => array(
								'src' => 'enabled',
								'value' => 1
							)
						)
					),
					'author_2' => new Fieldmanager_Autocomplete(
						array(
							'label' => __( 'Author 2 Username: (enter author username)', 'mason' ),
							'datasource' => new Fieldmanager_Datasource(
								array(
									'options' => $co_authors_list
								)
							),
							'display_if' => array(
								'src' => 'enabled',
								'value' => 1
							)
						)
					),
					'author_2_tagline' => new Fieldmanager_TextField(
						array(
							'label' => __( 'Author 2 Tag Line', 'mason' ),
							'display_if' => array(
								'src' => 'enabled',
								'value' => 1
							)
						)
					),
					'author_3' => new Fieldmanager_Autocomplete(
						array(
							'label' => __( 'Author 3 Username: (enter author username)', 'mason' ),
							'datasource' => new Fieldmanager_Datasource(
								array(
									'options' => $co_authors_list
								)
							),
							'display_if' => array(
								'src' => 'enabled',
								'value' => 1
							)
						)
					),
					'author_3_tagline' => new Fieldmanager_TextField(
						array(
							'label' => __( 'Author 3 Tag Line', 'mason' ),
							'display_if' => array(
								'src' => 'enabled',
								'value' => 1
							)
						)
					)
				)
			)
		);

		// Add the field form to Category term add/edit pages
		$field_group->add_term_form( __( 'Featured Authors', 'mason' ), 'category' );
```

When clicking the checkbox, the conditional display feature was causing .js errors and was not functioning properly. 

These changes address that issue and allow the scenario described to function properly.