### PR TITLE
Fix unit tests for multi tool labels

### DIFF
--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -488,7 +488,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		// minimum count of 5
 		$field->minimum_count = 5;
 		$html = $this->_get_html_for( $field );
-		$this->assertEquals( 6, substr_count( $html, '<a href="#" class="fmjs-remove" title="Remove">Remove</a>' ) );
+		$this->assertEquals( 6, substr_count( $html, '<a href="#" class="fmjs-remove" title="Remove"><span class="screen-reader-text">Remove</span></a>' ) );
 		$this->assertEquals( 6, substr_count( $html, 'fmjs-drag-icon' ) );
 	}
 
@@ -555,7 +555,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		// minimum count of 5
 		$field->minimum_count = 5;
 		$html = $this->_get_html_for( $field );
-		$this->assertEquals( 6, substr_count( $html, '<a href="#" class="fmjs-remove" title="Remove">Remove</a>' ) );
+		$this->assertEquals( 6, substr_count( $html, '<a href="#" class="fmjs-remove" title="Remove"><span class="screen-reader-text">Remove</span></a>' ) );
 		$this->assertEquals( 6, substr_count( $html, 'fmjs-drag-icon' ) );
 	}
 
@@ -603,7 +603,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		// minimum count of 5
 		$field->minimum_count = 5;
 		$html = $this->_get_html_for( $field );
-		$this->assertEquals( 6, substr_count( $html, '<a href="#" class="fmjs-remove" title="Remove">Remove</a>' ) );
+		$this->assertEquals( 6, substr_count( $html, '<a href="#" class="fmjs-remove" title="Remove"><span class="screen-reader-text">Remove</span></a>' ) );
 		$this->assertEquals( 6, substr_count( $html, 'fmjs-drag-icon' ) );
 	}
 
@@ -656,7 +656,7 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		// minimum count of 5
 		$field->minimum_count = 5;
 		$html = $this->_get_html_for( $field );
-		$this->assertEquals( 6, substr_count( $html, '<a href="#" class="fmjs-remove" title="Remove">Remove</a>' ) );
+		$this->assertEquals( 6, substr_count( $html, '<a href="#" class="fmjs-remove" title="Remove"><span class="screen-reader-text">Remove</span></a>' ) );
 		$this->assertEquals( 6, substr_count( $html, 'fmjs-drag-icon' ) );
 	}
 


### PR DESCRIPTION
These broke in #419, but the bug in #421 prevented Travis from reporting it.

Note that Travis will still fail on the latest nightly builds of core, due to a recent core update surrounding richtextareas.