### PR TITLE
Fieldmanager Gallery integration

### DIFF
--- a/css/fieldmanager-gallery.css
+++ b/css/fieldmanager-gallery.css
@@ -1,0 +1,22 @@
+
+.fm-gallery .gallery-wrapper {
+	margin: 5px 0 15px 15px;
+	padding-left: 10px;
+	border-left: solid 1px #ccc;
+}
+
+.fm-gallery .gallery-wrapper img {
+	max-width: 100%;
+	height: auto;
+}
+
+.fm-gallery .gallery-wrapper .gallery-item {
+	float: left;
+	margin: 10px;
+}
+
+.fm-gallery .gallery-wrapper:after {
+	content: ' ';
+	clear: left;
+	display: block;
+}

--- a/js/fieldmanager-gallery.js
+++ b/js/fieldmanager-gallery.js
@@ -1,0 +1,246 @@
+var fm_gallery_frame = [];
+( function( $ ) {
+
+var sortableCollection = function() {
+
+	$('.fm-gallery-button[data-collection=1]').each( function() {
+
+		var $button, $wrapper, $input;
+
+		$button = $(this);
+		$wrapper = $button.siblings( '.gallery-wrapper' );
+		$input   = $button.siblings( 'input.fm-gallery-id' );
+
+		$wrapper.sortable({
+
+			items: '> .gallery-item',
+
+			// Update hidden input value after sort.
+			stop: function( event, ui ) {
+
+				var val = [];
+
+				$wrapper.children('.gallery-item').each( function() {
+					val.push( $(this).data('fieldmanager-item-id') );
+				} );
+
+				$input.val( val.join(',') );
+
+				// Remove frame
+				// forces regen next time its opened - ensures correct selection.
+				delete fm_gallery_frame[ $button.attr('id') ];
+
+			}
+
+		});
+
+
+	} );
+
+}
+
+$( document ).ready( sortableCollection );
+$( document ).on( 'fieldmanager_gallery_preview', sortableCollection );
+
+$( document ).on( 'click', '.fm-gallery-remove, .fm-gallery-empty', function(e) {
+	e.preventDefault();
+
+	// Disable empty button
+	if ( $(this).hasClass('fm-gallery-empty') ) {;
+		$(this).addClass('button-disabled');
+	}
+
+	var parent = $(this).parents( '.fm-item.fm-gallery' );
+	parent.find( '.fm-gallery-id' ).val('');
+	parent.find( '.gallery-wrapper' ).html( '' );
+	fm_gallery_frame[ parent.find( '.fm-gallery-button' ).attr('id') ] = false;
+});
+
+$( document ).on( 'click', '.gallery-wrapper a', function( event ){
+	event.preventDefault();
+	$(this).closest('.gallery-wrapper').siblings('.fm-gallery-button').click();
+} );
+
+$( document ).on( 'click', '.fm-gallery-button', function( event ) {
+	var $el = $(this);
+	event.preventDefault();
+
+	// If the gallery frame already exists, reopen it.
+	if ( fm_gallery_frame[ $el.attr('id') ] ) {
+		fm_gallery_frame[ $el.attr('id') ].open();
+		return;
+	}
+	var selectedImages = [],
+		inputVal = $el.parent().find('.fm-gallery-id').val();
+
+	if ( inputVal.length ) {
+		selectedImages = inputVal.split(',');
+	}
+
+	// Modification to gallery editing workflow
+	var galleryFrame = wp.media.view.MediaFrame.Post.extend({
+
+		createStates: function() {
+			var options = this.options;
+
+			this.states.add([
+
+				new wp.media.controller.Library({
+					id:         'gallery',
+					title:      options.title,
+					priority:   40,
+					toolbar:    'main-gallery',
+					filterable: 'uploaded',
+					multiple:   'add',
+					editable:   false,
+
+					library:  wp.media.query( _.defaults({
+						type: 'image'
+					}, options.library ) )
+				}),
+
+				new wp.media.controller.GalleryEdit({
+					library: options.selection,
+					editing: options.editing,
+					menu:    'gallery'
+				}),
+
+				new wp.media.controller.GalleryAdd({
+				})
+
+			]);
+
+		}
+
+	});
+
+	var query_args = {
+		'type': 'image',
+		'post__in': selectedImages,
+		'orderby': 'post__in',
+		'perPage': -1
+	};
+
+	var attachments = wp.media.query( query_args );
+	var selection = new wp.media.model.Selection( attachments.models, {
+		props:    attachments.props.toJSON(),
+		multiple: true
+	});
+
+	selection.more().done( function() {
+		// Break ties with the query.
+		selection.props.set({ query: false });
+		selection.unmirror();
+		selection.props.unset('orderby');
+	});
+
+	var media_args = {
+		// Set the title of the modal.
+		title: $el.data('choose'),
+		selection: selection,
+
+		// Customize the submit button.
+		button: {
+			// Set the text of the button.
+			text: $el.data('update')
+		}
+	};
+
+	if ( $el.data( 'collection' ) ) {
+
+		if ( selectedImages.length ) {
+			media_args.state = 'gallery-edit';
+			media_args.editing = true;
+		} else {
+			media_args.state = 'gallery';
+		}
+		fm_gallery_frame[ $el.attr('id') ] = new galleryFrame( media_args );
+	} else {
+		fm_gallery_frame[ $el.attr('id') ] = wp.media( media_args );
+	}
+
+	/**
+	 * Handle the selection of one or more images
+	 */
+	var mediaFrameHandleSelect = function( attachments ) {
+
+		// Normal selection doesn't pass us a collection
+		if ( ! $el.data('collection') ) {
+			attachments = fm_gallery_frame[ $el.attr('id') ].state().get('selection');
+		}
+		// Update empty gallery button state
+		else {
+			$el.siblings('.fm-gallery-empty').removeClass('button-disabled');
+		}
+
+		var ids = [],
+		    galleryItems = [];
+
+		attachments.each( function( attachment ) {
+
+			attributes = attachment.attributes;
+			ids.push( attachment.id );
+
+			props = { size: fm_preview_size[ $el.attr('id') ] || 'thumbnail' };
+			props = wp.media.string.props( props, attributes );
+			props.align = 'none';
+			props.link = 'custom';
+			props.linkUrl = '#';
+			props.caption = '';
+
+			var galleryItem = $( '<div />', {
+				'class': 'gallery-item',
+				'data-fieldmanager-item-id': attachment.id,
+			} );
+
+			galleryItems.push( galleryItem );
+
+			if ( attributes.type == 'image' ) {
+
+				props.url = props.src;
+
+				if ( ! $el.data('collection') ) {
+					galleryItem.append( document.createTextNode( 'Uploaded file:' ) );
+					galleryItem.append( $( '<br />' ) );
+					galleryItem.append( wp.media.string.image( props ) );
+				} else {
+					galleryItem.append( wp.media.string.image( props ) );
+				}
+
+			} else {
+				galleryItem.append( document.createTextNode( 'Uploaded file:&nbsp;' ) );
+				galleryItem.append( $( '<br />' ) );
+				galleryItem.append( wp.media.string.link( props ) );
+			}
+
+			if ( ! $el.data('collection') ) {
+				galleryItem.append( $( '<br />' ) );
+				galleryItem.append( $( '<a/>', { 'class': "fm-gallery-remove fm-delete", 'href': "#", html: 'remove' } ) );
+				galleryItem.append( $( '<br />' ) );
+			}
+
+		});
+
+		// Store for saving
+		$el.parent().find('.fm-gallery-id').val( ids.join(',') );
+
+		var $wrapper = $el.parent().find( '.gallery-wrapper' );
+		$wrapper.html('').append( galleryItems ).trigger( 'fieldmanager_gallery_preview', [ $wrapper, attachments, wp ] );
+	};
+
+	// When an image is selected, run a callback.
+	fm_gallery_frame[ $el.attr('id') ].on( 'select', mediaFrameHandleSelect );
+	fm_gallery_frame[ $el.attr('id') ].on( 'update', mediaFrameHandleSelect );
+
+	// When closing modal, deletes frame by assuring always sync with the preview (data collection only)
+	fm_gallery_frame[ $el.attr('id') ].on( 'close', function(e) {
+		if ( $el.data('collection') ) {
+			delete fm_gallery_frame[ $el.attr('id') ];
+		}
+	} );
+
+	fm_gallery_frame[ $el.attr('id') ].open();
+
+} );
+
+} )( jQuery );

