### PR TITLE
Initialize QuickTags buttons on dynamic RichTextFields

### DIFF
--- a/js/richtext.js
+++ b/js/richtext.js
@@ -48,6 +48,11 @@
 						try {
 							if ( typeof tinyMCEPreInit.qtInit[ ed_id ] !== 'undefined' ) {
 								quicktags( tinyMCEPreInit.qtInit[ ed_id ] );
+								// _buttonsInit() only needs to be called on dynamic editors
+								// quicktags() handles it for us on the first initialization
+								if ( typeof QTags !== 'undefined' && -1 !== ed_id.indexOf( '-dynamic-' ) ) {
+									QTags._buttonsInit();
+								}
 							}
 						} catch(e){};
 					}


### PR DESCRIPTION
Core doesn't do this for us by default.

Fixes #337