### PR TITLE
Add network submenu context

### DIFF
--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -1064,7 +1064,7 @@ abstract class Fieldmanager_Field {
 	 * Add this group to an options page
 	 * @param string $title
 	 */
-	public function add_submenu_page( $parent_slug, $page_title, $menu_title = Null, $capability = 'manage_options', $menu_slug = Null ) {
+	public function add_submenu_page( $parent_slug, $page_title, $menu_title = null, $capability = null, $menu_slug = null ) {
 		$this->require_base();
 		return new Fieldmanager_Context_Submenu( $parent_slug, $page_title, $menu_title, $capability, $menu_slug, $this );
 	}
@@ -1077,7 +1077,8 @@ abstract class Fieldmanager_Field {
 		$this->require_base();
 		$submenus = _fieldmanager_registry( 'submenus' );
 		$s = $submenus[ $this->name ];
-		$active_submenu = new Fieldmanager_Context_Submenu( $s[0], $s[1], $s[2], $s[3], $s[4], $this, True );
+		$submenu = fm_match_context( 'network_submenu' ) ? 'Fieldmanager_Context_NetworkSubmenu' : 'Fieldmanager_Context_Submenu';
+		$active_submenu = new $submenu( $s[0], $s[1], $s[2], $s[3], $s[4], $this, true );
 		_fieldmanager_registry( 'active_submenu', $active_submenu );
 	}
 

--- a/php/context/class-fieldmanager-context-networksubmenu.php
+++ b/php/context/class-fieldmanager-context-networksubmenu.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Create a page in the WordPress Network Admin.
+ *
+ * @package Fieldmanager_Context
+ */
+class Fieldmanager_Context_NetworkSubmenu extends Fieldmanager_Context_Submenu {
+	/**
+	 * Capability required to access the submenu
+	 *
+	 * @var string
+	 */
+	public $capability = 'manage_network_options';
+
+	/**
+	 * Initialize the context.
+	 */
+	public function __construct( $parent_slug, $page_title, $menu_title = null, $capability = null, $menu_slug = null, $fm = null, $already_registered = false ) {
+		parent::__construct( $parent_slug, $page_title, $menu_title, $capability, $menu_slug, $fm, $already_registered );
+	}
+
+	/**
+	 * Add action to register the submenu page.
+	 */
+	protected function hook_registration() {
+		add_action( 'network_admin_menu', array( $this, 'register_submenu_page' ) );
+	}
+
+	/**
+	 * Get the admin page URL.
+	 *
+	 * @return string
+	 */
+	public function url() {
+		if ( $this->parent_slug && ! isset( $GLOBALS['_parent_pages'][ $this->parent_slug ] ) ) {
+			return network_admin_url( add_query_arg( 'page', $this->menu_slug, $this->parent_slug ) );
+		} else {
+			return network_admin_url( 'admin.php?page=' . $this->menu_slug );
+		}
+	}
+
+	/**
+	 * Get site option.
+	 *
+	 * @see get_site_option().
+	 */
+	protected function get_data( $data_id, $option_name, $single = false ) {
+		return get_site_option( $option_name, null );
+	}
+
+	/**
+	 * Add site option.
+	 *
+	 * @see add_site_option().
+	 */
+	protected function add_data( $data_id, $option_name, $option_value, $unique = false ) {
+		return add_site_option( $option_name, $option_value );
+	}
+
+	/**
+	 * Update site option.
+	 *
+	 * @see update_site_option().
+	 */
+	protected function update_data( $data_id, $option_name, $option_value, $option_prev_value = '' ) {
+		return update_site_option( $option_name, $option_value );
+	}
+
+	/**
+	 * Delete site option.
+	 *
+	 * @see delete_site_option().
+	 */
+	protected function delete_data( $data_id, $option_name, $option_value = '' ) {
+		return delete_site_option( $option_name );
+	}
+}

--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -30,7 +30,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 	 * @var string
 	 * Capability required
 	 */
-	public $capability;
+	public $capability = 'manage_options';
 
 	/**
 	 * @var string
@@ -53,7 +53,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 	public $updated_message = null;
 
 	/**
-	 * @var string
+	 * @var bool
 	 * For submenu pages, set autoload to true or false
 	 */
 	public $wp_option_autoload = False;
@@ -67,19 +67,30 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 	 * @param string $menu_slug
 	 * @param Fieldmanager_Field $fm
 	 */
-	public function __construct( $parent_slug, $page_title, $menu_title = Null, $capability = 'manage_options', $menu_slug = Null, $fm = Null, $already_registered = False ) {
+	public function __construct( $parent_slug, $page_title, $menu_title = null, $capability = null, $menu_slug = null, $fm = null, $already_registered = false ) {
+		if ( ! $fm ) {
+			return;
+		}
+
 		$this->fm = $fm;
 		$this->menu_slug = $menu_slug ?: $this->fm->name;
 		$this->menu_title = $menu_title ?: $page_title;
 		$this->parent_slug = $parent_slug;
 		$this->page_title = $page_title;
-		$this->capability = $capability;
+		$this->capability = $capability ?: $this->capability;
 		$this->updated_message = __( 'Options updated', 'fieldmanager' );
 		$this->uniqid = $this->fm->get_element_id() . '_form';
-		if ( ! $already_registered )  {
-			add_action( 'admin_menu', array( $this, 'register_submenu_page' ) );
+		if ( ! $already_registered ) {
+			$this->hook_registration();
 		}
 		add_action( 'admin_init', array( $this, 'handle_submenu_save' ) );
+	}
+
+	/**
+	 * Add action to register the submenu page.
+	 */
+	protected function hook_registration() {
+		add_action( 'admin_menu', array( $this, 'register_submenu_page' ) );
 	}
 
 	/**

--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -95,7 +95,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 	 * @return void.
 	 */
 	public function render_submenu_page() {
-		$values = get_option( $this->fm->name, null );
+		$values = $this->get_data( null, $this->fm->name );
 		?>
 		<div class="wrap">
 			<?php if ( ! empty( $_GET['msg'] ) && 'success' == $_GET['msg'] ) : ?>
@@ -147,7 +147,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 	public function save_submenu_data( $data = null ) {
 		$this->fm->data_id = $this->fm->name;
 		$this->fm->data_type = 'options';
-		$current = get_option( $this->fm->name, null );
+		$current = $this->get_data( null, $this->fm->name );
 		$data = $this->prepare_data( $current, $data );
 		$data = apply_filters( 'fm_submenu_presave_data', $data, $this );
 		if ( $this->fm->skip_save ) {
@@ -155,9 +155,9 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 		}
 
 		if ( isset( $current ) ) {
-			update_option( $this->fm->name, $data );
+			$this->update_data( null, $this->fm->name, $data );
 		} else {
-			add_option( $this->fm->name, $data, '', $this->wp_option_autoload ? 'yes' : 'no' );
+			$this->add_data( null, $this->fm->name, $data );
 		}
 
 		return true;

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,8 +1,8 @@
 <phpunit
 	bootstrap="tests/php/bootstrap.php"
-        backupGlobals="false"
-        colors="true"
-        >
+    backupGlobals="false"
+    colors="true"
+    >
     <testsuites>
         <!-- Default test suite to run all tests -->
         <testsuite>
@@ -12,6 +12,7 @@
     <groups>
         <exclude>
             <group>ajax</group>
+            <group>multisite</group>
         </exclude>
     </groups>
     <logging>

--- a/tests/php/test-fieldmanager-context-submenu_network.php
+++ b/tests/php/test-fieldmanager-context-submenu_network.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @group multisite
+ * @group submenu
+ */
+class Test_Fieldmanager_Context_NetworkSubmenu extends Test_Fieldmanager_Context_Submenu {
+	public function test_hook_registration() {
+		$context = new Fieldmanager_Context_NetworkSubmenu( null, null, null, null, null, $this->get_fields( 'hook_registration' ) );
+		$this->assert_unhooked( $context );
+	}
+
+	protected function get_context( $name ) {
+		$submenus = _fieldmanager_registry( 'submenus' );
+		$s = $submenus[ $name ];
+		return new Fieldmanager_Context_NetworkSubmenu( $s[0], $s[1], $s[2], $s[3], $s[4], $this->get_fields( $name ), true );
+	}
+
+	protected function unhook_registration( $context ) {
+		return remove_action( 'network_admin_menu', array( $context, 'register_submenu_page' ) );
+	}
+
+	protected function _get_option( $name ) {
+		return get_site_option( $name );
+	}
+
+	protected function _delete_option( $name ) {
+		return delete_site_option( $name );
+	}
+
+	protected function _get_admin_url( $path ) {
+		return network_admin_url( $path );
+	}
+}


### PR DESCRIPTION
A replacement for #120 that extends `Fieldmanager_Context_Submenu` instead of sneaking network support into it. More details about the new approach are in the commit message in 37cc404.

I'm open to suggestions for adding multi-network support. I don't have any experience with multi-network installs, so I don't know what a good developer experience for them would look like. But it also seems like the context could move to `*_network_option()` in a backwards-compatible manner later.