### PR TITLE
Properly bind tab button click events for new tabbed groups

### DIFF
--- a/js/fieldmanager-group-tabs.js
+++ b/js/fieldmanager-group-tabs.js
@@ -29,13 +29,13 @@ var FieldmanagerGroupTabs;
 				}
 				counter = el.siblings('.fm-item').length - 1;
 				var replaceProto = function( el, attr ) {
-					el.attr(attr, el.attr(attr).replace('-proto-', '-'+counter+'-'));
+					el.attr( attr, el.attr( attr ).replace( '-proto-', '-'+counter+'-' ) );
 				};
 
 				// We also need to set these unique IDs, because FM doesn't do it for us.
 				$( '.fm-tab-bar a', el ).each( function(){
 					replaceProto( $(this), 'href' );
-				})
+				});
 				$( '.wp-tabs-panel', el ).each( function(){
 					replaceProto( $(this), 'id' );
 				});

--- a/js/fieldmanager-group-tabs.js
+++ b/js/fieldmanager-group-tabs.js
@@ -19,13 +19,27 @@ var FieldmanagerGroupTabs;
 		 */
 		bindEvents: function() {
 
-			$( '.fm-tab-bar a' ).on( 'click', $.proxy( function( e ) {
-				e.preventDefault();
-				this.selectTab( $( e.currentTarget ) );
+			$('.fm-tab-bar').each( $.proxy( function( k, el ){
+				this.bindClickEvents( $(el) );
 			}, this ) );
-			$( '.fm-tab-bar li' ).on( 'click', $.proxy( function( e ) {
-				e.preventDefault();
-				this.selectTab( $( e.currentTarget ).children('a') );
+			$( document ).on( 'fm_added_element', $.proxy( function( e ){
+				var el = $(e.target);
+				if ( ! $( '.fm-tab-bar a', el ).length ) {
+					return;
+				}
+				counter = el.siblings('.fm-item').length - 1;
+				var replaceProto = function( el, attr ) {
+					el.attr(attr, el.attr(attr).replace('-proto-', '-'+counter+'-'));
+				};
+
+				// We also need to set these unique IDs, because FM doesn't do it for us.
+				$( '.fm-tab-bar a', el ).each( function(){
+					replaceProto( $(this), 'href' );
+				})
+				$( '.wp-tabs-panel', el ).each( function(){
+					replaceProto( $(this), 'id' );
+				});
+				this.bindClickEvents( el );
 			}, this ) );
 
 			if ( this.supportsLocalStorage() ) {
@@ -81,6 +95,20 @@ var FieldmanagerGroupTabs;
 				interval: 90
 			});
 
+		},
+
+		/**
+		 * Bind tab item click events
+		 */
+		bindClickEvents: function( el ) {
+			$( 'a', el ).on( 'click.fm-select-tab', $.proxy( function( e ) {
+				e.preventDefault();
+				this.selectTab( $( e.currentTarget ) );
+			}, this ) );
+			$( 'li', el ).on( 'click.fm-select-tab', $.proxy( function( e ) {
+				e.preventDefault();
+				this.selectTab( $( e.currentTarget ).children('a') );
+			}, this ) );
 		},
 
 		/**

--- a/js/fieldmanager-group-tabs.js
+++ b/js/fieldmanager-group-tabs.js
@@ -27,7 +27,13 @@ var FieldmanagerGroupTabs;
 				if ( ! $( '.fm-tab-bar a', el ).length ) {
 					return;
 				}
-				counter = el.siblings('.fm-item').length - 1;
+				counter = el.parent().data( 'fm-group-counter');
+				if ( ! counter ) {
+					counter = el.siblings('.fm-item').length - 1;
+				} else {
+					counter++;
+				}
+				el.parent().data( 'fm-group-counter', counter );
 				var replaceProto = function( el, attr ) {
 					el.attr( attr, el.attr( attr ).replace( '-proto-', '-'+counter+'-' ) );
 				};

--- a/js/fieldmanager-group-tabs.js
+++ b/js/fieldmanager-group-tabs.js
@@ -19,31 +19,31 @@ var FieldmanagerGroupTabs;
 		 */
 		bindEvents: function() {
 
-			$('.fm-tab-bar').each( $.proxy( function( k, el ){
-				this.bindClickEvents( $(el) );
+			$('.fm-tab-bar').each( $.proxy( function( k, el ) {
+				this.bindClickEvents( $( el ) );
 			}, this ) );
-			$( document ).on( 'fm_added_element', $.proxy( function( e ){
-				var el = $(e.target);
+			$( document ).on( 'fm_added_element', $.proxy( function( e ) {
+				var el = $( e.target );
 				if ( ! $( '.fm-tab-bar a', el ).length ) {
 					return;
 				}
-				counter = el.parent().data( 'fm-group-counter');
+				counter = el.parent().data( 'fm-group-counter' );
 				if ( ! counter ) {
-					counter = el.siblings('.fm-item').length - 1;
+					counter = el.siblings( '.fm-item' ).length - 1;
 				} else {
 					counter++;
 				}
 				el.parent().data( 'fm-group-counter', counter );
 				var replaceProto = function( el, attr ) {
-					el.attr( attr, el.attr( attr ).replace( '-proto-', '-'+counter+'-' ) );
+					el.attr( attr, el.attr( attr ).replace( '-proto-', '-' + counter + '-' ) );
 				};
 
 				// We also need to set these unique IDs, because FM doesn't do it for us.
-				$( '.fm-tab-bar a', el ).each( function(){
-					replaceProto( $(this), 'href' );
+				$( '.fm-tab-bar a', el ).each( function() {
+					replaceProto( $( this ), 'href' );
 				});
-				$( '.wp-tabs-panel', el ).each( function(){
-					replaceProto( $(this), 'id' );
+				$( '.wp-tabs-panel', el ).each( function() {
+					replaceProto( $( this ), 'id' );
 				});
 				this.bindClickEvents( el );
 			}, this ) );


### PR DESCRIPTION
Previously, the click events would only be bound on $(document).ready(),
leaving dynamically added groups without bound events.

Fixes #392