### PR TITLE
Pass `$append = true` after first save when datasource repeats

### DIFF
--- a/php/context/class-fieldmanager-context-storable.php
+++ b/php/context/class-fieldmanager-context-storable.php
@@ -54,8 +54,8 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 			$this->save_walk_children( $this->fm, $data, $this->fm->data_id );
 		}
 		if ( ! empty( $this->taxonomies_to_save ) ) {
-			foreach( $this->taxonomies_to_save as $taxonomy => $term_ids ) {
-				wp_set_object_terms( $this->fm->data_id, $term_ids, $taxonomy );
+			foreach( $this->taxonomies_to_save as $taxonomy => $data ) {
+				wp_set_object_terms( $this->fm->data_id, $data['term_ids'], $taxonomy, $data['append'] );
 			}
 			$this->taxonomies_to_save = array();
 		}

--- a/php/context/class-fieldmanager-context-storable.php
+++ b/php/context/class-fieldmanager-context-storable.php
@@ -10,6 +10,11 @@
 abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 
 	/**
+	 * @var array
+	 */
+	public $taxonomies_to_save = array();
+
+	/**
 	 * Render the field.
 	 *
 	 * @param array $args {
@@ -39,6 +44,7 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 		// Reset the save keys in the event this context instance is saved twice
 		$this->save_keys = array();
 
+		$this->fm->current_context = $this;
 		if ( $this->fm->serialize_data ) {
 			$this->save_field( $this->fm, $data, $this->fm->data_id );
 		} else {
@@ -46,6 +52,12 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 				$data = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : '';
 			}
 			$this->save_walk_children( $this->fm, $data, $this->fm->data_id );
+		}
+		if ( ! empty( $this->taxonomies_to_save ) ) {
+			foreach( $this->taxonomies_to_save as $taxonomy => $term_ids ) {
+				$this->update_term_relationships( $this->fm->data_id, $term_ids, $taxonomy );
+			}
+			$this->taxonomies_to_save = array();
 		}
 	}
 
@@ -205,4 +217,12 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 	 *                  @see delete_post_meta().
 	 */
 	abstract protected function delete_data( $data_id, $data_key, $data_value = '' );
+
+	/**
+	 * Method to update the term relations for the context
+	 */
+	protected function update_term_relationships( $data_id, $term_ids, $taxonomy ) {
+		wp_set_object_terms( $data_id, $term_ids, $taxonomy );
+	}
+
 }

--- a/php/context/class-fieldmanager-context-storable.php
+++ b/php/context/class-fieldmanager-context-storable.php
@@ -55,7 +55,7 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 		}
 		if ( ! empty( $this->taxonomies_to_save ) ) {
 			foreach( $this->taxonomies_to_save as $taxonomy => $term_ids ) {
-				$this->update_term_relationships( $this->fm->data_id, $term_ids, $taxonomy );
+				wp_set_object_terms( $this->fm->data_id, $term_ids, $taxonomy );
 			}
 			$this->taxonomies_to_save = array();
 		}
@@ -217,12 +217,5 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 	 *                  @see delete_post_meta().
 	 */
 	abstract protected function delete_data( $data_id, $data_key, $data_value = '' );
-
-	/**
-	 * Method to update the term relations for the context
-	 */
-	protected function update_term_relationships( $data_id, $term_ids, $taxonomy ) {
-		wp_set_object_terms( $data_id, $term_ids, $taxonomy );
-	}
 
 }

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -221,22 +221,25 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 		$tax_values = array_unique( $tax_values );
 		$taxonomies = $this->get_taxonomies();
 
