### PR TITLE
Cleanup validation JS and fix image validation rules #526

### DIFF
--- a/js/validation/fieldmanager-validation.js
+++ b/js/validation/fieldmanager-validation.js
@@ -1,22 +1,39 @@
+/*globals FM_VALIDATION_OPTIONS*/
 ( function( $ ) {
+	'use strict';
 
-fm_validation = {
-
-	invalidHandler: function( event, validator ) {
-		// Certain WordPress forms require additional cleanup to work smoothly with jQuery validation
-		var form = $( validator.currentForm ).attr( 'id' );
-		switch ( form ) {
-			case "post":
-				$( "#submitpost .spinner" ).hide();
-				$( "#submitpost #publish" ).removeClass( 'button-primary-disabled' );
-				$(window).off( 'beforeunload.edit-post' );
-				break;
+	var args = $.extend( {}, FM_VALIDATION_OPTIONS.options, {
+		ignore: function( index, form_element ) {
+			var $element = $( form_element );
+			if (
+				$element.closest( '.fm-item' ).is( ':visible' ) // Field wrapper is visible, not behind a display_if
+				&&
+				$element.is( FM_VALIDATION_OPTIONS.force.join( ', ' ) ) // And the field input exists in force option
+			) {
+				// Force inclusion of fields added to FM_VALIDATION_OPTIONS.force
+				return false;
+			} else {
+				// Other inputs follow the rules in FM_VALIDATION_OPTIONS.ignore
+				return ! $element.is( FM_VALIDATION_OPTIONS.ignore.join( ', ' ) );
+			}
+		},
+		invalidHandler: function( event, validator ) {
+			// Certain WordPress forms require additional cleanup to work smoothly with jQuery validation
+			var form = $( validator.currentForm ).attr( 'id' );
+			switch ( form ) {
+				case "post":
+					$( "#submitpost .spinner" ).hide();
+					$( "#submitpost #publish" ).removeClass( 'button-primary-disabled' );
+					$(window).off( 'beforeunload.edit-post' );
+					break;
+			}
+		},
+		submitHandler: function( form_element ) {
+			$(window).off( 'beforeunload.edit-post' );
+			form_element.submit();
 		}
-	},
-	submitHandler: function( form_element ) {
-		$(window).off( 'beforeunload.edit-post' );
-		form_element.submit();
-	}
-}
+	} );
 
-} ) ( jQuery );
+	$( 'form#' + FM_VALIDATION_OPTIONS.form_id ).validate( args );
+
+} )( jQuery );

--- a/js/validation/fieldmanager-validation.js
+++ b/js/validation/fieldmanager-validation.js
@@ -1,39 +1,53 @@
 /*globals FM_VALIDATION_OPTIONS*/
-( function( $ ) {
+(function( $ ) {
 	'use strict';
 
 	var args = $.extend( {}, FM_VALIDATION_OPTIONS.options, {
-		ignore: function( index, form_element ) {
-			var $element = $( form_element );
+
+		ignore: function( index, formElement ) {
+
+			var $element = $( formElement );
+
+			// Field wrapper is visible, not behind a display_if
+			// And the field input exists in force option
 			if (
-				$element.closest( '.fm-item' ).is( ':visible' ) // Field wrapper is visible, not behind a display_if
-				&&
-				$element.is( FM_VALIDATION_OPTIONS.force.join( ', ' ) ) // And the field input exists in force option
+				$element.closest( '.fm-item' ).is( ':visible' ) &&
+				$element.is( FM_VALIDATION_OPTIONS.force.join( ', ' ) )
 			) {
+
 				// Force inclusion of fields added to FM_VALIDATION_OPTIONS.force
 				return false;
 			} else {
+
 				// Other inputs follow the rules in FM_VALIDATION_OPTIONS.ignore
 				return ! $element.is( FM_VALIDATION_OPTIONS.ignore.join( ', ' ) );
 			}
 		},
 		invalidHandler: function( event, validator ) {
+
 			// Certain WordPress forms require additional cleanup to work smoothly with jQuery validation
 			var form = $( validator.currentForm ).attr( 'id' );
+
 			switch ( form ) {
-				case "post":
-					$( "#submitpost .spinner" ).hide();
-					$( "#submitpost #publish" ).removeClass( 'button-primary-disabled' );
-					$(window).off( 'beforeunload.edit-post' );
+
+				case 'post':
+
+					$( '.spinner', '#submitpost' ).hide();
+					$( '#publish', '#submitpost' ).removeClass( 'button-primary-disabled' );
+					$( window ).off( 'beforeunload.edit-post' );
+
 					break;
 			}
 		},
-		submitHandler: function( form_element ) {
-			$(window).off( 'beforeunload.edit-post' );
-			form_element.submit();
+		submitHandler: function( formElement ) {
+
+			$( window ).off( 'beforeunload.edit-post' );
+			formElement.submit();
 		}
 	} );
 
-	$( 'form#' + FM_VALIDATION_OPTIONS.form_id ).validate( args );
+	if ( 'undefined' !== typeof FM_VALIDATION_OPTIONS.form_id ) {
+		$( 'form#' + FM_VALIDATION_OPTIONS.form_id ).validate( args );
+	}
 
-} )( jQuery );
+})( jQuery );

--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -206,7 +206,7 @@ class Fieldmanager_Util_Validation {
 			// Fields that should always be ignored
 			$ignore[] = ".fm-autocomplete";
 			$ignore[] = "input[type='button']";
-			$ignore[] = ":hidden";
+			$ignore[] = ":hidden:not(.fm-media-id)";
 
 			// Certain fields need to be ignored depending on the context
 			switch ( $this->context ) {


### PR DESCRIPTION
- Fixes validation for image fields, which are hidden.
- Cleans up the validation JS, pass options to `wp_localize_script` instead of manually escaping and echo'ing every bit
- Pass options through a WP filter
- Pass options to JS handler in a way that allows Front-end extensions to work as well

Fixes #526 