--- a/php/class-fieldmanager-gallery.php
+++ b/php/class-fieldmanager-gallery.php
@@ -1,0 +1,215 @@
+<?php
+
+/**
+ * Gallery field
+ * @package Fieldmanager
+ */
+class Fieldmanager_Gallery extends Fieldmanager_Field {
+
+	/**
+	 * @var string
+	 * Override field_class
+	 */
+	public $field_class = 'gallery';
+
+	/**
+	 * @var string
+	 * Button Label
+	 */
+	public $button_label;
+
+	/**
+	 * @var string
+	 * Empty gallery button Label
+	 */
+	public $empty_gallery_label;
+
+	/**
+	 * @var string
+	 * Button label in the gallery modal popup
+	 */
+	public $modal_button_label;
+
+	/**
+	 * @var string
+	 * Title of the gallery modal popup
+	 */
+	public $modal_title;
+
+	/**
+	 * @var string
+	 * Class to attach to thumbnail gallery display
+	 */
+	public $thumbnail_class = 'thumbnail';
+
+	/**
+	 * @var bool
+	 * Whether or not to allow a collection of images
+	 */
+	public $collection = false;
+
+	/**
+	 * @var string
+	 * Which size a preview image should be.
+	 * Should be a string (e.g. "thumbnail", "large", or some size created with add_image_size)
+	 * You can use an array here
+	 */
+	public $preview_size = 'thumbnail';
+
+	/**
+	 * @var string
+	 * Static variable so we only load gallery JS once
+	 */
+	public static $has_registered_gallery = False;
+
+	/**
+	 * Plugin directory URL
+	 * @var null
+	 */
+	private $plugin_url = null;
+
+	/**
+	 * Plugin directory Path
+	 * @var null
+	 */
+	private $plugin_dir = null;
+
+	/**
+	 * Construct default attributes
+	 * @param string $label
+	 * @param array $options
+	 */
+	public function __construct( $label, $options = array() ) {
+
+		$this->plugin_dir = plugin_dir_path( __FILE__ );
+		$this->plugin_url = plugin_dir_url( __FILE__ );
+
+		if ( ! empty( $options['collection'] ) ) {
+			$this->button_label       = __( 'Attach Gallery', 'fieldmanager' );
+			$this->modal_button_label = __( 'Select Attachments', 'fieldmanager' );
+			$this->modal_title        = __( 'Choose Attachments', 'fieldmanager' );
+		} else {
+			$this->button_label       = __( 'Attach a File', 'fieldmanager' );
+			$this->modal_button_label = __( 'Select Attachment', 'fieldmanager' );
+			$this->modal_title        = __( 'Choose an Attachment', 'fieldmanager' );
+		}
+
+		add_action( 'admin_print_scripts', function() {
+			$post = get_post();
+			$args = array();
+			if ( isset( $post ) && $post->ID ) {
+				$args['post'] = $post->ID;
+			}
+			wp_enqueue_media( $args ); // generally on post pages this will not have an impact.
+		} );
+		if ( !self::$has_registered_gallery ) {
+			fm_add_style( 'fm-fm_gallery-ui', 'css/fieldmanager-gallery.css', array() );
+			fm_add_script( 'fm_gallery', 'js/fieldmanager-gallery.js', array( 'jquery' ) );
+			add_action( 'admin_enqueue_scripts', function() {
+				self::$has_registered_gallery = True;
+			} );
+		}
+
+		/**
+		 * Whitelist the data attribute used
+		 * to expose gallery item IDs to the JS.
+		 */
+		add_filter( 'wp_kses_allowed_html', function( $allowed_html ) {
+			$allowed_html['div']['data-fieldmanager-item-id'] = true;
+			return $allowed_html;
+		} );
+
+		parent::__construct( $label, $options );
+	}
+
+	/**
+	 * Presave; ensure that the value is an absolute integer
+	 */
+	public function presave( $value, $current_value = array() ) {
+
+		if ( false !== stripos( $value, ',' ) ) {
+			$values = explode( ',', $value );
+			$clean_values = array();
+			foreach( $values as $dirty_value ) {
+				if ( is_numeric( $dirty_value ) && $dirty_value > 0 ) {
+					$clean_values[] = absint( $dirty_value );
+				}
+			}
+			return $clean_values;
+		} else {
+
+			if ( $value == 0 || !is_numeric( $value ) ) {
+				return NULL;
+			}
+
+			return absint( $value );
+		}
+		return absint( $value );
+	}
+
+	/**
+	 * Form element
+	 * @param mixed $value
+	 * @return string HTML
+	 */
+	public function form_element( $value = array() ) {
+
+		$preview = '';
+		$values = is_array( $value ) ? $value : array( $value );
+
+		foreach ( $values as $value ) {
+
+			if ( is_numeric( $value ) && $value > 0 ) {
+
+				$attachment = get_post( $value );
+				$out = '<div class="gallery-item" data-fieldmanager-item-id="' . esc_attr( $value ) . '">';
+
+				if ( strpos( $attachment->post_mime_type, 'image/' ) === 0 ) {
+
+					if ( ! $this->collection ) {
+						$out .= sprintf( '%s<br />', esc_html__( 'Uploaded image:', 'fieldmanager' ) );
+					}
+
+					$out .= '<a href="#">' . wp_get_attachment_image( $value, $this->preview_size, false, array( 'class' => $this->thumbnail_class ) ) . '</a>';
+
+				} else {
+					$out .= sprintf( '%s', esc_html__( 'Uploaded file:', 'fieldmanager' ) ) . '&nbsp;';
+					$out .= wp_get_attachment_link( $value, $this->preview_size, True, True, $attachment->post_title );
+				}
+
+				if ( ! $this->collection ) {
+					$out .= sprintf( '<br /><a href="#" class="fm-gallery-remove fm-delete">%s</a>', __( 'remove' ) );
+				}
+
+				$out .= '</div>';
+
+				$preview .= apply_filters( 'fieldmanager_gallery_preview', $out, $values, $attachment );
+			}
+
+		}
+
+		$input_value = implode( ',', $values );
+
+		return sprintf(
+			'<input type="button" class="fm-gallery-button button-secondary fm-incrementable" id="%1$s" value="%3$s" data-choose="%7$s" data-update="%8$s" data-collection="%9$s" />' .
+			( $this->collection ? ' <input type="button" class="fm-gallery-empty button-secondary fm-incrementable' . ( empty( $input_value ) ? ' button-disabled' : '' ) . '" value="%10$s" />' : '' ) .
+			'<input type="hidden" name="%2$s" value="%4$s" class="fm-element fm-gallery-id" />
+			<div class="gallery-wrapper">%5$s</div>
+			<script type="text/javascript">
+			var fm_preview_size = fm_preview_size || [];
+			fm_preview_size["%1$s"]=%6$s;
+			</script>',
+			esc_attr( $this->get_element_id() ),
+			esc_attr( $this->get_form_name() ),
+			esc_attr( $this->button_label ),
+			esc_attr( $input_value ),
+			wp_kses_post( $preview ),
+			json_encode( $this->preview_size ),
+			esc_attr( $this->modal_title ),
+			esc_attr( $this->modal_button_label ),
+			intval( $this->collection ),
+			esc_attr( $this->empty_gallery_label )
+		);
+	}
+
+}

