### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,16 @@
 {
   "name": "alleyinteractive/wordpress-fieldmanager",
+  "type": "wordpress-plugin",
+  "keywords": ["wordpress", "plugin"],
   "authors": [
     {
       "name": "Alley Interactive",
       "email": "noreply@alleyinteractive.com"
     }
   ],
+  "require": {
+    "composer/installers": "~1.0"
+  },
   "require-dev": {
     "squizlabs/php_codesniffer": "2.*",
     "wp-coding-standards/wpcs": "dev-master"


### PR DESCRIPTION
Defined the package type to `wordpress-plugin`. This means by default it will be installed into `wp-content/plugins` instead of the usual vendor directory.

Requiring `composer/installers` also means that anyone using this package can customize the install path as well (app/plugins for example).
