### PR TITLE
Autocomplete highlight search character sequence in drop-down results

### DIFF
--- a/css/fieldmanager.css
+++ b/css/fieldmanager.css
@@ -370,3 +370,9 @@ a.fm-delete:hover {
 .form-field .fm-checkbox label {
 	display: inline;
 }
+
+/* Autocomplete */
+.fm-autocomplete-highlight {
+	font-weight: bold;
+	color: #cc0000;
+}

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -68,12 +68,44 @@ fm.autocomplete = {
 					} );
 				}
 
+				// Set autocomplete highligth
+				if ( typeof $el.data( 'autocomplete-highlight' ) !== 'undefined' ) {
+					ac_params.highlight = true;
+				}
 				$( this ).autocomplete( ac_params );
 				$( this ).addClass( 'fm-autocomplete-enabled' );
 			}
 		} );
 	}
 }
+
+$( document ).ready( function() {
+
+	// Highlighted autocomplete instance
+	$.widget( "fm.autocomplete", $.ui.autocomplete, {
+
+		// Default options
+		options: {
+			// Enable highlighting
+			highlight: false,
+			// Which class get's applied to the matched text
+			highlightClass: "fm-autocomplete-highlight"
+		},
+
+		_renderItem: function( ul, item ) {
+
+			// Wrap the matched text with a span
+			if ( this.options.highlight === true ) {
+				return $( "<li>" )
+					.append( item.label.replace( new RegExp( "(" + this.term + ")", "gi" ), "<span class='" + this.options.highlightClass + "'>$1</span>" ) )
+					.appendTo( ul );
+			}
+
+			// Return parent method (no highlight)
+			return this._super(ul, item);
+		}
+	});
+});
 
 $( document ).ready( fm.autocomplete.enable_autocomplete );
 $( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.autocomplete.enable_autocomplete );

--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -46,6 +46,12 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 	public $save_empty = False;
 
 	/**
+	 * @var boolean
+	 * Highlight menu items with current entered term
+	 */
+	public $highlight = True;
+
+	/**
 	 * Add libraries for autocomplete
 	 * @param string $label
 	 * @param array $options
@@ -99,6 +105,10 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 
 		if ( $this->exact_match ) {
 			$this->attributes['data-exact-match'] = True;
+		}
+
+		if ( $this->highlight ) {
+			$this->attributes['data-autocomplete-highlight'] = True;
 		}
 
 		if ( $this->datasource->use_ajax ) {


### PR DESCRIPTION
This patch allows to highlight the search character sequence in drop-down results in autocomplete fields. For example, if I have an item: "foo bar baz" it and I search for "ba" I'll see "foo **ba**r **ba**z" in drop down.

The patch extends jQuery UI autocompleter widget through the widget factory pattern.
In order to do the highlight, a `span` with `fm-autocomplete-highlight` class is wrapped around the sequence.

The highlight can be turned on/off with `highlight` constructor option (default to `true`), i.e.:

```php
$fm = new Fieldmanager_Autocomplete( array(
    'highlight' => true,
    'name' => 'size',
    'datasource'  => new Fieldmanager_Datasource( array(
        'options' => array( 'Small', 'Medium', 'Large' ),
    ) )
) );
```

Feel free to change CSS class name, styles and option name I used.

PS: I searched over the repository and it seems that a similar functionality or pull request doesn't yet exists. 
Actually, there is a component that does a similar thing (_docs-src/templates/bootstrap/js/jquery.autocomplete.js_) but it seems that is related only to the documentation part. 