+		$tree = $field->get_form_tree();
+		$oldest_parent = array_shift( $tree );
+
 		// Store the each term for this post. Handle grouped fields differently since multiple taxonomies are present.
 		if ( count( $taxonomies ) > 1 ) {
 			// Build the taxonomy insert data
 			$taxonomies_to_save = array();
 			foreach ( $tax_values as $term_id ) {
 				$term = $this->get_term( $term_id );
-				if ( empty( $field->current_context->taxonomies_to_save[ $term->taxonomy ] ) ) {
-					$field->current_context->taxonomies_to_save[ $term->taxonomy ] = array();
+				if ( empty( $oldest_parent->current_context->taxonomies_to_save[ $term->taxonomy ] ) ) {
+					$oldest_parent->current_context->taxonomies_to_save[ $term->taxonomy ] = array();
 				}
-				$field->current_context->taxonomies_to_save[ $term->taxonomy ][] = $term_id;
+				$oldest_parent->current_context->taxonomies_to_save[ $term->taxonomy ][] = $term_id;
 			}
 		} else {
-			if ( ! isset( $field->current_context->taxonomies_to_save[ $taxonomies[0] ] ) ) {
-				$field->current_context->taxonomies_to_save[ $taxonomies[0] ] = array();
+			if ( ! isset( $oldest_parent->current_context->taxonomies_to_save[ $taxonomies[0] ] ) ) {
+				$oldest_parent->current_context->taxonomies_to_save[ $taxonomies[0] ] = array();
 			}
-			$field->current_context->taxonomies_to_save[ $taxonomies[0] ] = array_merge( $field->current_context->taxonomies_to_save[ $taxonomies[0] ], $tax_values );
+			$oldest_parent->current_context->taxonomies_to_save[ $taxonomies[0] ] = array_merge( $oldest_parent->current_context->taxonomies_to_save[ $taxonomies[0] ], $tax_values );
 		}
 	}
 

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -224,22 +224,28 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 		$tree = $field->get_form_tree();
 		$oldest_parent = array_shift( $tree );
 
+		foreach( $taxonomies as $taxonomy ) {
+			if ( ! isset( $oldest_parent->current_context->taxonomies_to_save[ $taxonomy ] ) ) {
+				$oldest_parent->current_context->taxonomies_to_save[ $taxonomy ] = array(
+					'term_ids' => array(),
+					'append'   => $this->append_taxonomy,
+				);
+			} else {
+				// Append any means append all
+				$oldest_parent->current_context->taxonomies_to_save[ $taxonomy ]['append'] = $oldest_parent->current_context->taxonomies_to_save[ $taxonomy ]['append'] && $this->append_taxonomy;
+			}
+		}
+
 		// Store the each term for this post. Handle grouped fields differently since multiple taxonomies are present.
 		if ( count( $taxonomies ) > 1 ) {
 			// Build the taxonomy insert data
 			$taxonomies_to_save = array();
 			foreach ( $tax_values as $term_id ) {
 				$term = $this->get_term( $term_id );
-				if ( empty( $oldest_parent->current_context->taxonomies_to_save[ $term->taxonomy ] ) ) {
-					$oldest_parent->current_context->taxonomies_to_save[ $term->taxonomy ] = array();
-				}
-				$oldest_parent->current_context->taxonomies_to_save[ $term->taxonomy ][] = $term_id;
+				$oldest_parent->current_context->taxonomies_to_save[ $term->taxonomy ]['term_ids'][] = $term_id;
 			}
 		} else {
-			if ( ! isset( $oldest_parent->current_context->taxonomies_to_save[ $taxonomies[0] ] ) ) {
-				$oldest_parent->current_context->taxonomies_to_save[ $taxonomies[0] ] = array();
-			}
-			$oldest_parent->current_context->taxonomies_to_save[ $taxonomies[0] ] = array_merge( $oldest_parent->current_context->taxonomies_to_save[ $taxonomies[0] ], $tax_values );
+			$oldest_parent->current_context->taxonomies_to_save[ $taxonomies[0] ]['term_ids'] = array_merge( $oldest_parent->current_context->taxonomies_to_save[ $taxonomies[0] ]['term_ids'], $tax_values );
 		}
 	}
 

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -40,12 +40,6 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	public $append_taxonomy = False;
 
 	/**
-	 * @var boolean
-	 * When datasource is a part of a repeatable group, pass $append = true to wp_set_object_terms after the first group is saved.
-	 */
-	public $append_after_first_save = true;
-
-	/**
 	 * @var string
 	 * If true, additionally save taxonomy terms to WP's terms tables.
 	 */
@@ -223,14 +217,6 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	 */
 	public function save_taxonomy( $tax_values, $data_id ) {
 
-		static $saved_once;
-		$append_taxonomy = $this->append_taxonomy;
-		if ( ! empty( $saved_once ) && $this->append_after_first_save ) {
-			$append_taxonomy = true;
-		} else {
-			$saved_once = true;
-		}
-
 		$tax_values = array_map( 'intval', $tax_values );
 		$tax_values = array_unique( $tax_values );
 		$taxonomies = $this->get_taxonomies();
@@ -245,10 +231,10 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 				$taxonomies_to_save[ $term->taxonomy ][] = $term_id;
 			}
 			foreach ( $taxonomies_to_save as $taxonomy => $terms ) {
-				wp_set_object_terms( $data_id, $terms, $taxonomy, $append_taxonomy );
+				wp_set_object_terms( $data_id, $terms, $taxonomy, $this->append_taxonomy );
 			}
 		} else {
-			wp_set_object_terms( $data_id, $tax_values, $taxonomies[0], $append_taxonomy );
+			wp_set_object_terms( $data_id, $tax_values, $taxonomies[0], $this->append_taxonomy );
 		}
 	}
 

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -192,11 +192,11 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 						$tax_values = $value;
 				}
 			}
