### PR TITLE
Recognize term.php as context for "term"

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -355,7 +355,7 @@ function fm_calculate_context() {
 				break;
 			// Context = "term".
 			case 'edit-tags.php':
-            case 'term.php':
+			case 'term.php':
 				if ( !empty( $_POST['taxonomy'] ) ) {
 					$calculated_context = array( 'term', sanitize_text_field( $_POST['taxonomy'] ) );
 				} elseif ( !empty( $_GET['taxonomy'] ) ) {

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -355,7 +355,7 @@ function fm_calculate_context() {
 				break;
 			// Context = "term".
 			case 'edit-tags.php':
-			case 'term.php':
+			case 'term.php': // As of 4.5-alpha; see https://core.trac.wordpress.org/changeset/36308
 				if ( !empty( $_POST['taxonomy'] ) ) {
 					$calculated_context = array( 'term', sanitize_text_field( $_POST['taxonomy'] ) );
 				} elseif ( !empty( $_GET['taxonomy'] ) ) {

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -355,6 +355,7 @@ function fm_calculate_context() {
 				break;
 			// Context = "term".
 			case 'edit-tags.php':
+            case 'term.php':
 				if ( !empty( $_POST['taxonomy'] ) ) {
 					$calculated_context = array( 'term', sanitize_text_field( $_POST['taxonomy'] ) );
 				} elseif ( !empty( $_GET['taxonomy'] ) ) {


### PR DESCRIPTION
Since https://core.trac.wordpress.org/changeset/36308, the link for editing a term is `term.php`, not `edit-tags.php?action=edit`. This looks for that screen context when calculating Fieldmanager context values.

Fixes #433.