### PR TITLE
Fix Bug with Saving Fields in PHP 7

### DIFF
--- a/php/context/class-fieldmanager-context-storable.php
+++ b/php/context/class-fieldmanager-context-storable.php
@@ -46,7 +46,7 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 		if ( $this->fm->serialize_data ) {
 			$this->save_field( $this->fm, $data, $this->fm->data_id );
 		} else {
-			if ( null === $data ) {
+			if ( empty( $data ) ) {
 				$data = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : '';
 			}
 			$this->save_walk_children( $this->fm, $data, $this->fm->data_id );


### PR DESCRIPTION
While using PHP Version 7.0.9 on the most recent Varying Vagrant Vagrants (VVV) environment, I found that field manager fields weren't saving.  I found that on line 49 of `class-fieldmanager-context-storable.php`, $data was an empty string instead of null.  Changing the check to empty fixed the issue I was experiencing. 