### PR TITLE
Use `$field->description_after_element` to control description position

### DIFF
--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -95,6 +95,12 @@ abstract class Fieldmanager_Field {
 	public $description = '';
 
 	/**
+	 * @var boolean
+	 * If true, the description will be displayed after the element.
+	 */
+	public $description_after_element = true;
+
+	/**
 	 * @var string|boolean[]
 	 * Extra HTML attributes to apply to the form element. Use boolean true to apply a standalone attribute, e.g. 'required' => true
 	 */
@@ -533,6 +539,10 @@ abstract class Fieldmanager_Field {
 			}
 		}
 
+		if ( isset( $this->description ) && !empty( $this->description ) && ! $this->description_after_element ) {
+			$out .= sprintf( '<div class="fm-item-description">%s</div>', $this->escape( 'description' ) );
+		}
+
 		if ( Null === $value && Null !== $this->default_value )
 			$value = $this->default_value;
 
@@ -546,7 +556,7 @@ abstract class Fieldmanager_Field {
 
 		if ( $render_label_after ) $out .= $label;
 
-		if ( isset( $this->description ) && !empty( $this->description ) ) {
+		if ( isset( $this->description ) && !empty( $this->description ) && $this->description_after_element ) {
 			$out .= sprintf( '<div class="fm-item-description">%s</div>', $this->escape( 'description' ) );
 		}
 


### PR DESCRIPTION
Defaults to `true`. `false` places it before the element.

Fixes #102