--- a/tests/php/test-fieldmanager-gallery-field.php
+++ b/tests/php/test-fieldmanager-gallery-field.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * Tests the Fieldmanager Gallery
+ *
+ * @group field
+ * @group gallery
+ */
+class Test_Fieldmanager_Gallery_Field extends WP_UnitTestCase {
+
+	public function setUp() {
+		parent::setUp();
+		Fieldmanager_Field::$debug = true;
+
+		$this->post = $this->factory->post->create_and_get( array(
+			'post_status' => 'draft',
+			'post_content' => rand_str(),
+			'post_title' => rand_str(),
+		) );
+
+		// Add attachments needed for rendering
+		$this->media_id = [];
+		foreach ( range(1, 3) as $i ) {
+			$this->media_id[] = self::factory()->attachment->create_object( 'img' . $i . '.jpg', $this->post->ID, array( 'post_mime_type' => 'image/jpeg', 'post_type' => 'attachment' ) );
+		}
+	}
+
+	/**
+	 * Set up the request environment values and save the data.
+	 *
+	 * @param Fieldmanager_Field $field
+	 * @param WP_Post $post
+	 * @param mixed $values
+	 */
+	public function save_values( $field, $post, $values ) {
+		$field->add_meta_box( $field->name, $post->post_type )->save_to_post_meta( $post->ID, $values );
+	}
+
+	/**
+	 * Render the HTML for the field
+	 *
+	 * @param Fieldmanager_Field $field
+	 * @param WP_Post $post
+	 * @param mixed $values
+	 */
+	public function render( $field, $post ) {
+		ob_start();
+		$field->add_meta_box( $field->name, $post->post_type )->render_meta_box( $post );
+		return ob_get_clean();
+	}
+
+	/**
+	 * Test render 
+	 */
+	public function test_render () {
+
+		$gallery = new Fieldmanager_Gallery( false, array(
+			'name' => 'test_gallery',
+			'collection'          => false,
+			'button_label'        => 'Select images',
+			'modal_button_label'  => 'Select images',
+			'modal_title'         => 'Choose image',
+			'empty_gallery_label' => 'Empty gallery'
+		) );
+		
+		$html = $this->render( $gallery, $this->post );
+		$this->assertContains( 'name="test_gallery"', $html );
+		$this->assertContains( 'data-collection="0"', $html );
+		$this->assertContains( 'value="Select images"', $html );
+	}
+
+	/**
+	 * Test render
+	 */
+	public function test_render_default_value () {
+	
+		$gallery = new Fieldmanager_Gallery( false, array(
+			'name' => 'test_gallery',
+			'collection'          => false,
+			'button_label'        => 'Select images',
+			'modal_button_label'  => 'Select images',
+			'modal_title'         => 'Choose image',
+			'empty_gallery_label' => 'Empty gallery',
+			'default_value' => $this->media_id[0]
+		) );
+		$html = $this->render( $gallery, $this->post );
+		$this->assertContains( 'name="test_gallery"', $html );
+		$this->assertContains( 'data-collection="0"', $html );
+		$this->assertContains( 'value="Select images"', $html );
+		$this->assertRegExp( '/input\s+type="hidden"\s+name="test_gallery"\s+value="' . $this->media_id[0] . '"/', $html );
+	}
+
+	/**
+	 * Test render (empty) collection
+	 */
+	public function test_render_collection () {
+
+		$gallery = new Fieldmanager_Gallery( false, array(
+			'name' => 'test_gallery',
+			'collection'          => true,
+			'button_label'        => 'Select images',
+			'modal_button_label'  => 'Select images',
+			'modal_title'         => 'Choose image',
+			'empty_gallery_label' => 'Empty gallery'
+		) );
+	
+		$html = $this->render( $gallery, $this->post );
+		$this->assertContains( 'name="test_gallery"', $html );
+		$this->assertContains( 'data-collection="1"', $html );
+		$this->assertContains( 'value="Empty gallery"', $html );
+		$this->assertContains( 'button-disabled', $html );
+	}
+
+	/**
+	 * Test render collection
+	 */
+	public function test_render_collection_default_values () {
+
+		$gallery = new Fieldmanager_Gallery( false, array(
+			'name' => 'test_gallery',
+			'collection'          => true,
+			'button_label'        => 'Select images',
+			'modal_button_label'  => 'Select images',
+			'modal_title'         => 'Choose image',
+			'empty_gallery_label' => 'Empty gallery',
+			'default_value' => $this->media_id
+		) );
+	
+		$html = $this->render( $gallery, $this->post );
+		$this->assertContains( 'name="test_gallery"', $html );
+		$this->assertContains( 'data-collection="1"', $html );
+		$this->assertContains( 'value="Empty gallery"', $html );
+		$this->assertNotContains( 'button-disabled', $html );
+		$this->assertRegExp( '#src="http://example.org/wp-content/uploads/img(1|2).jpg"#', $html );
+	}
+
+	/**
+	 * Test save collection
+	 */
+	public function test_save_collection () {
+
+		$gallery = new Fieldmanager_Gallery( false, array(
+			'name' => 'test_gallery',
+			'collection'          => true,
+			'button_label'        => 'Select images',
+			'modal_button_label'  => 'Select images',
+			'modal_title'         => 'Choose image',
+			'empty_gallery_label' => 'Empty gallery'
+		) );
+	
+		$html = $this->render( $gallery, $this->post );
+		$this->assertContains( 'button-disabled', $html );
+		$this->save_values( $gallery, $this->post, implode( ',', $this->media_id ) );
+		$saved_value = get_post_meta( $this->post->ID, 'test_gallery', true );
+		$this->assertEquals( $this->media_id, $saved_value );
+
+		// Check rendering of non empty gallery
+		$html = $this->render( $gallery, $this->post );
+		$this->assertRegExp( '/input\s+type="hidden"\s+name="test_gallery"\s+value="' . implode( ',', $this->media_id ) . '"/', $html );
+		$this->assertRegExp( '#src="http://example.org/wp-content/uploads/img(1|2).jpg"#', $html );
+		$this->assertNotContains( 'button-disabled', $html );
+	}
+	
+	/**
+	 * Test save group collection
+	 */
+	public function test_save_collection_group () {
+		$gallery = new Fieldmanager_Gallery( false, array(
+			'name' => 'test_gallery',
+			'collection'          => true,
+			'button_label'        => 'Select images',
+			'modal_button_label'  => 'Select images',
+			'modal_title'         => 'Choose image',
+			'empty_gallery_label' => 'Empty gallery'
+		) );
+		
+		$group = new Fieldmanager_Group( array(
+			'name' => 'test_gallery_group',
+			'limit' => 0,
+			'add_to_prefix'  => false,
+			'label' => 'New Gallery',
+			'label_macro' => array( 'Gallery: %s', 'title' ),
+			'add_more_label' => 'Add another gallery',
+			'sortable' => true,
+			'children' => array(
+				'test_gallery' => $gallery
+			),
+		) );
+		
+		$html = $this->render( $group, $this->post );
+		$this->save_values( $group, $this->post, array( array( 'test_gallery' => implode( ',', $this->media_id ) ) ) );
+		$saved_value = get_post_meta( $this->post->ID, 'test_gallery_group', true );
+		$this->assertSame( $this->media_id, $saved_value[0]['test_gallery'] );
+	}	
+}