-			$this->save_taxonomy( $tax_values, $field->data_id );
+			$this->pre_save_taxonomy( $tax_values, $field );
 		}
 		if ( $this->only_save_to_taxonomy ) {
 			if ( empty( $values ) && ! ( $this->append_taxonomy ) ) {
-				$this->save_taxonomy( array(), $field->data_id );
+				$this->pre_save_taxonomy( array(), $field );
 			}
 			return array();
 		}
@@ -215,7 +215,7 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	 * @param mixed[] $tax_values
 	 * @return void
 	 */
-	public function save_taxonomy( $tax_values, $data_id ) {
+	public function pre_save_taxonomy( $tax_values, $field ) {
 
 		$tax_values = array_map( 'intval', $tax_values );
 		$tax_values = array_unique( $tax_values );
@@ -227,14 +227,16 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 			$taxonomies_to_save = array();
 			foreach ( $tax_values as $term_id ) {
 				$term = $this->get_term( $term_id );
-				if ( empty( $taxonomies_to_save[ $term->taxonomy ] ) ) $taxonomies_to_save[ $term->taxonomy ] = array();
-				$taxonomies_to_save[ $term->taxonomy ][] = $term_id;
-			}
-			foreach ( $taxonomies_to_save as $taxonomy => $terms ) {
-				wp_set_object_terms( $data_id, $terms, $taxonomy, $this->append_taxonomy );
+				if ( empty( $field->current_context->taxonomies_to_save[ $term->taxonomy ] ) ) {
+					$field->current_context->taxonomies_to_save[ $term->taxonomy ] = array();
+				}
+				$field->current_context->taxonomies_to_save[ $term->taxonomy ][] = $term_id;
 			}
 		} else {
-			wp_set_object_terms( $data_id, $tax_values, $taxonomies[0], $this->append_taxonomy );
+			if ( ! isset( $field->current_context->taxonomies_to_save[ $taxonomies[0] ] ) ) {
+				$field->current_context->taxonomies_to_save[ $taxonomies[0] ] = array();
+			}
+			$field->current_context->taxonomies_to_save[ $taxonomies[0] ] = array_merge( $field->current_context->taxonomies_to_save[ $taxonomies[0] ], $tax_values );
 		}
 	}
 

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -40,6 +40,12 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	public $append_taxonomy = False;
 
 	/**
+	 * @var boolean
+	 * When datasource is a part of a repeatable group, pass $append = true to wp_set_object_terms after the first group is saved.
+	 */
+	public $append_after_first_save = true;
+
+	/**
 	 * @var string
 	 * If true, additionally save taxonomy terms to WP's terms tables.
 	 */
@@ -217,6 +223,14 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	 */
 	public function save_taxonomy( $tax_values, $data_id ) {
 
+		static $saved_once;
+		$append_taxonomy = $this->append_taxonomy;
+		if ( ! empty( $saved_once ) && $this->append_after_first_save ) {
+			$append_taxonomy = true;
+		} else {
+			$saved_once = true;
+		}
+
 		$tax_values = array_map( 'intval', $tax_values );
 		$tax_values = array_unique( $tax_values );
 		$taxonomies = $this->get_taxonomies();
@@ -231,10 +245,10 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 				$taxonomies_to_save[ $term->taxonomy ][] = $term_id;
 			}
 			foreach ( $taxonomies_to_save as $taxonomy => $terms ) {
-				wp_set_object_terms( $data_id, $terms, $taxonomy, $this->append_taxonomy );
+				wp_set_object_terms( $data_id, $terms, $taxonomy, $append_taxonomy );
 			}
 		} else {
-			wp_set_object_terms( $data_id, $tax_values, $taxonomies[0], $this->append_taxonomy );
+			wp_set_object_terms( $data_id, $tax_values, $taxonomies[0], $append_taxonomy );
 		}
 	}
 

--- a/tests/php/test-fieldmanager-datasource-term.php
+++ b/tests/php/test-fieldmanager-datasource-term.php
@@ -382,38 +382,4 @@ class Test_Fieldmanager_Datasource_Term extends WP_UnitTestCase {
 		);
 	}
 
