### PR TITLE
Update valid_rules so other plugins/themes can extend validation. 

### DIFF
--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -92,8 +92,10 @@ class Fieldmanager_Util_Validation {
 	 */
 	private function setup( $form_id, $context ) {
 		// Set class variables
-		$this->form_id = $form_id;
-		$this->context = $context;
+		$this->form_id     = $form_id;
+		$this->context     = $context;
+		//Allows other plugins or theme to extend available rules
+		$this->valid_rules = apply_filters('fieldmanager_valid_rules', $this->valid_rules);
 
 		// Add the appropriate action hook to finalize and output validation JS
 		// Also determine where the jQuery validation script needs to be added


### PR DESCRIPTION
In order to extend fields validation with some custom rules we would need to change the class variable `valid_rules`, so I purpose to have an `apply_filter` here in order to accomplish this.