### PR TITLE
Display-if enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 tests/php/build
 tests/php/wp-unit-test
+node_modules
 
 # Silly Macs
 .DS_Store

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -214,6 +214,26 @@ $( document ).ready( function () {
 		} );
 	} );
 
+	// get list of unique display-if events
+	var displayEvents = [];
+	$( '.display-conditional-callback' ).each( function() {
+		var eventName = $(this).data( 'display-event' );
+		if ( eventName && displayEvents.indexOf( eventName ) === -1 ) {
+			displayEvents.push( eventName );
+		}
+	} );
+
+	// listen for those events and toggle fields according to custom JS like
+	// $( document ).trigger( 'my-custom-event', [ false ] );
+	$( document ).on( displayEvents.join( ' ' ), function( evt, showField ) {
+		// default to showing field if missing arg
+		if ( typeof showField === 'undefined' ) {
+			showField = true;
+		}
+		// new search for .display-conditional-callback to account for newly added repeatable fields
+		$( '.display-conditional-callback[data-display-event="' + evt.type + '"]').toggle( Boolean( showField ) );
+	} );
+
 	init_label_macros();
 	init_sortable();
 

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -198,7 +198,7 @@ $( document ).ready( function () {
 
 	// Controls the trigger to show or hide fields
 	$( document ).on( 'change', '.display-trigger', function() {
-		var val = $( this ).val().split(',');
+		var val = $( this ).val();
 		var name = $( this ).attr('name');
 		$( this ).closest( '.fm-wrapper' ).siblings().each( function() {
 			if ( $( this ).hasClass( 'display-if' ) ) {

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -127,7 +127,7 @@ var match_value = function( values, match_string, comparison ) {
 			}
 		}
 	}
-	// not-equals returns false if nothing found, otherwise return true
+	// not-equals returns true if nothing found, otherwise return false
 	return 'not-equals' === comparison;
 }
 
@@ -224,7 +224,7 @@ $( document ).ready( function () {
 	} );
 
 	// listen for those events and toggle fields according to custom JS like
-	// $( document ).trigger( 'my-custom-event', [ false ] );
+	// $( document ).trigger( 'my-custom-event', [ true|false ] );
 	$( document ).on( displayEvents.join( ' ' ), function( evt, showField ) {
 		// default to showing field if missing arg
 		if ( typeof showField === 'undefined' ) {

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -106,6 +106,22 @@ var fm_renumber = function( $wrappers ) {
 }
 
 /**
+ * get data attribute value(s), accounting for jQuery converting string to number automatically
+ * @param HTMLDivElement el Wrapper with the data attribute
+ * @return string|number|array Single string or number, or array if data attr contains CSV
+ */
+var get_compare_values = function( el ) {
+	var values = $( el ).data( 'display-value' );
+	try {
+		values = values.split( ',' );
+	} catch(e) {
+		// if jQuery already converted string to number
+		values = [ values ];
+	}
+	return values;
+}
+
+/**
  * @param array values List of possible values to match against
  * @param string match_string Current value of field
  * @param string comparison Type of match, i.e. 'equals', 'not-equals', 'contains'
@@ -183,7 +199,7 @@ $( document ).ready( function () {
 	// Initializes triggers to conditionally hide or show fields
 	$( '.display-if' ).each( function() {
 		var src = $( this ).data( 'display-src' );
-		var values = $( this ).data( 'display-value' ).split( ',' );
+		var values = get_compare_values( this );
 		var compare = $( this ).data( 'display-compare' );
 		var trigger = $( this ).siblings( '.fm-' + src + '-wrapper' ).find( '.fm-element' );
 		var val = trigger.val();
@@ -203,7 +219,7 @@ $( document ).ready( function () {
 		$( this ).closest( '.fm-wrapper' ).siblings().each( function() {
 			if ( $( this ).hasClass( 'display-if' ) ) {
 				if( name.match( $( this ).data( 'display-src' ) ) != null ) {
-					if ( match_value( $( this ).data( 'display-value' ).split( ',' ), val, $( this ).data( 'display-compare' ) ) ) {
+					if ( match_value( get_compare_values( this ), val, $( this ).data( 'display-compare' ) ) ) {
 						$( this ).show();
 					} else {
 						$( this ).hide();

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -105,13 +105,30 @@ var fm_renumber = function( $wrappers ) {
 	} );
 }
 
-var match_value = function( values, match_string ) {
+/**
+ * @param array values List of possible values to match against
+ * @param string match_string Current value of field
+ * @param string comparison Type of match, i.e. 'equals', 'not-equals', 'contains'
+ * @return bool True if we want to display the field, false if we want to hide the field
+ */
+var match_value = function( values, match_string, comparison ) {
+	comparison = comparison || 'equals';
 	for ( var index in values ) {
-		if ( values[index] == match_string ) {
+		// test if current value of the field contains any of the possible values
+		if ( 'contains' === comparison && match_string.indexOf( values[index] ) >= 0 ) {
 			return true;
 		}
+		// test equality of field against list of possible values
+		else if ( values[index] == match_string ) {
+			if ( 'equals' === comparison ) {
+				return true;
+			} else if ( 'not-equals' === comparison ) {
+				return false;
+			}
+		}
 	}
-	return false;
+	// not-equals returns false if nothing found, otherwise return true
+	return 'not-equals' === comparison;
 }
 
 fm_add_another = function( $element ) {
@@ -167,13 +184,14 @@ $( document ).ready( function () {
 	$( '.display-if' ).each( function() {
 		var src = $( this ).data( 'display-src' );
 		var values = $( this ).data( 'display-value' ).split( ',' );
+		var compare = $( this ).data( 'display-compare' );
 		var trigger = $( this ).siblings( '.fm-' + src + '-wrapper' ).find( '.fm-element' );
 		var val = trigger.val();
 		if ( trigger.is( ':radio' ) && trigger.filter( ':checked' ).length ) {
 			val = trigger.filter( ':checked' ).val();
 		}
 		trigger.addClass( 'display-trigger' );
-		if ( !match_value( values, val ) ) {
+		if ( !match_value( values, val, compare ) ) {
 			$( this ).hide();
 		}
 	} );
@@ -185,7 +203,7 @@ $( document ).ready( function () {
 		$( this ).closest( '.fm-wrapper' ).siblings().each( function() {
 			if ( $( this ).hasClass( 'display-if' ) ) {
 				if( name.match( $( this ).data( 'display-src' ) ) != null ) {
-					if ( match_value( $( this ).data( 'display-value' ).split( ',' ), val ) ) {
+					if ( match_value( $( this ).data( 'display-value' ).split( ',' ), val, $( this ).data( 'display-compare' ) ) ) {
 						$( this ).show();
 					} else {
 						$( this ).hide();

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -206,7 +206,8 @@ abstract class Fieldmanager_Field {
 	/**
 	 * @var array[]
 	 * Toggle the display of a field based on source field's name, value, and optional comparison (defaults to `equals`).
-	 * Or provide a document-level event and callback that can be defined in external Javascript. Examples:
+	 * Note that `value` accepts a single value or a comma-separated list.
+	 * You can also provide a document-level event and callback that can be defined in external Javascript. Examples:
 	 * $element->display_if = array(
 	 *	'src' => 'display-if-src-element',
 	 *	'value' => 'display-if-src-value',
@@ -221,9 +222,10 @@ abstract class Fieldmanager_Field {
 	public $display_if = array();
 
 	/**
-	 * @var array
+	 * @var array	'equals'		True when value of named field equals (non-strict) any item in list of provided values
+	 *				'not-equals'	True when value of named field does not equal (non-strict) any item in list of provided values
+	 *				'contains'		True when value of named field contains any item in list of provided values
 	 * Allowed comparisons for the display_if property; first element in this array will be the default.
-	 * Note that `equals` and `not-equals` comparisons will use *non-strict* equality in fieldmanager.js
 	 */
 	protected $display_comparisons = array( 'equals', 'not-equals', 'contains' );
 

--- a/tests/js/index.html
+++ b/tests/js/index.html
@@ -289,6 +289,70 @@
 			</div>
 		</div>
 		<!-- /#display-if-repeatable -->
+
+		<div id="display-if-multi-events" class="fm-wrapper fm-display_if_multi_events-wrapper" data-fm-array-position="0" >
+			<div class="fm-item fm-display_if_multi_events">
+				<div class="fm-wrapper fm-multi-repeatable-wrapper display-conditional-callback" data-fm-array-position="2" data-display-event="my-custom-event" >
+					<div class="fm-item fm-multi-repeatable fm-text fmjs-proto">
+						<div class="fmjs-removable-label fmjs-removable">
+							<div class="fmjs-removable-element">
+								<div class="fm-label fm-label-multi-repeatable"><label for="fm-display_if_multi_events-0-multi-repeatable-proto">Test Repeatable</label></div>
+							</div>
+							<a href="#" class="fmjs-remove" title="Remove">Remove</a>
+						</div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_multi_events[multi-repeatable][proto]"
+							id="fm-display_if_multi_events-0-multi-repeatable-proto"
+							value=""
+							size="50"/>
+					</div>
+					<div class="fm-item fm-multi-repeatable fm-text">
+						<div class="fmjs-removable-label fmjs-removable">
+							<div class="fmjs-removable-element">
+								<div class="fm-label fm-label-multi-repeatable"><label for="fm-display_if_multi_events-0-multi-repeatable-0">Test Repeatable</label></div>
+							</div>
+							<a href="#" class="fmjs-remove" title="Remove">Remove</a>
+						</div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_multi_events[multi-repeatable][0]"
+							id="fm-display_if_multi_events-0-multi-repeatable-0"
+							value=""
+							size="50"/>
+					</div>
+					<div class="fm-add-another-wrapper"><input type="button" class="fm-add-another fm-multi-repeatable-add-another button-secondary" value="Add field" name="fm_add_another_multi-repeatable" data-related-element="multi-repeatable" data-add-more-position="bottom" data-limit="0" /></div>
+				</div>
+				<div class="fm-wrapper fm-multi-single-wrapper display-conditional-callback" data-fm-array-position="0" data-display-event="my-custom-event" >
+					<div class="fm-item fm-multi-single fm-text">
+						<div class="fm-label fm-label-multi-single"><label for="fm-display_if_multi_events-0-multi-single-0">Test Single</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_multi_events[multi-single]"
+							id="fm-display_if_multi_events-0-multi-single-0"
+							value=""
+							size="50"/>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-multi-other-wrapper display-conditional-callback" data-fm-array-position="0" data-display-event="my-other-event" >
+					<div class="fm-item fm-multi-other fm-text">
+						<div class="fm-label fm-label-multi-other"><label for="fm-display_if_multi_events-0-multi-other-0">Test Other</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_multi_events[multi-other]"
+							id="fm-display_if_multi_events-0-multi-other-0"
+							value=""
+							size="50"/>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- /#display-if-multi-events -->
+
 		<div id="renumbered" class="fm-wrapper" data-fm-array-position="1">
 			<div class="fm-item">
 				<div class="fm-element" name="mytest[0]">First</div>

--- a/tests/js/index.html
+++ b/tests/js/index.html
@@ -173,6 +173,122 @@
 		</div>
 		<!-- /#display-if-numeric -->
 
+		<div id="display-if-csv" class="fm-wrapper fm-display_if_csv-wrapper" data-fm-array-position="0" >
+			<div class="fm-item fm-display_if_csv">
+				<div class="fm-wrapper fm-primary-csv-wrapper" data-fm-array-position="0" >
+					<div class="fm-item fm-primary-csv fm-text">
+						<div class="fm-label fm-label-primary-csv"><label for="fm-display_if_csv-0-primary-csv-0">Primary Field</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_csv[primary-csv]"
+							id="fm-display_if_csv-0-primary-csv-0"
+							value="bar"
+							size="50"/>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-csv-strings-wrapper display-if" data-fm-array-position="0" data-display-src="primary-csv" data-display-value="foo,bar,zap" data-display-compare="equals" >
+					<div class="fm-item fm-csv-strings fm-text">
+						<div class="fm-label fm-label-csv-strings"><label for="fm-display_if_csv-0-csv-strings-0">Test Strings</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_csv[csv-strings]"
+							id="fm-display_if_csv-0-csv-strings-0"
+							value=""
+							size="50"/>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-csv-numbers-wrapper display-if" data-fm-array-position="0" data-display-src="primary-csv" data-display-value="11,12,13" data-display-compare="equals" >
+					<div class="fm-item fm-csv-numbers fm-text">
+						<div class="fm-label fm-label-csv-numbers"><label for="fm-display_if_csv-0-csv-numbers-0">Test Numbers</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_csv[csv-numbers]"
+							id="fm-display_if_csv-0-csv-numbers-0"
+							value=""
+							size="50"/>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-csv-not-equals-wrapper display-if" data-fm-array-position="0" data-display-src="primary-csv" data-display-value="bar,zap" data-display-compare="not-equals" >
+					<div class="fm-item fm-csv-not-equals fm-text">
+						<div class="fm-label fm-label-csv-not-equals"><label for="fm-display_if_csv-0-csv-not-equals-0">Test Not Equals</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_csv[csv-not-equals]"
+							id="fm-display_if_csv-0-csv-not-equals-0"
+							value=""
+							size="50"/>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-csv-contains-wrapper display-if" data-fm-array-position="0" data-display-src="primary-csv" data-display-value="fo,za" data-display-compare="contains" >
+					<div class="fm-item fm-csv-contains fm-text">
+						<div class="fm-label fm-label-csv-contains"><label for="fm-display_if_csv-0-csv-contains-0">Test Contains</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_csv[csv-contains]"
+							id="fm-display_if_csv-0-csv-contains-0"
+							value=""
+							size="50"/>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- /#display-if-csv -->
+
+		<div id="display-if-repeatable" class="fm-wrapper fm-display_if_repeatable-wrapper" data-fm-array-position="0" >
+			<div class="fm-item fm-display_if_repeatable">
+				<div class="fm-wrapper fm-primary-repeatable-wrapper" data-fm-array-position="0" >
+					<div class="fm-item fm-primary-repeatable fm-text">
+						<div class="fm-label fm-label-primary-repeatable"><label for="fm-display_if_repeatable-0-primary-repeatable-0">Primary Field</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_repeatable[primary-repeatable]"
+							id="fm-display_if_repeatable-0-primary-repeatable-0"
+							value="bar"
+							size="50"/>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-test-repeatable-wrapper display-if" data-fm-array-position="2" data-display-src="primary-repeatable" data-display-value="foo" data-display-compare="equals" >
+					<div class="fm-item fm-test-repeatable fm-text fmjs-proto">
+						<div class="fmjs-removable-label fmjs-removable">
+							<div class="fmjs-removable-element">
+								<div class="fm-label fm-label-test-repeatable"><label for="fm-display_if_repeatable-0-test-repeatable-proto">Test Repeatable</label></div>
+							</div>
+							<a href="#" class="fmjs-remove" title="Remove">Remove</a>
+						</div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_repeatable[test-repeatable][proto]"
+							id="fm-display_if_repeatable-0-test-repeatable-proto"
+							value=""
+							size="50"/>
+					</div>
+					<div class="fm-item fm-test-repeatable fm-text">
+						<div class="fmjs-removable-label fmjs-removable">
+							<div class="fmjs-removable-element">
+								<div class="fm-label fm-label-test-repeatable"><label for="fm-display_if_repeatable-0-test-repeatable-0">Test Repeatable</label></div>
+							</div>
+							<a href="#" class="fmjs-remove" title="Remove">Remove</a>
+						</div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_repeatable[test-repeatable][0]"
+							id="fm-display_if_repeatable-0-test-repeatable-0"
+							value=""
+							size="50"/>
+					</div>
+					<div class="fm-add-another-wrapper"><input type="button" class="fm-add-another fm-test-repeatable-add-another button-secondary" value="Add field" name="fm_add_another_test-repeatable" data-related-element="test-repeatable" data-add-more-position="bottom" data-limit="0" /></div>
+				</div>
+			</div>
+		</div>
+		<!-- /#display-if-repeatable -->
 		<div id="renumbered" class="fm-wrapper" data-fm-array-position="1">
 			<div class="fm-item">
 				<div class="fm-element" name="mytest[0]">First</div>

--- a/tests/js/index.html
+++ b/tests/js/index.html
@@ -69,35 +69,109 @@
 			<li class="fm-item"><span class="fmjs-drag"></span>Third</li>
 		</ul><!-- #not-sortable -->
 
-		<div id="displayif-strings">
-			<div class="fm-wrapper fm-test-displayif-wrapper">
-				<input class="fm-element" name="test-displayif" value="bar" />
-			</div>
-			<div id="di-foo" class="display-if" data-display-src="test-displayif" data-display-value="foo">foo</div>
-			<div id="di-bar" class="display-if" data-display-src="test-displayif" data-display-value="bar">bar</div>
-			<div id="di-foobar" class="display-if" data-display-src="test-displayif" data-display-value="foo,bar">foo,bar</div>
-			<div class="display-always">display</div>
-		</div><!-- #displayif-strings -->
 
-		<div id="displayif-blanks">
-			<div class="fm-wrapper fm-test-displayif-wrapper">
-				<input class="fm-element" name="test-displayif" value="" />
+		<div id="display-if-compare" class="fm-wrapper fm-display_if_test-wrapper" data-fm-array-position="0" >
+			<div class="fm-item fm-display_if_test">
+				<div class="fm-wrapper fm-primary-wrapper" data-fm-array-position="0" >
+					<div class="fm-item fm-primary fm-select">
+						<div class="fm-label fm-label-primary">
+							<label for="fm-display_if_test-0-primary-0">Primary Field</label>
+						</div>
+						<select class="fm-element" name="display_if_test[primary]" id="fm-display_if_test-0-primary-0" size="1">
+							<option value="">&nbsp;</option>
+							<option value="foo" >Foo</option>
+							<option value="bar" >Bar</option>
+							<option value="zap" >Zap</option>
+						</select>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-single-test-equals-wrapper display-if" data-fm-array-position="0" data-display-src="primary" data-display-value="foo" data-display-compare="equals" >
+					<div class="fm-item fm-single-test-equals fm-text">
+						<div class="fm-label fm-label-single-test-equals">
+							<label for="fm-display_if_test-0-single-test-equals-0">Test Equals foo</label>
+						</div>
+						<input
+						class="fm-element"
+						type="text"
+						name="display_if_test[single-test-equals]"
+						id="fm-display_if_test-0-single-test-equals-0"
+						value=""
+						size="50"/>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-single-test-not-equals-wrapper display-if" data-fm-array-position="0" data-display-src="primary" data-display-value="foo" data-display-compare="not-equals" >
+					<div class="fm-item fm-single-test-not-equals fm-text">
+						<div class="fm-label fm-label-single-test-not-equals">
+							<label for="fm-display_if_test-0-single-test-not-equals-0">Test Not Equals foo</label>
+						</div>
+						<input
+						class="fm-element"
+						type="text"
+						name="display_if_test[single-test-not-equals]"
+						id="fm-display_if_test-0-single-test-not-equals-0"
+						value=""
+						size="50"/>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-single-test-contains-wrapper display-if" data-fm-array-position="0" data-display-src="primary" data-display-value="fo" data-display-compare="contains" >
+					<div class="fm-item fm-single-test-contains fm-text">
+						<div class="fm-label fm-label-single-test-contains">
+							<label for="fm-display_if_test-0-single-test-contains-0">Test Contains fo</label>
+						</div>
+						<input
+						class="fm-element"
+						type="text"
+						name="display_if_test[single-test-contains]"
+						id="fm-display_if_test-0-single-test-contains-0"
+						value=""
+						size="50"/>
+					</div>
+				</div>
 			</div>
-			<div id="di-blank" class="display-if" data-display-src="test-displayif" data-display-value="">[blank]</div>
-			<div id="di-notblank" class="display-if" data-display-src="test-displayif" data-display-value="notblank">notblank</div>
-			<div class="display-always">display</div>
-		</div><!-- #displayif-blanks -->
-
-		<!-- Doesn't work: The data attribute is treated as a number, not a string
-		<div id="displayif-numbers">
-			<div class="fm-test-displayif-wrapper">
-				<input class="fm-element" value="789" />
-			</div>
-			<div id="di-123" class="display-if" data-display-src="test-displayif" data-display-value="123">123</div>
-			<div id="di-456" class="display-if" data-display-src="test-displayif" data-display-value="456">456</div>
-			<div id="di-789" class="display-if" data-display-src="test-displayif" data-display-value="789">789</div>
 		</div>
-		-->
+		<!-- /#display-if-compare -->
+
+		<div id="display-if-numeric" class="fm-wrapper fm-display_if_numeric-wrapper" data-fm-array-position="0" >
+			<div class="fm-item fm-display_if_numeric">
+				<div class="fm-wrapper fm-primary-numeric-wrapper" data-fm-array-position="0" >
+					<div class="fm-item fm-primary-numeric fm-text">
+						<div class="fm-label fm-label-primary-numeric"><label for="fm-display_if_numeric-0-primary-numeric-0">Primary Field</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_numeric[primary-numeric]"
+							id="fm-display_if_numeric-0-primary-numeric-0"
+							value="12"
+							size="50"/>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-numeric-test-equals-wrapper display-if" data-fm-array-position="0" data-display-src="primary-numeric" data-display-value="12" data-display-compare="equals" >
+					<div class="fm-item fm-numeric-test-equals fm-text">
+						<div class="fm-label fm-label-numeric-test-equals"><label for="fm-display_if_numeric-0-numeric-test-equals-0">Test Equals 12</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_numeric[numeric-test-equals]"
+							id="fm-display_if_numeric-0-numeric-test-equals-0"
+							value=""
+							size="50"/>
+					</div>
+				</div>
+				<div class="fm-wrapper fm-numeric-test-not-equals-wrapper display-if" data-fm-array-position="0" data-display-src="primary-numeric" data-display-value="12" data-display-compare="not-equals" >
+					<div class="fm-item fm-numeric-test-not-equals fm-text">
+						<div class="fm-label fm-label-numeric-test-not-equals"><label for="fm-display_if_numeric-0-numeric-test-not-equals-0">Test Not Equals 12</label></div>
+						<input
+							class="fm-element"
+							type="text"
+							name="display_if_numeric[numeric-test-not-equals]"
+							id="fm-display_if_numeric-0-numeric-test-not-equals-0"
+							value=""
+							size="50"/>
+					</div>
+				</div>
+			</div>
+		</div>
+		<!-- /#display-if-numeric -->
 
 		<div id="renumbered" class="fm-wrapper" data-fm-array-position="1">
 			<div class="fm-item">

--- a/tests/js/test-fieldmanager.js
+++ b/tests/js/test-fieldmanager.js
@@ -115,6 +115,61 @@
 		assert.equal( $( '.fm-test-repeatable:visible:not(.fmjs-proto)' ).length, 2 );
 	} );
 
+	/**
+	 * test using custom JS events to show/hide fields
+	 */
+	QUnit.test( "Display-if custom events", function( assert ) {
+		// start with all visible
+		assert.equal( $( '.fm-multi-repeatable:visible:not(.fmjs-proto)' ).length, 1 );
+		assert.equal( $( '.fm-multi-single:visible' ).length, 1 );
+		assert.equal( $( '.fm-multi-other:visible' ).length, 1 );
+
+		// hide two of them
+		$( document ).trigger( 'my-custom-event', [ false ] );
+		assert.equal( $( '.fm-multi-repeatable:visible:not(.fmjs-proto)' ).length, 0 );
+		assert.equal( $( '.fm-multi-single:visible' ).length, 0 );
+		assert.equal( $( '.fm-multi-other:visible' ).length, 1 );
+
+		// hide again, should stay hidden
+		$( document ).trigger( 'my-custom-event', [ false ] );
+		assert.equal( $( '.fm-multi-repeatable:visible:not(.fmjs-proto)' ).length, 0 );
+		assert.equal( $( '.fm-multi-single:visible' ).length, 0 );
+		assert.equal( $( '.fm-multi-other:visible' ).length, 1 );
+
+		// show them
+		$( document ).trigger( 'my-custom-event', [ true ] );
+		assert.equal( $( '.fm-multi-repeatable:visible:not(.fmjs-proto)' ).length, 1 );
+		assert.equal( $( '.fm-multi-single:visible' ).length, 1 );
+		assert.equal( $( '.fm-multi-other:visible' ).length, 1 );
+
+		// show again, should stay visible
+		$( document ).trigger( 'my-custom-event', [ true ] );
+		assert.equal( $( '.fm-multi-repeatable:visible:not(.fmjs-proto)' ).length, 1 );
+		assert.equal( $( '.fm-multi-single:visible' ).length, 1 );
+		assert.equal( $( '.fm-multi-other:visible' ).length, 1 );
+
+		// add a repeated field, should be visible
+		$('.fm-multi-repeatable-add-another:first').click();
+		assert.equal( $( '.fm-multi-repeatable:visible:not(.fmjs-proto)' ).length, 2 );
+
+		// hide again
+		$( document ).trigger( 'my-custom-event', [ false ] );
+		assert.equal( $( '.fm-multi-repeatable:visible:not(.fmjs-proto)' ).length, 0 );
+		assert.equal( $( '.fm-multi-single:visible' ).length, 0 );
+		assert.equal( $( '.fm-multi-other:visible' ).length, 1 );
+
+		// hide the other one
+		$( document ).trigger( 'my-other-event', [ false ] );
+		assert.equal( $( '.fm-multi-other:visible' ).length, 0 );
+
+		// show originals again
+		$( document ).trigger( 'my-custom-event', [ true ] );
+		assert.equal( $( '.fm-multi-repeatable:visible:not(.fmjs-proto)' ).length, 2 );
+		assert.equal( $( '.fm-multi-single:visible' ).length, 1 );
+		assert.equal( $( '.fm-multi-other:visible' ).length, 0 );
+
+	} );
+
 	QUnit.test( 'Renumber', function( assert ) {
 		// Reorganize the items in the simple group.
 		var $fieldLast = $( '#renumbered .fm-item' ).last();

--- a/tests/js/test-fieldmanager.js
+++ b/tests/js/test-fieldmanager.js
@@ -31,39 +31,30 @@
 		assert.notOk( $notSortable.sortable( 'instance' ), "Invisible sortable element should not have a sortable() instance" );
 	});
 
-	QUnit.test( "Display-if", function( assert ) {
-		$( '.fm-test-displayif-wrapper .fm-element' ).each(function() {
-			assert.ok( $( this ).hasClass( 'display-trigger' ), "add '.display-trigger' to trigger" );
-		});
+	QUnit.test( "Display-if comparisons for single field", function( assert ) {
+		// start with non-foo value
+		assert.notEqual( $( '#fm-display_if_test-0-primary-0' ).val(), 'foo' );
+		assert.notOk( $( '.fm-single-test-equals-wrapper' ).is( ':visible' ) );
+		assert.ok( $( '.fm-single-test-not-equals-wrapper' ).is( ':visible' ) );
+		assert.notOk( $( '.fm-single-test-contains-wrapper' ).is( ':visible' ) );
 
-		assert.ok( $( '#di-foo' ).not( ':visible' ), "hide display-if value of 'foo'" );
-		assert.ok( $( '#di-bar' ).is( ':visible' ), "show display-if value of 'bar'" );
-		assert.ok( $( '#di-foobar' ).is( ':visible' ), "show display-if value of 'foo,bar'" );
+		// change to foo and expect opposite results
+		$( '#fm-display_if_test-0-primary-0' ).val( 'foo' ).change();
+		assert.ok( $( '.fm-single-test-equals-wrapper' ).is( ':visible' ) );
+		assert.notOk( $( '.fm-single-test-not-equals-wrapper' ).is( ':visible' ) );
+		assert.ok( $( '.fm-single-test-contains-wrapper' ).is( ':visible' ) );
 
-		assert.ok( $( '#di-blank' ).is( ':visible' ), "show display-if value of 'blank'" );
-		assert.ok( $( '#di-notblank' ).not( ':visible' ), "hide display-if value of 'notblank'" );
+	} );
 
-		$( '.display-always' ).each(function() {
-			assert.ok( $( this ).is( ':visible' ), 'non display-if field is visible (parent #' + $( this ).parent().attr( 'id' ) + ')' );
-		});
+	QUnit.test( "Display-if numeric comparisons", function( assert ) {
+		assert.ok( $('#fm-display_if_numeric-0-primary-numeric-0').val() == 12 );
+		assert.ok( $( '.fm-numeric-test-equals-wrapper' ).is( ':visible' ) );
+		assert.notOk( $( '.fm-numeric-test-not-equals-wrapper' ).is( ':visible' ) );
 
-		$( '#displayif-strings .display-trigger' ).attr( 'value', 'foo' ).trigger( 'change' );
-		assert.ok( $( '#di-foo' ).is( ':visible' ), "show display-if value of 'foo' after change" );
-		assert.ok( $( '#di-bar' ).not( ':visible' ), "hide display-if value of 'bar' after change" );
-		assert.ok( $( '#di-foobar' ).is( ':visible' ), "still show display-if value of 'foo,bar'" );
-
-		$( '#displayif-blanks .display-trigger' ).attr( 'value', 'notblank' ).trigger( 'change' );
-		assert.ok( $( '#di-blank' ).not( ':visible' ), "hide display-if value of 'blank' after change" );
-		assert.ok( $( '#di-notblank' ).is( ':visible' ), "show display-if value of 'notblank' after change" );
-
-		$( '.display-always' ).each(function() {
-			assert.ok( $( this ).is( ':visible' ), 'non display-if field is visible after changes (parent #' + $( this ).parent().attr( 'id' ) + ')' );
-		});
-
-		// assert.ok( $( '#di-789' ).is( ':visible' ), "show display-if value of '789'" );
-		// assert.ok( $( '#di-123' ).not( ':visible' ), "hide display-if value of '123'" );
-		// assert.ok( $( '#di-456' ).is( ':visible' ), "hide display-if value of '456'" );
-	});
+		$('#fm-display_if_numeric-0-primary-numeric-0').val( 13 ).change();
+		assert.notOk( $( '.fm-numeric-test-equals-wrapper' ).is( ':visible' ) );
+		assert.ok( $( '.fm-numeric-test-not-equals-wrapper' ).is( ':visible' ) );
+	} );
 
 	QUnit.test( 'Renumber', function( assert ) {
 		// Reorganize the items in the simple group.

--- a/tests/js/test-fieldmanager.js
+++ b/tests/js/test-fieldmanager.js
@@ -31,29 +31,88 @@
 		assert.notOk( $notSortable.sortable( 'instance' ), "Invisible sortable element should not have a sortable() instance" );
 	});
 
+	/**
+	 * test basic string comparisons for equals, not-equals, contains
+	 */
 	QUnit.test( "Display-if comparisons for single field", function( assert ) {
+		$trigger = $( '#fm-display_if_test-0-primary-0' );
 		// start with non-foo value
-		assert.notEqual( $( '#fm-display_if_test-0-primary-0' ).val(), 'foo' );
+		assert.notEqual( $trigger.val(), 'foo' );
 		assert.notOk( $( '.fm-single-test-equals-wrapper' ).is( ':visible' ) );
 		assert.ok( $( '.fm-single-test-not-equals-wrapper' ).is( ':visible' ) );
 		assert.notOk( $( '.fm-single-test-contains-wrapper' ).is( ':visible' ) );
 
 		// change to foo and expect opposite results
-		$( '#fm-display_if_test-0-primary-0' ).val( 'foo' ).change();
+		$trigger.val( 'foo' ).change();
 		assert.ok( $( '.fm-single-test-equals-wrapper' ).is( ':visible' ) );
 		assert.notOk( $( '.fm-single-test-not-equals-wrapper' ).is( ':visible' ) );
 		assert.ok( $( '.fm-single-test-contains-wrapper' ).is( ':visible' ) );
 
 	} );
 
+	/**
+	 * test numeric equals and not-equals
+	 */
 	QUnit.test( "Display-if numeric comparisons", function( assert ) {
-		assert.ok( $('#fm-display_if_numeric-0-primary-numeric-0').val() == 12 );
+		$trigger = $('#fm-display_if_numeric-0-primary-numeric-0');
+		assert.equal( $trigger.val(), 12 );
 		assert.ok( $( '.fm-numeric-test-equals-wrapper' ).is( ':visible' ) );
 		assert.notOk( $( '.fm-numeric-test-not-equals-wrapper' ).is( ':visible' ) );
 
-		$('#fm-display_if_numeric-0-primary-numeric-0').val( 13 ).change();
+		$trigger.val( 13 ).change();
 		assert.notOk( $( '.fm-numeric-test-equals-wrapper' ).is( ':visible' ) );
 		assert.ok( $( '.fm-numeric-test-not-equals-wrapper' ).is( ':visible' ) );
+	} );
+
+	/**
+	 * test equals, not-equals, contains with string and numeric CSV values
+	 */
+	QUnit.test( "Display-if CSV comparisons", function( assert ) {
+		$trigger = $('#fm-display_if_csv-0-primary-csv-0');
+
+		assert.equal( $trigger.val(), 'bar' );
+		assert.ok( $( '.fm-csv-strings-wrapper' ).is(':visible' ) );
+		assert.notOk( $( '.fm-csv-numbers-wrapper' ).is(':visible' ) );
+		assert.notOk( $( '.fm-csv-not-equals-wrapper' ).is(':visible' ) );
+		assert.notOk( $( '.fm-csv-contains-wrapper' ).is(':visible' ) );
+
+		$trigger.val( 12 ).change();
+		assert.notOk( $( '.fm-csv-strings-wrapper' ).is(':visible' ) );
+		assert.ok( $( '.fm-csv-numbers-wrapper' ).is(':visible' ) );
+		assert.ok( $( '.fm-csv-not-equals-wrapper' ).is(':visible' ) );
+		assert.notOk( $( '.fm-csv-contains-wrapper' ).is(':visible' ) );
+
+		$trigger.val( 'foo' ).change();
+		assert.ok( $( '.fm-csv-strings-wrapper' ).is(':visible' ) );
+		assert.notOk( $( '.fm-csv-numbers-wrapper' ).is(':visible' ) );
+		assert.ok( $( '.fm-csv-not-equals-wrapper' ).is(':visible' ) );
+		assert.ok( $( '.fm-csv-contains-wrapper' ).is(':visible' ) );
+	} );
+
+	/**
+	 * test showing/hiding repeatable fields
+	 */
+	QUnit.test( "Display-if for repeatable field", function( assert ) {
+		$trigger = $( '#fm-display_if_repeatable-0-primary-repeatable-0' );
+		assert.equal( $trigger.val(), 'bar' );
+		// start with no visible fields
+		assert.equal( $( '.fm-test-repeatable:visible:not(.fmjs-proto)' ).length, 0 );
+
+		// change to display-if value
+		$trigger.val( 'foo' ).change();
+		assert.equal( $( '.fm-test-repeatable:visible:not(.fmjs-proto)' ).length, 1 );
+
+		// add a field, should be visible
+		$('.fm-test-repeatable-add-another:first').click();
+		assert.equal( $( '.fm-test-repeatable:visible:not(.fmjs-proto)' ).length, 2 );
+
+		// hide fields
+		$trigger.val( 'bar' ).change();
+		assert.equal( $( '.fm-test-repeatable:visible:not(.fmjs-proto)' ).length, 0 );
+
+		// show again
+		$trigger.val( 'foo' ).change();
+		assert.equal( $( '.fm-test-repeatable:visible:not(.fmjs-proto)' ).length, 2 );
 	} );
 
 	QUnit.test( 'Renumber', function( assert ) {

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -1011,6 +1011,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 	 * @group display_if
 	 */
 	public function test_display_if() {
+		// test src, value, and default comparison
 		$field = new Fieldmanager_Textfield( array(
 			'name' => 'display_if_testing',
 			'display_if' => array(
@@ -1021,5 +1022,59 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$html = $this->_get_html_for( $field );
 		$this->assertContains( "data-display-src=\"source_field\"", $html );
 		$this->assertContains( "data-display-value=\"source_value\"", $html );
+		$this->assertContains( "data-display-compare=\"equals\"", $html );
+
+		// test compare -> equals
+		$field = new Fieldmanager_Textfield( array(
+			'name' => 'display_if_testing',
+			'display_if' => array(
+				'src' => 'source_field',
+				'value' => 'source_value',
+				'compare' => 'equals',
+			),
+		) );
+		$html = $this->_get_html_for( $field );
+		$this->assertContains( "data-display-compare=\"equals\"", $html );
+
+		// test compare -> not-equals
+		$field = new Fieldmanager_Textfield( array(
+			'name' => 'display_if_testing',
+			'display_if' => array(
+				'src' => 'source_field',
+				'value' => 'source_value',
+				'compare' => 'not-equals',
+			),
+		) );
+		$html = $this->_get_html_for( $field );
+		$this->assertContains( "data-display-compare=\"not-equals\"", $html );
+
+		// test compare -> contains
+		$field = new Fieldmanager_Textfield( array(
+			'name' => 'display_if_testing',
+			'display_if' => array(
+				'src' => 'source_field',
+				'value' => 'source_value',
+				'compare' => 'contains',
+			),
+		) );
+		$html = $this->_get_html_for( $field );
+		$this->assertContains( "data-display-compare=\"contains\"", $html );
 	}
+
+	/**
+	 * @group display_if
+	 * @expectedException FM_Developer_Exception
+	 */
+	public function test_display_if_invalid_compare() {
+		$field = new Fieldmanager_Textfield( array(
+			'name' => 'display_if_testing',
+			'display_if' => array(
+				'src' => 'source_field',
+				'value' => 'source_value',
+				'compare' => 'equality',
+			),
+		) );
+		$markup = $field->element_markup();
+	}
+
 }

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -1006,4 +1006,20 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertContains( "value=\"{$to_save[1]}\"", $html );
 		$this->assertContains( "value=\"{$to_save[2]}\"", $html );
 	}
+
+	/**
+	 * @group display_if
+	 */
+	public function test_display_if() {
+		$field = new Fieldmanager_Textfield( array(
+			'name' => 'display_if_testing',
+			'display_if' => array(
+				'src' => 'source_field',
+				'value' => 'source_value',
+			),
+		) );
+		$html = $this->_get_html_for( $field );
+		$this->assertContains( "data-display-src=\"source_field\"", $html );
+		$this->assertContains( "data-display-value=\"source_value\"", $html );
+	}
 }

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -1010,7 +1010,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 	/**
 	 * @group display_if
 	 */
-	public function test_display_if() {
+	public function test_display_if_valid_field_compare() {
 		// test src, value, and default comparison
 		$field = new Fieldmanager_Textfield( array(
 			'name' => 'display_if_testing',
@@ -1023,6 +1023,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertContains( "data-display-src=\"source_field\"", $html );
 		$this->assertContains( "data-display-value=\"source_value\"", $html );
 		$this->assertContains( "data-display-compare=\"equals\"", $html );
+		$this->assertRegExp( '/class=\"(?:.* )?display-if(?: .*)?\"/', $html );
 
 		// test compare -> equals
 		$field = new Fieldmanager_Textfield( array(
@@ -1063,15 +1064,68 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 
 	/**
 	 * @group display_if
-	 * @expectedException FM_Developer_Exception
 	 */
-	public function test_display_if_invalid_compare() {
+	public function test_display_if_conditional_callback() {
+		// test compare -> contains
+		$field = new Fieldmanager_Textfield( array(
+			'name' => 'display_if_testing',
+			'display_if' => array(
+				'event' => 'my_special_event',
+				'callback' => 'my_conditional_callback',
+			),
+		) );
+		$html = $this->_get_html_for( $field );
+		$this->assertContains( "data-display-event=\"my_special_event\"", $html );
+		$this->assertContains( "data-display-callback=\"my_conditional_callback\"", $html );
+		$this->assertRegExp( '/class=\"(?:.* )?display-conditional-callback(?: .*)?\"/', $html );
+	}
+
+	/**
+	 * @group display_if
+	 * @expectedException FM_Developer_Exception
+     * @expectedExceptionMessage Invalid `display_if` comparison type
+	 */
+	public function test_display_if_invalid_field_compare() {
 		$field = new Fieldmanager_Textfield( array(
 			'name' => 'display_if_testing',
 			'display_if' => array(
 				'src' => 'source_field',
 				'value' => 'source_value',
-				'compare' => 'equality',
+				'compare' => 'not_an_allowed_comparison',
+			),
+		) );
+		$markup = $field->element_markup();
+	}
+
+	/**
+	 * @group display_if
+	 * @expectedException FM_Developer_Exception
+     * @expectedExceptionMessage Invalid `display_if` arguments
+	 */
+	public function test_display_if_invalid_args() {
+		// need to use src and value, or event and callback
+		$field = new Fieldmanager_Textfield( array(
+			'name' => 'display_if_testing',
+			'display_if' => array(
+				'src' => 'source_field',
+				'callback' => 'my_conditional_callback',
+			),
+		) );
+		$markup = $field->element_markup();
+	}
+
+	/**
+	 * @group display_if
+	 * @expectedException FM_Developer_Exception
+     * @expectedExceptionMessage Invalid `display_if` arguments
+	 */
+	public function test_display_if_empty_required_arg() {
+		// need to use src and value, or event and callback
+		$field = new Fieldmanager_Textfield( array(
+			'name' => 'display_if_testing',
+			'display_if' => array(
+				'src' => 'source_field',
+				'callback' => '',
 			),
 		) );
 		$markup = $field->element_markup();

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -1071,12 +1071,10 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 			'name' => 'display_if_testing',
 			'display_if' => array(
 				'event' => 'my_special_event',
-				'callback' => 'my_conditional_callback',
 			),
 		) );
 		$html = $this->_get_html_for( $field );
 		$this->assertContains( "data-display-event=\"my_special_event\"", $html );
-		$this->assertContains( "data-display-callback=\"my_conditional_callback\"", $html );
 		$this->assertRegExp( '/class=\"(?:.* )?display-conditional-callback(?: .*)?\"/', $html );
 	}
 
@@ -1103,12 +1101,12 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
      * @expectedExceptionMessage Invalid `display_if` arguments
 	 */
 	public function test_display_if_invalid_args() {
-		// need to use src and value, or event and callback
+		// if src is used, value must also be used
 		$field = new Fieldmanager_Textfield( array(
 			'name' => 'display_if_testing',
 			'display_if' => array(
 				'src' => 'source_field',
-				'callback' => 'my_conditional_callback',
+				'event' => 'my_conditional_callback',
 			),
 		) );
 		$markup = $field->element_markup();
@@ -1120,12 +1118,12 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
      * @expectedExceptionMessage Invalid `display_if` arguments
 	 */
 	public function test_display_if_empty_required_arg() {
-		// need to use src and value, or event and callback
+		// src and value must both be not empty
 		$field = new Fieldmanager_Textfield( array(
 			'name' => 'display_if_testing',
 			'display_if' => array(
 				'src' => 'source_field',
-				'callback' => '',
+				'value' => '',
 			),
 		) );
 		$markup = $field->element_markup();

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -1016,12 +1016,12 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 			'name' => 'display_if_testing',
 			'display_if' => array(
 				'src' => 'source_field',
-				'value' => 'source_value',
+				'value' => 'source_value,other_value',
 			),
 		) );
 		$html = $this->_get_html_for( $field );
 		$this->assertContains( "data-display-src=\"source_field\"", $html );
-		$this->assertContains( "data-display-value=\"source_value\"", $html );
+		$this->assertContains( "data-display-value=\"source_value,other_value\"", $html );
 		$this->assertContains( "data-display-compare=\"equals\"", $html );
 		$this->assertRegExp( '/class=\"(?:.* )?display-if(?: .*)?\"/', $html );
 


### PR DESCRIPTION
Allows you to specify a comparison type for a display-if field, like:
```
new Fieldmanager_Field( array(
    'display_if' => array(
        'src' => 'display-if-src-element',
        'value' => 'display-if-src-value',
        'compare' => 'equals',
    )
);
```
The allowed comparisons are `equals` (the default), `not-equals`, `contains`. Note that `equals` and `not-equals` use non-strict equality, and `contains` is a basic string comparison using `String.prototype.indexOf()`

You can also toggle field by triggering a custom event from external Javascript. You set up the field like:
```
new Fieldmanager_Field( array(
    'display_if' => array(
        'event' => 'my_special_event',
    )
);
```
Then toggle the fields using:
```
$( document ).trigger( 'my_special_event', [ showField ] );
```
Where `showField` is `true` if fields are to be shown and `false` if to be hidden

Doesn't address any of [these issues](https://github.com/alleyinteractive/wordpress-fieldmanager/labels/display-if) specifically, although some might be solvable using custom events. Also, fixes some issues with numeric values.