--- a/tests/php/test-fieldmanager-gallery-field.php
+++ b/tests/php/test-fieldmanager-gallery-field.php
@@ -50,7 +50,7 @@ class Test_Fieldmanager_Gallery_Field extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test render 
+	 * Test render
 	 */
 	public function test_render () {
 
@@ -62,7 +62,7 @@ class Test_Fieldmanager_Gallery_Field extends WP_UnitTestCase {
 			'modal_title'         => 'Choose image',
 			'empty_gallery_label' => 'Empty gallery'
 		) );
-		
+
 		$html = $this->render( $gallery, $this->post );
 		$this->assertContains( 'name="test_gallery"', $html );
 		$this->assertContains( 'data-collection="0"', $html );
@@ -73,7 +73,7 @@ class Test_Fieldmanager_Gallery_Field extends WP_UnitTestCase {
 	 * Test render
 	 */
 	public function test_render_default_value () {
-	
+
 		$gallery = new Fieldmanager_Gallery( false, array(
 			'name' => 'test_gallery',
 			'collection'          => false,
@@ -103,7 +103,7 @@ class Test_Fieldmanager_Gallery_Field extends WP_UnitTestCase {
 			'modal_title'         => 'Choose image',
 			'empty_gallery_label' => 'Empty gallery'
 		) );
-	
+
 		$html = $this->render( $gallery, $this->post );
 		$this->assertContains( 'name="test_gallery"', $html );
 		$this->assertContains( 'data-collection="1"', $html );
@@ -125,7 +125,7 @@ class Test_Fieldmanager_Gallery_Field extends WP_UnitTestCase {
 			'empty_gallery_label' => 'Empty gallery',
 			'default_value' => $this->media_id
 		) );
-	
+
 		$html = $this->render( $gallery, $this->post );
 		$this->assertContains( 'name="test_gallery"', $html );
 		$this->assertContains( 'data-collection="1"', $html );
@@ -147,7 +147,7 @@ class Test_Fieldmanager_Gallery_Field extends WP_UnitTestCase {
 			'modal_title'         => 'Choose image',
 			'empty_gallery_label' => 'Empty gallery'
 		) );
-	
+
 		$html = $this->render( $gallery, $this->post );
 		$this->assertContains( 'button-disabled', $html );
 		$this->save_values( $gallery, $this->post, implode( ',', $this->media_id ) );
@@ -160,7 +160,7 @@ class Test_Fieldmanager_Gallery_Field extends WP_UnitTestCase {
 		$this->assertRegExp( '#src="http://example.org/wp-content/uploads/img(1|2).jpg"#', $html );
 		$this->assertNotContains( 'button-disabled', $html );
 	}
-	
+
 	/**
 	 * Test save group collection
 	 */
@@ -173,7 +173,7 @@ class Test_Fieldmanager_Gallery_Field extends WP_UnitTestCase {
 			'modal_title'         => 'Choose image',
 			'empty_gallery_label' => 'Empty gallery'
 		) );
