### PR TITLE
collapsible fields caret

### DIFF
--- a/css/fieldmanager.css
+++ b/css/fieldmanager.css
@@ -88,7 +88,7 @@
 	content: "\f140";
 }
 
-.fmjs-collapsible-handle .toggle-indicator {
+.fmjs-collapsible-handle .field-group-toggler {
 	float: right;
 }
 

--- a/css/fieldmanager.css
+++ b/css/fieldmanager.css
@@ -84,7 +84,7 @@
 	vertical-align: middle;
 }
 
-.fm-item .fmjs-collapsible-handle.closed .toggle-indicator:before {
+.fm-item .field-group-toggler.closed .toggle-indicator:before {
 	content: "\f140";
 }
 

--- a/css/fieldmanager.css
+++ b/css/fieldmanager.css
@@ -71,21 +71,34 @@
 	display: block;
 }
 
-.fm-group-label-wrapper.fmjs-collapsible-handle:hover .toggle-indicator {
+.fm-group-label-wrapper.fmjs-collapsible-handle:hover .field-group-toggler {
 	color: #777;
 }
 
-.fm-group .toggle-indicator {
-	color: #a0a5aa;
+.field-group-toggler {
+	display: block;
+	width: 21px;
+	height: 21px;
 	margin-left: 5px;
+	text-align: center;
+	color: #a0a5aa;
+	outline: 0;
+	outline: 0;
 }
 
-.fm-group .toggle-indicator:before {
+.field-group-toggler:before {
+	font-family: dashicons;
+	font-size: 15px;
+	line-height: 1;
+	display: inline-block;
+	content: '\f143';
 	vertical-align: middle;
+	border-radius: 50%;
+	speak: none;
 }
 
-.fm-item .field-group-toggler.closed .toggle-indicator:before {
-	content: "\f140";
+.field-group-toggler.closed:before {
+	content: '\f140';
 }
 
 .fmjs-collapsible-handle .field-group-toggler {

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -157,7 +157,8 @@ $( document ).ready( function () {
 	} );
 
 	// Handle collapse events
-	$( document ).on( 'click', '.fmjs-collapsible-handle', function() {
+	$( document ).on( 'click', '.field-group-toggler', function( e ) {
+		e.preventDefault();
 		$( this ).parents( '.fm-group' ).first().children( '.fm-group-inner' ).slideToggle( 'fast' );
 		fm_renumber( $( this ).parents( '.fm-wrapper' ).first() );
 		$( this ).parents( '.fm-group' ).first().trigger( 'fm_collapsible_toggle' );

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -939,7 +939,7 @@ abstract class Fieldmanager_Field {
 	 * @return string
 	 */
 	public function get_collapse_handle() {
-		return  sprintf( '<a href="#" class="field-group-toggler" title="%1$s"><span class="screen-reader-text">%1$s</span><span class="toggle-indicator" aria-hidden="true"></span></a>', esc_attr__( 'Toggle field group', 'fieldmanager' ) );
+		return  sprintf( '<a href="#" class="field-group-toggler" title="%1$s"><span class="screen-reader-text">%1$s</span></a>', esc_attr__( 'Toggle field group', 'fieldmanager' ) );
 	}
 
 	/**

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -939,7 +939,7 @@ abstract class Fieldmanager_Field {
 	 * @return string
 	 */
 	public function get_collapse_handle() {
-		return '<span class="toggle-indicator" aria-hidden="true"></span>';
+		return  sprintf( '<a href="#" class="field-group-toggler"><span class="screen-reader-text">%1$s</span><span class="toggle-indicator" aria-hidden="true"></span></a>', esc_attr__( 'Toggle field group', 'fieldmanager' ) );
 	}
 
 	/**

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -939,7 +939,7 @@ abstract class Fieldmanager_Field {
 	 * @return string
 	 */
 	public function get_collapse_handle() {
-		return  sprintf( '<a href="#" class="field-group-toggler"><span class="screen-reader-text">%1$s</span><span class="toggle-indicator" aria-hidden="true"></span></a>', esc_attr__( 'Toggle field group', 'fieldmanager' ) );
+		return  sprintf( '<a href="#" class="field-group-toggler" title="%1$s"><span class="screen-reader-text">%1$s</span><span class="toggle-indicator" aria-hidden="true"></span></a>', esc_attr__( 'Toggle field group', 'fieldmanager' ) );
 	}
 
 	/**


### PR DESCRIPTION
This PR moves the collapsible field handler to an `<a>` button with accessibility in mind. One major difference here is that the toggle is not fired when the user clicks on the `fm-group-label-wrapper` but rather is toggled when clicked on the caret on the right side of the wrapper. This behavior mimics the default meta box behavior and adds `aria` attributes for accessibility. 