### PR TITLE
Target :input, not .input, in label macros

### DIFF
--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -371,7 +371,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		$extra_attrs = '';
 		if ( $this->label_macro ) {
 			$this->label_format = $this->label_macro[0];
-			$this->label_token = sprintf( '.fm-%s input.fm-element', $this->label_macro[1] );
+			$this->label_token = sprintf( '.fm-%s .fm-element:input', $this->label_macro[1] );
 		}
 
 		if ( $this->label_format && $this->label_token ) {


### PR DESCRIPTION
From the docs: "Selects all input, textarea, select and button elements." Fixes #397.