### PR TITLE
remove php7 from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ matrix:
       env: WP_VERSION=nightly
     - php: 5.6
       env: WP_TRAVISCI=phpcs
-  allow_failures:
-    - php: 7.0
   fast_finish: true
 
 branches:


### PR DESCRIPTION
PHP7 is fully supported by WordPress core, it should be fully supported by fieldmanager