### PR TITLE
Fix `@var` and missing variable in filter docs

### DIFF
--- a/php/util/class-fieldmanager-util-assets.php
+++ b/php/util/class-fieldmanager-util-assets.php
@@ -62,7 +62,7 @@ class Fieldmanager_Util_Assets {
 		/**
 		 * Filters the script argument arrays for Fieldmanager_Util_Assets::enqueue_script().
 		 *
-		 * @var array Arrays of script arguments. @see Fieldmanager_Util_Assets::add_script().
+		 * @param array $scripts Arrays of script arguments. @see Fieldmanager_Util_Assets::add_script().
 		 */
 		$enqueue_scripts = apply_filters( 'fm_enqueue_scripts', array_values( $this->scripts ) );
 		foreach ( $enqueue_scripts as $args ) {
@@ -73,7 +73,7 @@ class Fieldmanager_Util_Assets {
 		/**
 		 * Filters the stylesheet argument arrays for Fieldmanager_Util_Assets::enqueue_style().
 		 *
-		 * @var array Arrays of stylesheet arguments. @see Fieldmanager_Util_Assets::add_style().
+		 * @param array $styles Arrays of stylesheet arguments. @see Fieldmanager_Util_Assets::add_style().
 		 */
 		$enqueue_styles = apply_filters( 'fm_enqueue_styles', array_values( $this->styles ) );
 		foreach ( $enqueue_styles as $args ) {


### PR DESCRIPTION
The docs I added in #522 contained several mistakes, fixed (I hope) here.
