### PR TITLE
Adds a default color

### DIFF
--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -27,6 +27,13 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	public static $has_registered_statics = false;
 
 	/**
+	 * The default color for the color picker.
+	 *
+	 * @var string
+	 */
+	public $default_color = null;
+
+	/**
 	 * Build the colorpicker object and enqueue assets.
 	 *
 	 * @param string $label
@@ -43,6 +50,12 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 
 		$this->sanitize = array( $this, 'sanitize_hex_color' );
 
+		if ( ! empty( $options['default_color'] ) ) {
+			$this->default_color = $options['default_color'];
+		} else if ( ! empty( $options['default_value'] ) ) {
+			$this->default_color = $options['default_value'];
+		}
+
 		parent::__construct( $label, $options );
 	}
 
@@ -57,7 +70,7 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 			'<input class="fm-element fm-colorpicker-popup" name="%1$s" id="%2$s" data-default-color="%3$s" value="%4$s" %5$s />',
 			esc_attr( $this->get_form_name() ),
 			esc_attr( $this->get_element_id() ),
-			esc_attr( $this->default_value ),
+			esc_attr( $this->default_color ),
 			esc_attr( $value ),
 			$this->get_element_attributes()
 		);

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -50,13 +50,13 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 
 		$this->sanitize = array( $this, 'sanitize_hex_color' );
 
-		if ( ! empty( $options['default_color'] ) ) {
-			$this->default_color = $options['default_color'];
-		} else if ( ! empty( $options['default_value'] ) ) {
-			$this->default_color = $options['default_value'];
-		}
-
 		parent::__construct( $label, $options );
+
+		// If we have a default_value and default_color was not explicitly set
+		// to be empty, set default_color to default_value.
+		if ( ! isset( $this->default_color ) && ! empty( $this->default_value ) ) {
+			$this->default_color = $this->default_value;
+		}
 	}
 
 	/**

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -20,6 +20,13 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	public $field_class = 'colorpicker';
 
 	/**
+	 * The default color for the color picker.
+	 *
+	 * @var string
+	 */
+	public $default_color = null;
+
+	/**
 	 * Static variable so we only load static assets once.
 	 *
 	 * @var boolean
@@ -43,6 +50,10 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 
 		$this->sanitize = array( $this, 'sanitize_hex_color' );
 
+		if ( ! empty( $options['default_color'] ) ) {
+			$this->default_color = $options['default_color'];
+		}
+
 		parent::__construct( $label, $options );
 	}
 
@@ -54,9 +65,10 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	 */
 	public function form_element( $value = '' ) {
 		return sprintf(
-			'<input class="fm-element fm-colorpicker-popup" name="%1$s" id="%2$s" value="%3$s" %4$s />',
+			'<input class="fm-element fm-colorpicker-popup" name="%1$s" id="%2$s" data-default-color="%3$s" value="%4$s" %5$s />',
 			esc_attr( $this->get_form_name() ),
 			esc_attr( $this->get_element_id() ),
+			esc_attr( $this->default_color ),
 			esc_attr( $value ),
 			$this->get_element_attributes()
 		);

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -20,13 +20,6 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	public $field_class = 'colorpicker';
 
 	/**
-	 * The default color for the color picker.
-	 *
-	 * @var string
-	 */
-	public $default_color = null;
-
-	/**
 	 * Static variable so we only load static assets once.
 	 *
 	 * @var boolean
@@ -50,10 +43,6 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 
 		$this->sanitize = array( $this, 'sanitize_hex_color' );
 
-		if ( ! empty( $options['default_color'] ) ) {
-			$this->default_color = $options['default_color'];
-		}
-
 		parent::__construct( $label, $options );
 	}
 
@@ -68,7 +57,7 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 			'<input class="fm-element fm-colorpicker-popup" name="%1$s" id="%2$s" data-default-color="%3$s" value="%4$s" %5$s />',
 			esc_attr( $this->get_form_name() ),
 			esc_attr( $this->get_element_id() ),
-			esc_attr( $this->default_color ),
+			esc_attr( $this->default_value ),
 			esc_attr( $value ),
 			$this->get_element_attributes()
 		);

--- a/tests/php/test-fieldmanager-colorpicker-field.php
+++ b/tests/php/test-fieldmanager-colorpicker-field.php
@@ -28,12 +28,29 @@ class Test_Fieldmanager_Colorpicker_Field extends WP_UnitTestCase {
 	}
 
 	public function test_default_color() {
-		$fm = new Fieldmanager_Colorpicker( array( 'name' => 'test_colorpicker', 'default_value' => '#ff0000' ) );
-
+		$fm_1 = new Fieldmanager_Colorpicker( 'test-1', array( 'name' => 'test_colorpicker', 'default_color' => '#ff0000' ) );
 		ob_start();
-		$fm->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
+		$fm_1->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
 		$html = ob_get_clean();
-		$this->assertEquals( 1, preg_match( '[data-default-color="#ff0000"]', $html ) );
+		$this->assertRegExp( '/data-default-color="#ff0000"/', $html );
+
+		$fm_2 = new Fieldmanager_Colorpicker( 'test-1', array( 'name' => 'test_colorpicker', 'default_value' => '#ff0000' ) );
+		ob_start();
+		$fm_2->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
+		$html = ob_get_clean();
+		$this->assertRegExp( '/data-default-color="#ff0000"/', $html );
+
+		$fm_3 = new Fieldmanager_Colorpicker( 'test-1', array( 'name' => 'test_colorpicker', 'default_color' => '', 'default_value' => '#ff0000' ) );
+		ob_start();
+		$fm_3->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
+		$html = ob_get_clean();
+		$this->assertRegExp( '/data-default-color/', $html );
+
+		$fm_4 = new Fieldmanager_Colorpicker( 'test-1', array( 'name' => 'test_colorpicker' ) );
+		ob_start();
+		$fm_4->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
+		$html = ob_get_clean();
+		$this->assertRegExp( '/data-default-color/', $html );
 	}
 
 	public function test_basic_save() {

--- a/tests/php/test-fieldmanager-colorpicker-field.php
+++ b/tests/php/test-fieldmanager-colorpicker-field.php
@@ -28,7 +28,7 @@ class Test_Fieldmanager_Colorpicker_Field extends WP_UnitTestCase {
 	}
 
 	public function test_default_color() {
-		$fm = new Fieldmanager_Colorpicker( array( 'name' => 'test_colorpicker', 'default_color' => '#ff0000' ) );
+		$fm = new Fieldmanager_Colorpicker( array( 'name' => 'test_colorpicker', 'default_value' => '#ff0000' ) );
 
 		ob_start();
 		$fm->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );

--- a/tests/php/test-fieldmanager-colorpicker-field.php
+++ b/tests/php/test-fieldmanager-colorpicker-field.php
@@ -27,32 +27,6 @@ class Test_Fieldmanager_Colorpicker_Field extends WP_UnitTestCase {
 		$this->assertRegExp( '#<input class="[^"]*fm-colorpicker-popup[^>]+name="test_colorpicker"#', $html );
 	}
 
-	public function test_default_color() {
-		$fm_1 = new Fieldmanager_Colorpicker( 'test-1', array( 'name' => 'test_colorpicker', 'default_color' => '#ff0000' ) );
-		ob_start();
-		$fm_1->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
-		$html = ob_get_clean();
-		$this->assertRegExp( '/data-default-color="#ff0000"/', $html );
-
-		$fm_2 = new Fieldmanager_Colorpicker( 'test-1', array( 'name' => 'test_colorpicker', 'default_value' => '#ff0000' ) );
-		ob_start();
-		$fm_2->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
-		$html = ob_get_clean();
-		$this->assertRegExp( '/data-default-color="#ff0000"/', $html );
-
-		$fm_3 = new Fieldmanager_Colorpicker( 'test-1', array( 'name' => 'test_colorpicker', 'default_color' => '', 'default_value' => '#ff0000' ) );
-		ob_start();
-		$fm_3->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
-		$html = ob_get_clean();
-		$this->assertRegExp( '/data-default-color/', $html );
-
-		$fm_4 = new Fieldmanager_Colorpicker( 'test-1', array( 'name' => 'test_colorpicker' ) );
-		ob_start();
-		$fm_4->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
-		$html = ob_get_clean();
-		$this->assertRegExp( '/data-default-color/', $html );
-	}
-
 	public function test_basic_save() {
 		$test_data = '#bada55';
 		$fm = new Fieldmanager_Colorpicker( array( 'name' => 'test_colorpicker' ) );
@@ -67,5 +41,28 @@ class Test_Fieldmanager_Colorpicker_Field extends WP_UnitTestCase {
 
 		$fm->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post->ID, $test_data );
 		$this->assertEquals( '', get_post_meta( $this->post->ID, 'test_colorpicker', true ) );
+	}
+
+	public function default_color_iterations() {
+		return array(
+			array( array( 'default_color' => '#ff0000' ), '/data-default-color="#ff0000" value=""/' ),
+			array( array( 'default_value' => '#abc' ), '/data-default-color="#abc" value="#abc"/' ),
+			array( array( 'default_color' => '', 'default_value' => '#001122' ), '/data-default-color="" value="#001122"/' ),
+			array( array(), '/data-default-color="" value=""/' ),
+		);
+	}
+
+	/**
+	 * @dataProvider default_color_iterations
+	 * @param  array $args Fieldmanager_Colorpicker args
+	 * @param  string $regex Test regex
+	 */
+	public function test_default_color( $args, $regex ) {
+		$args['name'] = rand_str();
+		$fm = new Fieldmanager_Colorpicker( $args );
+		ob_start();
+		$fm->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
+		$html = ob_get_clean();
+		$this->assertRegExp( $regex, $html );
 	}
 }

--- a/tests/php/test-fieldmanager-colorpicker-field.php
+++ b/tests/php/test-fieldmanager-colorpicker-field.php
@@ -27,6 +27,15 @@ class Test_Fieldmanager_Colorpicker_Field extends WP_UnitTestCase {
 		$this->assertRegExp( '#<input class="[^"]*fm-colorpicker-popup[^>]+name="test_colorpicker"#', $html );
 	}
 
+	public function test_default_color() {
+		$fm = new Fieldmanager_Colorpicker( array( 'name' => 'test_colorpicker', 'default_color' => '#ff0000' ) );
+
+		ob_start();
+		$fm->add_meta_box( 'Test Colorpicker', 'post' )->render_meta_box( $this->post, array() );
+		$html = ob_get_clean();
+		$this->assertEquals( 1, preg_match( '[data-default-color="#ff0000"]', $html ) );
+	}
+
 	public function test_basic_save() {
 		$test_data = '#bada55';
 		$fm = new Fieldmanager_Colorpicker( array( 'name' => 'test_colorpicker' ) );


### PR DESCRIPTION
Allows developers to supply a new option `default_color` to specify whether or not the color picker will use the clear or default functionality.

From https://github.com/alleyinteractive/wordpress-fieldmanager/issues/490