### PR TITLE
A fix to handle showing CHozen items if they are loaded in a hidden block

### DIFF
--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -266,7 +266,7 @@ $( document ).ready( function () {
 				}
 			}
 		} );
-		// check for chozen not loaded do to being hidden and load t found
+		// check if chozen not loaded due to being hidden and load if found
 		$(".chzn-select").not( ".chzn-done" ).chosen().trigger("chosen:updated");
 	};
 	$( document ).on( 'change', '.display-trigger', fm.trigger_display_if );

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -266,6 +266,8 @@ $( document ).ready( function () {
 				}
 			}
 		} );
+		// check for chozen not loaded do to being hidden and load t found
+		$(".chzn-select").not( ".chzn-done" ).chosen().trigger("chosen:updated");
 	};
 	$( document ).on( 'change', '.display-trigger', fm.trigger_display_if );
 


### PR DESCRIPTION
There is a know problem https://github.com/harvesthq/chosen/issues/92 where Chozen doesn't load in hidden elements. 
This fix just rechecks for elements that are marked to have chozen added but don't have it loaded and triggers it to be loaded if found when the trigger_display_if is run