### PR TITLE
Make `Fieldmanager_Options::$sanitize` a non-closure function

### DIFF
--- a/php/class-fieldmanager-options.php
+++ b/php/class-fieldmanager-options.php
@@ -65,13 +65,20 @@ abstract class Fieldmanager_Options extends Fieldmanager_Field {
 		fm_add_style( 'fm_options_css', 'css/fieldmanager-options.css' );
 
 		// Sanitization
-		$this->sanitize = function( $value ) {
-			if ( isset( $value ) && is_array( $value ) && !empty( $value ) ) {
-				return array_map( 'sanitize_text_field', $value );
-			} else {
-				return sanitize_text_field( $value );
-			}
-		};
+		$this->sanitize = array( $this, 'sanitize' );
+	}
+
+	/**
+	 * Sanitize function that can handle arrays as well as string values.
+	 * @param array|string $value
+	 * @return array|string Sanitized $value
+	 */
+	public function sanitize( $value ) {
+		if ( isset( $value ) && is_array( $value ) && ! empty( $value ) ) {
+			return array_map( 'sanitize_text_field', $value );
+		} else {
+			return sanitize_text_field( $value );
+		}
 	}
 
 	/**


### PR DESCRIPTION
`Fieldmanager_Options::$sanitize` was defined as a closure, which means that objects of this class are not serializable. This commit makes `$sanitize` a regular function.

This is similar to #357, and also alleyinteractive/fm-zones#3