### PR TITLE
Added character counters

### DIFF
--- a/css/fieldmanager.css
+++ b/css/fieldmanager.css
@@ -369,3 +369,22 @@ a.fm-delete:hover {
 .form-field .fm-checkbox label {
 	display: inline;
 }
+
+/* character counter */
+.fm-character-counter {
+	position: relative;
+	display: inline;
+}
+
+.fm-character-counter span {
+	position: absolute;
+	right: 10px;
+	top: -1px;
+	opacity: 1;
+	color: #aaa;
+	font-size: 0.9rem;
+}
+
+.fm-character-counter-padding {
+	padding-right: 35px !important;
+}

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -267,4 +267,65 @@ $( document ).ready( function () {
 	$( document ).on( 'fm_activate_tab', init_sortable );
 } );
 
+/**
+ * Add character counter to input text / textarea elements
+ *
+ * @param object
+ *  - selector string jQuery selector
+ *  - type string It ca be 'lenght' (displays typed chars) or 'maxlength' (displays remaining chars)
+ */
+fm_add_character_counter = function() {
+	var args = jQuery.extend( {
+		debug: 0,
+		selector: null,
+		type: 'maxlength',
+		maxlength: 100,
+		force_container_block: false
+	}, arguments[0] );
+
+	jQuery( args.selector ).each( function(){
+
+		var el = jQuery( this );
+
+		// Check for fm
+		if ( el.closest( '.fm-item' ).hasClass( 'fmjs-proto' ) ) {
+			return;
+		}
+
+		// Add padding
+		el.addClass( 'fm-character-counter-padding' );
+
+		// Check type of counter
+		var type = typeof( el.attr( 'maxlength' ) ) === 'undefined' ? 'length' : args.type;
+
+		var div = jQuery( '<div />' );
+		var span = jQuery( '<span />' );
+
+		// Fix for textarea
+		if ( /^textarea$/i.test( el.prop( 'tagName' ) ) ) {
+			span.css( 'top', 'inherit' );
+			if ( args.force_container_block )
+				div.css( 'display', 'block' );
+		}
+
+		div.addClass( 'fm-character-counter' );
+		el.wrap(div);
+
+		span.text( type === 'length' ? el.val().length : el.attr( 'maxlength' ) - el.val().length );
+
+		el.before( span );
+
+		el.on( 'keydown', function() {
+			span.text( type === 'length' ? el.val().length : el.attr( 'maxlength' ) - el.val().length );
+		});
+		el.on( 'keyup', function() {
+			span.text( type === 'length' ? el.val().length : el.attr( 'maxlength' ) - el.val().length );
+		});
+	});
+}
+// Add character counter based on 'data-character-counter' attribute
+jQuery( document ).ready( function() {
+	fm_add_character_counter( { selector: '.fm-element[data-character-counter]' } );
+} );
+
 } )( jQuery );


### PR DESCRIPTION
This PR adds character counter inside input text and textarea FM elements for all fields having `data-character-counter` attribute (see image below). For example:

```php
$fm = new Fieldmanager_Autocomplete( array(
   'name' => 'foo',
   attributes' => [
      'data-character-counter' => true,
      'maxlength' => 100
   ]
) );
```
If the element has the `maxlength` attribute, then the counter shows the remaining characters instead of those typed.

The PR consists only of JS/CSS code and it exports the JavaScript `fm_add_character_counter` function that can be used not only within FM fields but also with all WP standard post's fields. For example the following code:

```javascript
fm_add_character_counter({ selector: '#title' });
```

add the counter to title input fields if applied in the edit post screen.  

PS: The default CSS values are for demonstration purposes and can be improved/modified.


![fm_character_count](https://cloud.githubusercontent.com/assets/12462056/13305224/0e1b95e2-db5a-11e5-866f-6ed44c9d25f2.jpg)