-	public function test_disable_append_true_after_first_save() {
-		$fm = new Fieldmanager_Group( array(
-			'name'     => 'author_data',
-			'children' => array(
-				'school' => new Fieldmanager_Group(array(
-					'label' => 'School',
-					'add_more_label' => 'Add new',
-					'limit' => 0,
-					'children' => array(
-						'school_city' => new Fieldmanager_Autocomplete( array(
-							'label' => 'School city',
-							'datasource' => new Fieldmanager_Datasource_Term( array(
-								'taxonomy' => 'post_tag',
-								'taxonomy_save_to_terms' => true,
-								'append_after_first_save' => false,
-							))
-						)),
-					)
-				))
-			)
-		) );
-		$data = array(
-			'school' => array(
-				array( 'school_city' => $this->term->term_id ),
-				array( 'school_city' => $this->term_2->term_id ),
-			),
-		);
-		$fm->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post->ID, $data );
-		$this->assertEquals(
-			array( $this->term_2->term_id ),
-			wp_get_post_terms( $this->post->ID, $this->term->taxonomy, array( 'fields' => 'ids' ) )
-		);
-	}
-
 }

--- a/tests/php/test-fieldmanager-datasource-term.php
+++ b/tests/php/test-fieldmanager-datasource-term.php
@@ -348,4 +348,38 @@ class Test_Fieldmanager_Datasource_Term extends WP_UnitTestCase {
 		$this->assertTrue( $wp_taxonomies['category']->sort );
 		$this->assertTrue( $wp_taxonomies['post_tag']->sort );
 	}
+
+	public function test_append_true_after_first_save() {
+		$fm = new Fieldmanager_Group( array(
+			'name'     => 'author_data',
+			'children' => array(
+				'school' => new Fieldmanager_Group(array(
+					'label' => 'School',
+					'add_more_label' => 'Add new',
+					'limit' => 0,
+					'children' => array(
+						'school_city' => new Fieldmanager_Autocomplete( array(
+							'label' => 'School city',
+							'datasource' => new Fieldmanager_Datasource_Term( array(
+								'taxonomy' => 'post_tag',
+								'taxonomy_save_to_terms' => true
+							))
+						)),
+					)
+				))
+			)
+		) );
+		$data = array(
+			'school' => array(
+				array( 'school_city' => $this->term->term_id ),
+				array( 'school_city' => $this->term_2->term_id ),
+			),
+		);
+		$fm->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post->ID, $data );
+		$this->assertEqualSets(
+			array( $this->term->term_id, $this->term_2->term_id ),
+			wp_get_post_terms( $this->post->ID, $this->term->taxonomy, array( 'fields' => 'ids' ) )
+		);
+	}
+
 }

--- a/tests/php/test-fieldmanager-datasource-term.php
+++ b/tests/php/test-fieldmanager-datasource-term.php
@@ -382,4 +382,38 @@ class Test_Fieldmanager_Datasource_Term extends WP_UnitTestCase {
 		);
 	}
 
+	public function test_disable_append_true_after_first_save() {
+		$fm = new Fieldmanager_Group( array(
+			'name'     => 'author_data',
+			'children' => array(
+				'school' => new Fieldmanager_Group(array(
+					'label' => 'School',
+					'add_more_label' => 'Add new',
+					'limit' => 0,
+					'children' => array(
+						'school_city' => new Fieldmanager_Autocomplete( array(
+							'label' => 'School city',
+							'datasource' => new Fieldmanager_Datasource_Term( array(
+								'taxonomy' => 'post_tag',
+								'taxonomy_save_to_terms' => true,
+								'append_after_first_save' => false,
+							))
+						)),
+					)
+				))
+			)
+		) );
+		$data = array(
+			'school' => array(
+				array( 'school_city' => $this->term->term_id ),
+				array( 'school_city' => $this->term_2->term_id ),
+			),
+		);
+		$fm->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post->ID, $data );
+		$this->assertEquals(
+			array( $this->term_2->term_id ),
+			wp_get_post_terms( $this->post->ID, $this->term->taxonomy, array( 'fields' => 'ids' ) )
+		);
+	}
+
 }


### PR DESCRIPTION
When a Term datasource is a part of a repeatable group, the expected behavior is to save all terms present in all groups, not just the term of the last group. By passing `$append = true` after the first save, we can ensure subsequent terms maintain their relationship to the post.

Fixes #356