### PR TITLE
Allow custom form templates

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -133,10 +133,15 @@ function fieldmanager_get_baseurl() {
  *     requested template is not found.
  */
 function fieldmanager_get_template( $tpl_slug ) {
-	if ( ! file_exists( plugin_dir_path( __FILE__ ) . 'templates/' . $tpl_slug . '.php' ) ) {
+	
+	if ( file_exists( get_stylesheet_directory() . '/plugins/fieldmanager/templates/' . $tpl_slug . '.php' ) ){
+		$tpl_slug = locate_template( 'plugins/fieldmanager/templates/' . $tpl_slug . '.php' );
+	} elseif ( file_exists( plugin_dir_path( __FILE__ ) . 'templates/' . $tpl_slug . '.php' ) ) {
+		$tpl_slug = plugin_dir_path( __FILE__ ) . 'templates/' . $tpl_slug . '.php';
+	} else {
 		$tpl_slug = 'textfield';
 	}
-	return plugin_dir_path( __FILE__ ) . 'templates/' . $tpl_slug . '.php';
+	return $tpl_slug;
 }
 
 /**


### PR DESCRIPTION
This pull request allows usage of custom templates without having to change the plugin's core. It searches first in parent/child theme directory, for example in 

`[..]/themes/theme-name/plugins/fieldmanager/templates/`, 

and if it doesn't find the right template file, continue to search in plugin own directory.

Could be any path really. I chose this one arbitrarily .