### PR TITLE
Fix missing `parent::tearDown()`s

### DIFF
--- a/tests/php/test-fieldmanager-context-term-fm-term-meta.php
+++ b/tests/php/test-fieldmanager-context-term-fm-term-meta.php
@@ -28,6 +28,8 @@ class Test_Fieldmanager_Context_Term_FM_Term_Meta extends WP_UnitTestCase {
 	}
 
 	public function tearDown() {
+		parent::tearDown();
+
 		$meta = fm_get_term_meta( $this->term_id, $this->taxonomy );
 		foreach ( $meta as $key => $value ) {
 			fm_delete_term_meta( $this->term_id, $this->taxonomy, $key );

--- a/tests/php/test-fieldmanager-context-term.php
+++ b/tests/php/test-fieldmanager-context-term.php
@@ -26,6 +26,8 @@ class Test_Fieldmanager_Context_Term extends WP_UnitTestCase {
 	}
 
 	public function tearDown() {
+		parent::tearDown();
+
 		if ( _fm_phpunit_is_wp_at_least( 4.4 ) ) {
 			$meta = get_term_meta( $this->term_id );
 			foreach ( $meta as $key => $value ) {


### PR DESCRIPTION
after https://core.trac.wordpress.org/changeset/39626; split from #565.