### PR TITLE
Fix argument order for optgroup key=>val pairs

### DIFF
--- a/php/class-fieldmanager-options.php
+++ b/php/class-fieldmanager-options.php
@@ -91,7 +91,7 @@ abstract class Fieldmanager_Options extends Fieldmanager_Field {
 		if ( isset( $values[0] ) && is_array( $values[0] ) ) {
 			foreach ( $options as $group => $data ) {
 				foreach ( $data as $value => $label ) {
-					$this->add_option_data( $value, $label, $group, $group );
+					$this->add_option_data( $label, $value, $group, $group );
 				}
 			}
 		} else {


### PR DESCRIPTION
This is a breaking change, but it was implemented wrong in the beginning. It's very rarely used, so I think it's safe to merge this.