-		
+
 		$group = new Fieldmanager_Group( array(
 			'name' => 'test_gallery_group',
 			'limit' => 0,
@@ -186,10 +186,11 @@ class Test_Fieldmanager_Gallery_Field extends WP_UnitTestCase {
 				'test_gallery' => $gallery
 			),
 		) );
-		
+
 		$html = $this->render( $group, $this->post );
 		$this->save_values( $group, $this->post, array( array( 'test_gallery' => implode( ',', $this->media_id ) ) ) );
 		$saved_value = get_post_meta( $this->post->ID, 'test_gallery_group', true );
 		$this->assertSame( $this->media_id, $saved_value[0]['test_gallery'] );
-	}	
+	}
 }
+


### PR DESCRIPTION
This PR aims to merge https://github.com/fusioneng/fieldmanager-gallery into FM. 

The Fieldmanager Gallery provided is based on my [PR](https://github.com/fusioneng/fieldmanager-gallery/pull/12) that adds some fix and enhamcements to the latest Fieldmanager Gallery (that, to be honest, don't seems to be currently actively maintained and it still has a serious bug). In particular:

- Gallery disappearing. I merged these [fixes](https://github.com/fusioneng/fieldmanager-gallery/pull/6) that live in a branch (vip-fixed) that is some commits behind master. 

- Added `empty_gallery_button` (only for collections) in order to remove a gallery. This could solve this [issue](https://github.com/fusioneng/fieldmanager-gallery/issues/11)

- Fixed the synchronization with the gallery preview and the modal media frame. Not too a serious bug but annoying.

- Uses `fm_add_style` and `fm_add_script` support functions to load JS/CSS

- The PR also contains PHPUnit test file for the gallery.

Note: There was two years old [PR](https://github.com/alleyinteractive/wordpress-fieldmanager/pull/174) opened by @danielbachhuber but it does not seem to me that there have been actions over it.