### PR TITLE
Update translated strings

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -35,6 +35,21 @@ module.exports = function( grunt ) {
 				}
 			}
 		},
+		makepot: {
+			target: {
+				options: {
+					domainPath: '/languages',
+					mainFile: 'fieldmanager.php',
+					potFilename: 'fieldmanager.pot',
+					potHeaders: {
+						poedit: true,
+						'x-poedit-keywordslist': true
+					},
+					type: 'wp-plugin',
+					updateTimestamp: true
+				}
+			}
+		},
 		phpcs: {
 			plugin: {},
 			options: {
@@ -51,8 +66,8 @@ module.exports = function( grunt ) {
 	grunt.loadNpmTasks( 'grunt-contrib-connect' );
 	grunt.loadNpmTasks( 'grunt-contrib-qunit' );
 	grunt.loadNpmTasks( 'grunt-phpcs' );
+	grunt.loadNpmTasks( 'grunt-wp-i18n' );
 
-	grunt.task.run( 'connect' );
-
-	grunt.registerTask( 'default', ['qunit:latest'] );
+	grunt.registerTask( 'default', [ 'connect', 'qunit:latest' ] );
+	grunt.registerTask( 'i18n', [ 'makepot' ] );
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -68,6 +68,6 @@ module.exports = function( grunt ) {
 	grunt.loadNpmTasks( 'grunt-phpcs' );
 	grunt.loadNpmTasks( 'grunt-wp-i18n' );
 
-	grunt.registerTask( 'default', [ 'connect', 'qunit:latest' ] );
-	grunt.registerTask( 'i18n', [ 'makepot' ] );
+	// Run server for QUnit.
+	grunt.task.run( 'connect' );
 };

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -441,7 +441,7 @@ function fm_register_submenu_page( $group_name, $parent_slug, $page_title, $menu
 		$submenus = array();
 	}
 	if ( isset( $submenus[ $group_name ] ) ) {
-		throw new FM_Duplicate_Submenu_Name_Exception( sprintf( esc_html__( '%s is already in use as a submenu name', 'fieldmanager' ), $group_name ) );
+		throw new FM_Duplicate_Submenu_Name_Exception( sprintf( esc_html__( '`%s` is already in use as a submenu name.', 'fieldmanager' ), $group_name ) );
 	}
 
 	if ( !$menu_title ) {
@@ -469,7 +469,7 @@ function fm_register_submenu_page( $group_name, $parent_slug, $page_title, $menu
 function _fm_submenu_render() {
 	$context = _fieldmanager_registry( 'active_submenu' );
 	if ( !is_object( $context ) ) {
-		throw new FM_Submenu_Not_Initialized_Exception( esc_html__( 'The Fieldmanger context for this submenu was not initialized', 'fieldmanager' ) );
+		throw new FM_Submenu_Not_Initialized_Exception( esc_html__( 'The Fieldmanger context for this submenu was not initialized.', 'fieldmanager' ) );
 	}
 	$context->render_submenu_page();
 }

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -441,6 +441,7 @@ function fm_register_submenu_page( $group_name, $parent_slug, $page_title, $menu
 		$submenus = array();
 	}
 	if ( isset( $submenus[ $group_name ] ) ) {
+		/* translators: %s: submenu group name */
 		throw new FM_Duplicate_Submenu_Name_Exception( sprintf( esc_html__( '`%s` is already in use as a submenu name.', 'fieldmanager' ), $group_name ) );
 	}
 

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -13,6 +13,8 @@ Description: Add fields to content types programatically.
 Author: Austin Smith, Matthew Boynes
 Version: 1.1.0-beta.1
 Author URI: http://www.alleyinteractive.com/
+Text Domain: fieldmanager
+Domain Path: /languages
 */
 
 /**
@@ -138,6 +140,16 @@ function fieldmanager_get_template( $tpl_slug ) {
 	}
 	return plugin_dir_path( __FILE__ ) . 'templates/' . $tpl_slug . '.php';
 }
+
+/**
+ * Load Fieldmanager's translated strings.
+ *
+ * @return bool @see load_plugin_textdomain().
+ */
+function fm_load_textdomain() {
+	return load_plugin_textdomain( 'fieldmanager', false, plugin_basename( FM_BASE_DIR ) . '/languages/' );
+}
+add_action( 'init', 'fm_load_textdomain' );
 
 /**
  * Enqueue a script, optionally localizing data to it.

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -442,7 +442,7 @@ function fm_register_submenu_page( $group_name, $parent_slug, $page_title, $menu
 	}
 	if ( isset( $submenus[ $group_name ] ) ) {
 		/* translators: %s: submenu group name */
-		throw new FM_Duplicate_Submenu_Name_Exception( sprintf( esc_html__( '`%s` is already in use as a submenu name.', 'fieldmanager' ), $group_name ) );
+		throw new FM_Duplicate_Submenu_Name_Exception( sprintf( esc_html__( '%s is already in use as a submenu name.', 'fieldmanager' ), "`{$group_name}`" ) );
 	}
 
 	if ( !$menu_title ) {

--- a/languages/fieldmanager.pot
+++ b/languages/fieldmanager.pot
@@ -1,0 +1,327 @@
+# Copyright (C) 2016 Austin Smith, Matthew Boynes
+# This file is distributed under the same license as the Fieldmanager package.
+msgid ""
+msgstr ""
+"Project-Id-Version: Fieldmanager 1.1.0-beta.1\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/fieldmanager\n"
+"POT-Creation-Date: 2016-12-31 06:54:43+00:00\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"X-Generator: grunt-wp-i18n 0.5.4\n"
+"X-Poedit-KeywordsList: "
+"__;_e;_x:1,2c;_ex:1,2c;_n:1,2;_nx:1,2,4c;_n_noop:1,2;_nx_noop:1,2,3c;esc_"
+"attr__;esc_html__;esc_attr_e;esc_html_e;esc_attr_x:1,2c;esc_html_x:1,2c;\n"
+"Language: en\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Poedit-Country: United States\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-Basepath: ../\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-Bookmarks: \n"
+"X-Textdomain-Support: yes\n"
+
+#: fieldmanager.php:457
+#. translators: %s: submenu group name
+msgid "%s is already in use as a submenu name."
+msgstr ""
+
+#: fieldmanager.php:485
+msgid "The Fieldmanger context for this submenu was not initialized."
+msgstr ""
+
+#: php/class-fieldmanager-autocomplete.php:67
+msgid "You must supply a datasource for the autocomplete field."
+msgstr ""
+
+#: php/class-fieldmanager-autocomplete.php:71
+msgid "No datasource."
+msgstr ""
+
+#: php/class-fieldmanager-checkbox.php:69
+msgid "Saved a checkbox with a value that was not one of the options."
+msgstr ""
+
+#: php/class-fieldmanager-draggablepost.php:130
+msgid "drop posts here"
+msgstr ""
+
+#: php/class-fieldmanager-draggablepost.php:168
+msgid "(no authors)"
+msgstr ""
+
+#: php/class-fieldmanager-field.php:338 php/class-fieldmanager-group.php:169
+#. translators: %s: `post_parent`
+msgid ""
+"A post can only have one parent, therefore you cannot store to %s in "
+"repeatable fields."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:374
+#: php/datasource/class-fieldmanager-datasource.php:65
+#. translators: 1: property name, 2: class name, 3: field name
+msgid ""
+"You attempted to set a property %1$s that is nonexistant or invalid for an "
+"instance of %2$s named %3$s."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:390 php/class-fieldmanager-group.php:159
+#: php/class-fieldmanager-group.php:314
+#. translators: 1: `'serialize_data' => false`, 2: `'index' => true`
+msgid "You cannot use %1$s with %2$s."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:742
+#. translators: 1: `$values`, 2: `$limit`, 3: `limit` property value
+msgid "%1$s should be an array because %2$s is %3$d."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:762
+#. translators: 1: count of submitted values, 2: `limit` property value
+msgid "Submitted %1$d values against a limit of %2$d."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:770
+msgid "Use of a non-numeric key suggests that something is wrong with this group."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:881
+#. translators: %s: `presave()`
+msgid "%s in the base class should not get arrays, but did."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:887 php/class-fieldmanager-options.php:217
+#. translators: 1: input name, 2: field label
+msgid "Input %1$s is not valid for field \"%2$s\"."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:945
+msgid "Add group"
+msgstr ""
+
+#: php/class-fieldmanager-field.php:945
+msgid "Add field"
+msgstr ""
+
+#: php/class-fieldmanager-field.php:967
+msgid "Move"
+msgstr ""
+
+#: php/class-fieldmanager-field.php:975 php/class-fieldmanager-media.php:96
+msgid "Remove"
+msgstr ""
+
+#: php/class-fieldmanager-field.php:1054
+msgid "This method requires WordPress 4.4 or above."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:1124
+msgid "You cannot use this method on a subgroup."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:1138
+msgid "Sorry, you're not supposed to do that..."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:1154
+msgid "You may be able to use your browser's back button to resolve this error."
+msgstr ""
+
+#: php/class-fieldmanager-field.php:1168
+msgid ""
+"Sorry, you've created an invalid field definition. Please check your code "
+"and try again."
+msgstr ""
+
+#: php/class-fieldmanager-grid.php:76
+msgid "Show Data Grid"
+msgstr ""
+
+#: php/class-fieldmanager-grid.php:77
+msgid "Hide Data Grid"
+msgstr ""
+
+#: php/class-fieldmanager-group.php:135 php/class-fieldmanager-group.php:187
+#. translators: %s: `'serialize_data' => false`
+msgid "You cannot use %s with repeating groups."
+msgstr ""
+
+#: php/class-fieldmanager-group.php:150
+#. translators: 1: group child name, 2: group child name
+msgid "Group child name conflict: %1$s / %2$s."
+msgstr ""
+
+#: php/class-fieldmanager-group.php:249
+msgid "More..."
+msgstr ""
+
+#: php/class-fieldmanager-group.php:334
+#. translators: %s: input name
+msgid "Found %s in data but not in children."
+msgstr ""
+
+#: php/class-fieldmanager-media.php:91
+msgid "Attach a File"
+msgstr ""
+
+#: php/class-fieldmanager-media.php:92
+msgid "Select Attachment"
+msgstr ""
+
+#: php/class-fieldmanager-media.php:93
+msgid "Choose an Attachment"
+msgstr ""
+
+#: php/class-fieldmanager-media.php:94
+msgid "Uploaded Image:"
+msgstr ""
+
+#: php/class-fieldmanager-media.php:95
+msgid "Uploaded File:"
+msgstr ""
+
+#: php/context/class-fieldmanager-context-page.php:44
+#: php/context/class-fieldmanager-context.php:43
+msgid "Nonce validation failed."
+msgstr ""
+
+#: php/context/class-fieldmanager-context-page.php:70
+msgid "Save Options"
+msgstr ""
+
+#: php/context/class-fieldmanager-context-post.php:200
+#: php/context/class-fieldmanager-context-quickedit.php:196
+msgid "Current user cannot edit this post."
+msgstr ""
+
+#: php/context/class-fieldmanager-context-quickedit.php:55
+msgid "You must set a valid column display callback."
+msgstr ""
+
+#: php/context/class-fieldmanager-context-storable.php:74
+#. translators: %s: field storage key
+msgid "You have two fields in this group saving to the same key: %s."
+msgstr ""
+
+#: php/context/class-fieldmanager-context-submenu.php:77
+msgid "Options updated."
+msgstr ""
+
+#: php/context/class-fieldmanager-context-submenu.php:137
+msgid "Current user cannot edit this page."
+msgstr ""
+
+#: php/context/class-fieldmanager-context-term.php:117
+#: php/context/class-fieldmanager-context-term.php:134
+#. translators: 1: `title`, 2: `taxonomies`, 3: `Fieldmanager_Context_Term`
+msgid "%1$s and %2$s are required values for %3$s."
+msgstr ""
+
+#: php/context/class-fieldmanager-context-term.php:233
+#. translators: %s: field name
+msgid "The field name %s is reserved for WordPress on the term form."
+msgstr ""
+
+#: php/context/class-fieldmanager-context-term.php:284
+msgid "Current user cannot edit this term."
+msgstr ""
+
+#: php/context/class-fieldmanager-context-user.php:75
+msgid "Current user cannot edit this user."
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource-post.php:221
+#. translators: 1: post type name, 2: post ID, 3: field name
+msgid "Tried to alter %1$s %2$d through field %3$s, which current user cannot edit."
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource-post.php:289
+#: php/datasource/class-fieldmanager-datasource-term.php:371
+msgid "View"
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource-post.php:303
+#: php/datasource/class-fieldmanager-datasource-term.php:386
+#: php/datasource/class-fieldmanager-datasource-user.php:256
+msgid "Edit"
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource-user.php:79
+#. translators: 1: invalid property name, 2: list of valid property names
+msgid "Store property %1$s is invalid. Must be one of %2$s."
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource-user.php:82
+#: php/datasource/class-fieldmanager-datasource-user.php:108
+#. translators: used between list items, there is a space after the comma
+msgid ", "
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource-user.php:94
+#. translators: 1: `Fieldmanager_Datasource_User`, 2: `store_property`, 3: `ID`
+msgid ""
+"You cannot use reciprocal relationships with %1$s if %2$s is not set to "
+"%3$s."
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource-user.php:105
+#. translators: 1: invalid property name, 2: list of valid property names
+msgid "Display property %1$s is invalid. Must be one of %2$s."
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource-user.php:227
+#. translators: %s: property name
+msgid "Tried to refer to user %s which current user cannot edit."
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource.php:68
+msgid "Nonexistant or invalid option."
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource.php:80
+#. translators: %s: `$options`
+msgid "Invalid datasource options; must use the %s parameter to supply an array."
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource.php:86
+msgid "Invalid datasource options."
+msgstr ""
+
+#: php/util/class-fieldmanager-util-term-meta.php:69
+msgid "Fieldmanager Term Metadata"
+msgstr ""
+
+#: php/util/class-fieldmanager-util-validation.php:139
+#: php/util/class-fieldmanager-util-validation.php:154
+#. translators: %s: validation rule name
+msgid "The validation rule %s does not exist."
+msgstr ""
+
+#. Plugin Name of the plugin/theme
+msgid "Fieldmanager"
+msgstr ""
+
+#. Plugin URI of the plugin/theme
+msgid "https://github.com/alleyinteractive/wordpress-fieldmanager"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid "Add fields to content types programatically."
+msgstr ""
+
+#. Author of the plugin/theme
+msgid "Austin Smith, Matthew Boynes"
+msgstr ""
+
+#. Author URI of the plugin/theme
+msgid "http://www.alleyinteractive.com/"
+msgstr ""
+
+#: php/datasource/class-fieldmanager-datasource-user.php:84
+#: php/datasource/class-fieldmanager-datasource-user.php:110
+msgctxt "property name like `user_nicename`"
+msgid "`%s`"
+msgstr ""

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-connect": "~0.11.0",
     "grunt-contrib-qunit": "~0.7.0",
-    "grunt-phpcs": "^0.4.0"
+    "grunt-phpcs": "^0.4.0",
+    "grunt-wp-i18n": "~0.5.0"
   }
 }

--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -64,11 +64,11 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 		fm_add_script( 'fm_autocomplete_js', 'js/fieldmanager-autocomplete.js', array( 'fieldmanager_script', 'jquery-ui-autocomplete' ), '1.0.6', false, 'fm_search', array( 'nonce' => wp_create_nonce( 'fm_search_nonce' ) ) );
 
 		if ( empty( $this->datasource ) ) {
-			$message = esc_html__( 'You must supply a datasource for the autocomplete field', 'fieldmanager' );
+			$message = esc_html__( 'You must supply a datasource for the autocomplete field.', 'fieldmanager' );
 			if ( Fieldmanager_Field::$debug ) {
 				throw new FM_Developer_Exception( $message );
 			} else {
-				wp_die( $message, esc_html__( 'No Datasource', 'fieldmanager' ) );
+				wp_die( $message, esc_html__( 'No datasource.', 'fieldmanager' ) );
 			}
 		}
 		$this->datasource->allow_optgroups = False;

--- a/php/class-fieldmanager-checkbox.php
+++ b/php/class-fieldmanager-checkbox.php
@@ -66,7 +66,7 @@ class Fieldmanager_Checkbox extends Fieldmanager_Field {
 			return $this->unchecked_value;
 		}
 		else {
-			$this->_unauthorized_access( __( 'Saved a checkbox with a value that was not one of the options', 'fieldmanager' ) );
+			$this->_unauthorized_access( __( 'Saved a checkbox with a value that was not one of the options.', 'fieldmanager' ) );
 		}
 	}
 }

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -334,7 +334,7 @@ abstract class Fieldmanager_Field {
 		// A post can only have one parent, so if this saves to post_parent and
 		// it's repeatable, we're doing it wrong.
 		if ( $this->datasource && ! empty( $this->datasource->save_to_post_parent ) && $this->is_repeatable() ) {
-			_doing_it_wrong( 'Fieldmanager_Datasource_Post::$save_to_post_parent', __( 'A post can only have one parent, therefore you cannot store to post_parent in repeatable fields.', 'fieldmanager' ), '1.0.0' );
+			_doing_it_wrong( 'Fieldmanager_Datasource_Post::$save_to_post_parent', __( 'A post can only have one parent, therefore you cannot store to `post_parent` in repeatable fields.', 'fieldmanager' ), '1.0.0' );
 			$this->datasource->save_to_post_parent = false;
 			$this->datasource->only_save_to_post_parent = false;
 		}
@@ -369,7 +369,7 @@ abstract class Fieldmanager_Field {
 				$this->$key = $value;
 			} elseif ( self::$debug ) {
 				$message = sprintf(
-					__( 'You attempted to set a property "%1$s" that is nonexistant or invalid for an instance of "%2$s" named "%3$s".', 'fieldmanager' ),
+					__( 'You attempted to set a property `%1$s` that is nonexistant or invalid for an instance of `%2$s` named `%3$s`.', 'fieldmanager' ),
 					$key, get_class( $this ), !empty( $options['name'] ) ? $options['name'] : 'NULL'
 				);
 				throw new FM_Developer_Exception( esc_html( $message ) );
@@ -383,7 +383,7 @@ abstract class Fieldmanager_Field {
 
 		// Cannot use serialize_data => false with index => true
 		if ( ! $this->serialize_data && $this->index ) {
-			throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with `"index" => true`', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with `"index" => true`.', 'fieldmanager' ) );
 		}
 	}
 
@@ -730,7 +730,7 @@ abstract class Fieldmanager_Field {
 				return;
 			}
 
-			$this->_unauthorized_access( sprintf( __( '$values should be an array because $limit is %d', 'fieldmanager' ), $this->limit ) );
+			$this->_unauthorized_access( sprintf( __( '`$values` should be an array because `$limit` is %d.', 'fieldmanager' ), $this->limit ) );
 		}
 
 		if ( empty( $values ) ) {
@@ -745,7 +745,7 @@ abstract class Fieldmanager_Field {
 		// If $this->limit is not 0 or 1, and $values has more than $limit, that could also be an attack...
 		if ( $this->limit > 1 && count( $values ) > $this->limit ) {
 			$this->_unauthorized_access(
-				sprintf( __( 'submitted %1$d values against a limit of %2$d', 'fieldmanager' ), count( $values ), $this->limit )
+				sprintf( __( 'Submitted %1$d values against a limit of %2$d.', 'fieldmanager' ), count( $values ), $this->limit )
 			);
 		}
 
@@ -863,12 +863,12 @@ abstract class Fieldmanager_Field {
 		// this point, but those elements must override this function. Let's
 		// make sure we're dealing with one value here.
 		if ( is_array( $value ) ) {
-			$this->_unauthorized_access( __( 'presave() in the base class should not get arrays, but did.', 'fieldmanager' ) );
+			$this->_unauthorized_access( __( '`presave()` in the base class should not get arrays, but did.', 'fieldmanager' ) );
 		}
 		foreach ( $this->validate as $func ) {
 			if ( !call_user_func( $func, $value ) ) {
 				$this->_failed_validation( sprintf(
-					__( 'Input "%1$s" is not valid for field "%2$s" ', 'fieldmanager' ),
+					__( 'Input `%1$s` is not valid for field `%2$s` ', 'fieldmanager' ),
 					(string) $value,
 					$this->label
 				) );
@@ -1035,7 +1035,7 @@ abstract class Fieldmanager_Field {
 	public function add_term_meta_box( $title, $taxonomies, $show_on_add = true, $show_on_edit = true, $parent = '' ) {
 		// Bail if term meta table is not installed.
 		if ( get_option( 'db_version' ) < 34370 ) {
-			_doing_it_wrong( __METHOD__, esc_html__( 'This method requires WordPress 4.4 or above', 'fieldmanager' ), 'Fieldmanager-1.0.0-beta.3' );
+			_doing_it_wrong( __METHOD__, esc_html__( 'This method requires WordPress 4.4 or above.', 'fieldmanager' ), 'Fieldmanager-1.0.0-beta.3' );
 			return false;
 		}
 
@@ -1105,7 +1105,7 @@ abstract class Fieldmanager_Field {
 
 	private function require_base() {
 		if ( !empty( $this->parent ) ) {
-			throw new FM_Developer_Exception( esc_html__( 'You cannot use this method on a subgroup', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html__( 'You cannot use this method on a subgroup.', 'fieldmanager' ) );
 		}
 	}
 

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -334,7 +334,8 @@ abstract class Fieldmanager_Field {
 		// A post can only have one parent, so if this saves to post_parent and
 		// it's repeatable, we're doing it wrong.
 		if ( $this->datasource && ! empty( $this->datasource->save_to_post_parent ) && $this->is_repeatable() ) {
-			_doing_it_wrong( 'Fieldmanager_Datasource_Post::$save_to_post_parent', __( 'A post can only have one parent, therefore you cannot store to `post_parent` in repeatable fields.', 'fieldmanager' ), '1.0.0' );
+			/* translators: %s: `post_parent` */
+			_doing_it_wrong( 'Fieldmanager_Datasource_Post::$save_to_post_parent', sprintf( __( 'A post can only have one parent, therefore you cannot store to %s in repeatable fields.', 'fieldmanager' ), '`post_parent`' ), '1.0.0' );
 			$this->datasource->save_to_post_parent = false;
 			$this->datasource->only_save_to_post_parent = false;
 		}
@@ -370,8 +371,8 @@ abstract class Fieldmanager_Field {
 			} elseif ( self::$debug ) {
 				$message = sprintf(
 					/* translators: 1: property name, 2: class name, 3: field name */
-					__( 'You attempted to set a property `%1$s` that is nonexistant or invalid for an instance of `%2$s` named `%3$s`.', 'fieldmanager' ),
-					$key, get_class( $this ), !empty( $options['name'] ) ? $options['name'] : 'NULL'
+					__( 'You attempted to set a property %1$s that is nonexistant or invalid for an instance of %2$s named %3$s.', 'fieldmanager' ),
+					"`{$key}`", '`' . get_class( $this ) . '`', ! empty( $options['name'] ) ? "`{$options['name']}`" : '`NULL`'
 				);
 				throw new FM_Developer_Exception( esc_html( $message ) );
 			}
@@ -384,7 +385,12 @@ abstract class Fieldmanager_Field {
 
 		// Cannot use serialize_data => false with index => true
 		if ( ! $this->serialize_data && $this->index ) {
-			throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with `"index" => true`.', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html( sprintf(
+				/* translators: 1: `'serialize_data' => false`, 2: `'index' => true` */
+				__( 'You cannot use %1$s with %2$s.', 'fieldmanager' ),
+				"`'serialize_data' => false`",
+				"`'index' => true`"
+			) ) );
 		}
 	}
 
@@ -731,8 +737,13 @@ abstract class Fieldmanager_Field {
 				return;
 			}
 
-			/* translators: %d: `limit` property value */
-			$this->_unauthorized_access( sprintf( __( '`$values` should be an array because `$limit` is %d.', 'fieldmanager' ), $this->limit ) );
+			/* translators: 1: `$values`, 2: `$limit`, 3: `limit` property value */
+			$this->_unauthorized_access( sprintf(
+				__( '%1$s should be an array because %2$s is %3$d.', 'fieldmanager' ),
+				'`$values`',
+				'`$limit`',
+				$this->limit
+			) );
 		}
 
 		if ( empty( $values ) ) {
@@ -866,14 +877,15 @@ abstract class Fieldmanager_Field {
 		// this point, but those elements must override this function. Let's
 		// make sure we're dealing with one value here.
 		if ( is_array( $value ) ) {
-			$this->_unauthorized_access( __( '`presave()` in the base class should not get arrays, but did.', 'fieldmanager' ) );
+			/* translators: %s: `presave()` */
+			$this->_unauthorized_access( sprintf( __( '%s in the base class should not get arrays, but did.', 'fieldmanager' ), '`presave()`' ) );
 		}
 		foreach ( $this->validate as $func ) {
 			if ( !call_user_func( $func, $value ) ) {
 				$this->_failed_validation( sprintf(
 					/* translators: 1: input name, 2: field label */
-					__( 'Input `%1$s` is not valid for field `%2$s`.', 'fieldmanager' ),
-					(string) $value,
+					__( 'Input %1$s is not valid for field "%2$s".', 'fieldmanager' ),
+					'`' . (string) $value . '`',
 					$this->label
 				) );
 			}

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -868,7 +868,7 @@ abstract class Fieldmanager_Field {
 		foreach ( $this->validate as $func ) {
 			if ( !call_user_func( $func, $value ) ) {
 				$this->_failed_validation( sprintf(
-					__( 'Input `%1$s` is not valid for field `%2$s` ', 'fieldmanager' ),
+					__( 'Input `%1$s` is not valid for field `%2$s`', 'fieldmanager' ),
 					(string) $value,
 					$this->label
 				) );

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -868,7 +868,7 @@ abstract class Fieldmanager_Field {
 		foreach ( $this->validate as $func ) {
 			if ( !call_user_func( $func, $value ) ) {
 				$this->_failed_validation( sprintf(
-					__( 'Input `%1$s` is not valid for field `%2$s`', 'fieldmanager' ),
+					__( 'Input `%1$s` is not valid for field `%2$s`.', 'fieldmanager' ),
 					(string) $value,
 					$this->label
 				) );

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -369,6 +369,7 @@ abstract class Fieldmanager_Field {
 				$this->$key = $value;
 			} elseif ( self::$debug ) {
 				$message = sprintf(
+					/* translators: 1: property name, 2: class name, 3: field name */
 					__( 'You attempted to set a property `%1$s` that is nonexistant or invalid for an instance of `%2$s` named `%3$s`.', 'fieldmanager' ),
 					$key, get_class( $this ), !empty( $options['name'] ) ? $options['name'] : 'NULL'
 				);
@@ -730,6 +731,7 @@ abstract class Fieldmanager_Field {
 				return;
 			}
 
+			/* translators: %d: `limit` property value */
 			$this->_unauthorized_access( sprintf( __( '`$values` should be an array because `$limit` is %d.', 'fieldmanager' ), $this->limit ) );
 		}
 
@@ -745,6 +747,7 @@ abstract class Fieldmanager_Field {
 		// If $this->limit is not 0 or 1, and $values has more than $limit, that could also be an attack...
 		if ( $this->limit > 1 && count( $values ) > $this->limit ) {
 			$this->_unauthorized_access(
+				/* translators: 1: count of submitted values, 2: `limit` property value */
 				sprintf( __( 'Submitted %1$d values against a limit of %2$d.', 'fieldmanager' ), count( $values ), $this->limit )
 			);
 		}
@@ -868,6 +871,7 @@ abstract class Fieldmanager_Field {
 		foreach ( $this->validate as $func ) {
 			if ( !call_user_func( $func, $value ) ) {
 				$this->_failed_validation( sprintf(
+					/* translators: 1: input name, 2: field label */
 					__( 'Input `%1$s` is not valid for field `%2$s`.', 'fieldmanager' ),
 					(string) $value,
 					$this->label

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -130,7 +130,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		// Repeatable groups cannot used unserialized data
 		$is_repeatable = ( 1 != $this->limit );
 		if ( ! $this->serialize_data && $is_repeatable ) {
-			throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with repeating groups', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with repeating groups.', 'fieldmanager' ) );
 		}
 
 		// If this is collapsed, collapsibility is implied
@@ -142,20 +142,20 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		foreach ( $this->children as $name => $element ) {
 			// if the array key is not an int, and the name attr is set, and they don't match, we got a problem.
 			if ( $element->name && !is_int( $name ) && $element->name != $name ) {
-				throw new FM_Developer_Exception( esc_html__( 'Group child name conflict: ', 'fieldmanager' ) . $name . ' / ' . $element->name );
+				throw new FM_Developer_Exception( sprintf( esc_html__( 'Group child name conflict: `%1$s` / `%2$s`.', 'fieldmanager' ), $name, $element->name ) );
 			} elseif ( ! $element->name ) {
 				$element->name = $name;
 			}
 
 			// Catch errors when using serialize_data => false and index => true
 			if ( ! $this->serialize_data && $element->index ) {
-				throw new FM_Developer_Exception( esc_html__( 'You cannot use `serialize_data => false` with `index => true`', 'fieldmanager' ) );
+				throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with `"index" => true`.', 'fieldmanager' ) );
 			}
 
 			// A post can only have one parent, so if this saves to post_parent and
 			// it's repeatable, we're doing it wrong.
 			if ( $element->datasource && ! empty( $element->datasource->save_to_post_parent ) && $this->is_repeatable() ) {
-				_doing_it_wrong( 'Fieldmanager_Datasource_Post::$save_to_post_parent', __( 'A post can only have one parent, therefore you cannot store to post_parent in repeatable fields.', 'fieldmanager' ), '1.0.0' );
+				_doing_it_wrong( 'Fieldmanager_Datasource_Post::$save_to_post_parent', __( 'A post can only have one parent, therefore you cannot store to `post_parent` in repeatable fields.', 'fieldmanager' ), '1.0.0' );
 				$element->datasource->save_to_post_parent = false;
 				$element->datasource->only_save_to_post_parent = false;
 			}
@@ -171,7 +171,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 
 		// Check for invalid usage of repeatables and serialize_data
 		if ( $is_repeatable && $this->has_unserialized_descendants ) {
-			throw new FM_Developer_Exception( esc_html__( 'You cannot use `serialize_data => false` with repeating groups', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with repeating groups.', 'fieldmanager' ) );
 		}
 
 		// Add the tab JS and CSS if it is needed
@@ -294,7 +294,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 
 		// Catch errors when using serialize_data => false and index-> true
 		if ( ! $this->serialize_data && $child->index ) {
-			throw new FM_Developer_Exception( esc_html__( 'You cannot use `serialize_data => false` with `index => true`', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with `"index" => true`.', 'fieldmanager' ) );
 		}
 	}
 
@@ -310,7 +310,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 				if ( !isset( $this->children[$key] ) ) {
 					// If we're here, it means that the input, generally $_POST, contains a value that doesn't belong,
 					// and thus one which we cannot sanitize and must not save. This might be an attack.
-					$this->_unauthorized_access( sprintf( __( 'Found "%1$s" in data but not in children', 'fieldmanager' ), $key ) );
+					$this->_unauthorized_access( sprintf( __( 'Found `%s` in data but not in children.', 'fieldmanager' ), $key ) );
 				}
 			}
 		}

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -142,6 +142,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		foreach ( $this->children as $name => $element ) {
 			// if the array key is not an int, and the name attr is set, and they don't match, we got a problem.
 			if ( $element->name && !is_int( $name ) && $element->name != $name ) {
+				/* translators: 1: group child name, 2: group child name */
 				throw new FM_Developer_Exception( sprintf( esc_html__( 'Group child name conflict: `%1$s` / `%2$s`.', 'fieldmanager' ), $name, $element->name ) );
 			} elseif ( ! $element->name ) {
 				$element->name = $name;
@@ -310,6 +311,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 				if ( !isset( $this->children[$key] ) ) {
 					// If we're here, it means that the input, generally $_POST, contains a value that doesn't belong,
 					// and thus one which we cannot sanitize and must not save. This might be an attack.
+					/* translators: %s: input name */
 					$this->_unauthorized_access( sprintf( __( 'Found `%s` in data but not in children.', 'fieldmanager' ), $key ) );
 				}
 			}

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -130,7 +130,11 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		// Repeatable groups cannot used unserialized data
 		$is_repeatable = ( 1 != $this->limit );
 		if ( ! $this->serialize_data && $is_repeatable ) {
-			throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with repeating groups.', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html( sprintf(
+				/* translators: %s: `'serialize_data' => false` */
+				__( 'You cannot use %s with repeating groups.', 'fieldmanager' ),
+				"`'serialize_data' => false`"
+			) ) );
 		}
 
 		// If this is collapsed, collapsibility is implied
@@ -143,20 +147,26 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 			// if the array key is not an int, and the name attr is set, and they don't match, we got a problem.
 			if ( $element->name && !is_int( $name ) && $element->name != $name ) {
 				/* translators: 1: group child name, 2: group child name */
-				throw new FM_Developer_Exception( sprintf( esc_html__( 'Group child name conflict: `%1$s` / `%2$s`.', 'fieldmanager' ), $name, $element->name ) );
+				throw new FM_Developer_Exception( sprintf( esc_html__( 'Group child name conflict: %1$s / %2$s.', 'fieldmanager' ), "`{$name}`", "`{$element->name}`" ) );
 			} elseif ( ! $element->name ) {
 				$element->name = $name;
 			}
 
 			// Catch errors when using serialize_data => false and index => true
 			if ( ! $this->serialize_data && $element->index ) {
-				throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with `"index" => true`.', 'fieldmanager' ) );
+				throw new FM_Developer_Exception( esc_html( sprintf(
+					/* translators: 1: `'serialize_data' => false`, 2: `'index' => true` */
+					__( 'You cannot use %1$s with %2$s.', 'fieldmanager' ),
+					"`'serialize_data' => false`",
+					"`'index' => true`"
+				) ) );
 			}
 
 			// A post can only have one parent, so if this saves to post_parent and
 			// it's repeatable, we're doing it wrong.
 			if ( $element->datasource && ! empty( $element->datasource->save_to_post_parent ) && $this->is_repeatable() ) {
-				_doing_it_wrong( 'Fieldmanager_Datasource_Post::$save_to_post_parent', __( 'A post can only have one parent, therefore you cannot store to `post_parent` in repeatable fields.', 'fieldmanager' ), '1.0.0' );
+				/* translators: %s: `post_parent` */
+				_doing_it_wrong( 'Fieldmanager_Datasource_Post::$save_to_post_parent', sprintf( __( 'A post can only have one parent, therefore you cannot store to %s in repeatable fields.', 'fieldmanager' ), '`post_parent`' ), '1.0.0' );
 				$element->datasource->save_to_post_parent = false;
 				$element->datasource->only_save_to_post_parent = false;
 			}
@@ -172,7 +182,11 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 
 		// Check for invalid usage of repeatables and serialize_data
 		if ( $is_repeatable && $this->has_unserialized_descendants ) {
-			throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with repeating groups.', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html( sprintf(
+				/* translators: %s: `'serialize_data' => false` */
+				__( 'You cannot use %s with repeating groups.', 'fieldmanager' ),
+				"`'serialize_data' => false`"
+			) ) );
 		}
 
 		// Add the tab JS and CSS if it is needed
@@ -295,7 +309,12 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 
 		// Catch errors when using serialize_data => false and index-> true
 		if ( ! $this->serialize_data && $child->index ) {
-			throw new FM_Developer_Exception( esc_html__( 'You cannot use `"serialize_data" => false` with `"index" => true`.', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html( sprintf(
+				/* translators: 1: `'serialize_data' => false`, 2: `'index' => true` */
+				__( 'You cannot use %1$s with %2$s.', 'fieldmanager' ),
+				"`'serialize_data' => false`",
+				"`'index' => true`"
+			) ) );
 		}
 	}
 
@@ -312,7 +331,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 					// If we're here, it means that the input, generally $_POST, contains a value that doesn't belong,
 					// and thus one which we cannot sanitize and must not save. This might be an attack.
 					/* translators: %s: input name */
-					$this->_unauthorized_access( sprintf( __( 'Found `%s` in data but not in children.', 'fieldmanager' ), $key ) );
+					$this->_unauthorized_access( sprintf( __( 'Found %s in data but not in children.', 'fieldmanager' ), "`{$key}`" ) );
 				}
 			}
 		}

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -91,9 +91,9 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 		$this->button_label         = __( 'Attach a File', 'fieldmanager' );
 		$this->modal_button_label   = __( 'Select Attachment', 'fieldmanager' );
 		$this->modal_title          = __( 'Choose an Attachment', 'fieldmanager' );
-		$this->selected_image_label = __( 'Uploaded image:', 'fieldmanager' );
-		$this->selected_file_label  = __( 'Uploaded file:', 'fieldmanager' );
-		$this->remove_media_label   = __( 'remove', 'fieldmanager' );
+		$this->selected_image_label = __( 'Uploaded Image:', 'fieldmanager' );
+		$this->selected_file_label  = __( 'Uploaded File:', 'fieldmanager' );
+		$this->remove_media_label   = __( 'Remove', 'fieldmanager' );
 
 		if ( ! self::$has_registered_media ) {
 			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), '1.0.4' );

--- a/php/class-fieldmanager-options.php
+++ b/php/class-fieldmanager-options.php
@@ -213,7 +213,7 @@ abstract class Fieldmanager_Options extends Fieldmanager_Field {
 		foreach ( $this->validate as $func ) {
 			if ( !call_user_func( $func, $value ) ) {
 				$this->_failed_validation( sprintf(
-					__( 'Input "%1$s" is not valid for field "%2$s" ', 'fieldmanager' ),
+					__( 'Input `%1$s` is not valid for field `%2$s`.', 'fieldmanager' ),
 					(string) $value,
 					$this->label
 				) );

--- a/php/class-fieldmanager-options.php
+++ b/php/class-fieldmanager-options.php
@@ -213,6 +213,7 @@ abstract class Fieldmanager_Options extends Fieldmanager_Field {
 		foreach ( $this->validate as $func ) {
 			if ( !call_user_func( $func, $value ) ) {
 				$this->_failed_validation( sprintf(
+					/* translators: 1: input name, 2: field label */
 					__( 'Input `%1$s` is not valid for field `%2$s`.', 'fieldmanager' ),
 					(string) $value,
 					$this->label

--- a/php/class-fieldmanager-options.php
+++ b/php/class-fieldmanager-options.php
@@ -214,8 +214,8 @@ abstract class Fieldmanager_Options extends Fieldmanager_Field {
 			if ( !call_user_func( $func, $value ) ) {
 				$this->_failed_validation( sprintf(
 					/* translators: 1: input name, 2: field label */
-					__( 'Input `%1$s` is not valid for field `%2$s`.', 'fieldmanager' ),
-					(string) $value,
+					__( 'Input %1$s is not valid for field "%2$s".', 'fieldmanager' ),
+					'`' . (string) $value . '`',
 					$this->label
 				) );
 			}

--- a/php/context/class-fieldmanager-context-page.php
+++ b/php/context/class-fieldmanager-context-page.php
@@ -41,7 +41,7 @@ class Fieldmanager_Context_Page extends Fieldmanager_Context {
 	 */
 	public function save_page_form() {
 		if( !wp_verify_nonce( $_POST['fieldmanager-' . $this->fm->name . '-nonce'], 'fieldmanager-save-' . $this->fm->name ) ) {
-			$this->fm->_unauthorized_access( __( 'Nonce validation failed', 'fieldmanager' ) );
+			$this->fm->_unauthorized_access( __( 'Nonce validation failed.', 'fieldmanager' ) );
 		}
 		$this->fm->data_id = $user_id;
 		$value = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : "";

--- a/php/context/class-fieldmanager-context-post.php
+++ b/php/context/class-fieldmanager-context-post.php
@@ -197,7 +197,7 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context_Storable {
 		// Make sure the current user is authorized to save this post.
 		if ( $_POST['post_type'] == 'post' ) {
 			if ( ! current_user_can( 'edit_post', $post_id ) ) {
-				$this->fm->_unauthorized_access( __( 'User cannot edit this post', 'fieldmanager' ) );
+				$this->fm->_unauthorized_access( __( 'Current user cannot edit this post.', 'fieldmanager' ) );
 				return;
 			}
 		}

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -193,7 +193,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 		// Make sure the current user can save this post
 		if( $_POST['post_type'] == 'post' ) {
 			if( !current_user_can( 'edit_post', $post_id ) ) {
-				$this->fm->_unauthorized_access( __( 'User cannot edit this post', 'fieldmanager' ) );
+				$this->fm->_unauthorized_access( __( 'Current user cannot edit this post.', 'fieldmanager' ) );
 				return;
 			}
 		}

--- a/php/context/class-fieldmanager-context-storable.php
+++ b/php/context/class-fieldmanager-context-storable.php
@@ -70,7 +70,7 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 		$field->data_type = $this->fm->data_type;
 
 		if ( isset( $this->save_keys[ $field->get_element_key() ] ) ) {
-			throw new FM_Developer_Exception( sprintf( esc_html__( 'You have two fields in this group saving to the same key: %s', 'fieldmanager' ), $field->get_element_key() ) );
+			throw new FM_Developer_Exception( sprintf( esc_html__( 'You have two fields in this group saving to the same key: `%s`.', 'fieldmanager' ), $field->get_element_key() ) );
 		} else {
 			$this->save_keys[ $field->get_element_key() ] = true;
 		}

--- a/php/context/class-fieldmanager-context-storable.php
+++ b/php/context/class-fieldmanager-context-storable.php
@@ -70,6 +70,7 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 		$field->data_type = $this->fm->data_type;
 
 		if ( isset( $this->save_keys[ $field->get_element_key() ] ) ) {
+			/* translators: %s: field storage key */
 			throw new FM_Developer_Exception( sprintf( esc_html__( 'You have two fields in this group saving to the same key: `%s`.', 'fieldmanager' ), $field->get_element_key() ) );
 		} else {
 			$this->save_keys[ $field->get_element_key() ] = true;

--- a/php/context/class-fieldmanager-context-storable.php
+++ b/php/context/class-fieldmanager-context-storable.php
@@ -71,7 +71,7 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 
 		if ( isset( $this->save_keys[ $field->get_element_key() ] ) ) {
 			/* translators: %s: field storage key */
-			throw new FM_Developer_Exception( sprintf( esc_html__( 'You have two fields in this group saving to the same key: `%s`.', 'fieldmanager' ), $field->get_element_key() ) );
+			throw new FM_Developer_Exception( sprintf( esc_html__( 'You have two fields in this group saving to the same key: %s.', 'fieldmanager' ), "`{$field->get_element_key()}`" ) );
 		} else {
 			$this->save_keys[ $field->get_element_key() ] = true;
 		}

--- a/php/context/class-fieldmanager-context-submenu.php
+++ b/php/context/class-fieldmanager-context-submenu.php
@@ -74,7 +74,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 		$this->parent_slug = $parent_slug;
 		$this->page_title = $page_title;
 		$this->capability = $capability;
-		$this->updated_message = __( 'Options updated', 'fieldmanager' );
+		$this->updated_message = __( 'Options updated.', 'fieldmanager' );
 		$this->uniqid = $this->fm->get_element_id() . '_form';
 		if ( ! $already_registered )  {
 			add_action( 'admin_menu', array( $this, 'register_submenu_page' ) );
@@ -134,7 +134,7 @@ class Fieldmanager_Context_Submenu extends Fieldmanager_Context_Storable {
 		}
 
 		if ( ! current_user_can( $this->capability ) ) {
-			$this->fm->_unauthorized_access( __( 'Current user cannot edit this page', 'fieldmanager' ) );
+			$this->fm->_unauthorized_access( __( 'Current user cannot edit this page.', 'fieldmanager' ) );
 			return;
 		}
 

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -217,6 +217,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context_Storable {
 	public function term_fields( $html_template, $taxonomy, $term = null ) {
 		// Make sure the user hasn't specified a field name we can't use
 		if ( in_array( $this->fm->name, $this->reserved_fields ) ) {
+			/* translators: %s: field name */
 			$this->fm->_invalid_definition( sprintf( __( 'The field name `%s` is reserved for WordPress on the term form.', 'fieldmanager' ), $this->fm->name ) );
 		}
 

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -112,7 +112,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context_Storable {
 				'field'        => null,
 			) );
 			if ( ! isset( $args['title'], $args['taxonomies'] ) ) {
-				throw new FM_Developer_Exception( esc_html__( '"title" and "taxonomies" are required values for Fieldmanager_Context_Term', 'fieldmanager' ) );
+				throw new FM_Developer_Exception( esc_html__( '`title` and `taxonomies` are required values for `Fieldmanager_Context_Term`.', 'fieldmanager' ) );
 			}
 
 			$this->title        = $args['title'];
@@ -123,7 +123,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context_Storable {
 			$this->use_fm_meta  = $args['use_fm_meta'];
 			$this->fm           = $args['field'];
 		} elseif ( empty( $taxonomies ) ) {
-			throw new FM_Developer_Exception( esc_html__( '"title" and "taxonomies" are required values for Fieldmanager_Context_Term', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html__( '`title` and `taxonomies` are required values for `Fieldmanager_Context_Term`.', 'fieldmanager' ) );
 		} else {
 			// Instantiating Fieldmanager_Context_Term using individual
 			// arguments is deprecated as of Fieldmanager-1.0.0-beta.3; you
@@ -217,7 +217,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context_Storable {
 	public function term_fields( $html_template, $taxonomy, $term = null ) {
 		// Make sure the user hasn't specified a field name we can't use
 		if ( in_array( $this->fm->name, $this->reserved_fields ) ) {
-			$this->fm->_invalid_definition( sprintf( __( 'The field name "%s" is reserved for WordPress on the term form.', 'fieldmanager' ), $this->fm->name ) );
+			$this->fm->_invalid_definition( sprintf( __( 'The field name `%s` is reserved for WordPress on the term form.', 'fieldmanager' ), $this->fm->name ) );
 		}
 
 		// Set the data type and ID
@@ -268,7 +268,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context_Storable {
 		// Make sure the current user can save this post
 		$tax_obj = get_taxonomy( $taxonomy );
 		if ( ! current_user_can( $tax_obj->cap->manage_terms ) ) {
-			$this->fm->_unauthorized_access( __( 'User cannot edit this term', 'fieldmanager' ) );
+			$this->fm->_unauthorized_access( __( 'Current user cannot edit this term.', 'fieldmanager' ) );
 			return;
 		}
 

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -112,7 +112,13 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context_Storable {
 				'field'        => null,
 			) );
 			if ( ! isset( $args['title'], $args['taxonomies'] ) ) {
-				throw new FM_Developer_Exception( esc_html__( '`title` and `taxonomies` are required values for `Fieldmanager_Context_Term`.', 'fieldmanager' ) );
+				throw new FM_Developer_Exception( esc_html( sprintf(
+					/* translators: 1: `title`, 2: `taxonomies`, 3: `Fieldmanager_Context_Term` */
+					__( '%1$s and %2$s are required values for %3$s.', 'fieldmanager' ),
+					'`title`',
+					'`taxonomies`',
+					'`Fieldmanager_Context_Term`'
+				) ) );
 			}
 
 			$this->title        = $args['title'];
@@ -123,7 +129,13 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context_Storable {
 			$this->use_fm_meta  = $args['use_fm_meta'];
 			$this->fm           = $args['field'];
 		} elseif ( empty( $taxonomies ) ) {
-			throw new FM_Developer_Exception( esc_html__( '`title` and `taxonomies` are required values for `Fieldmanager_Context_Term`.', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( esc_html( sprintf(
+				/* translators: 1: `title`, 2: `taxonomies`, 3: `Fieldmanager_Context_Term` */
+				__( '%1$s and %2$s are required values for %3$s.', 'fieldmanager' ),
+				'`title`',
+				'`taxonomies`',
+				'`Fieldmanager_Context_Term`'
+			) ) );
 		} else {
 			// Instantiating Fieldmanager_Context_Term using individual
 			// arguments is deprecated as of Fieldmanager-1.0.0-beta.3; you
@@ -218,7 +230,7 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context_Storable {
 		// Make sure the user hasn't specified a field name we can't use
 		if ( in_array( $this->fm->name, $this->reserved_fields ) ) {
 			/* translators: %s: field name */
-			$this->fm->_invalid_definition( sprintf( __( 'The field name `%s` is reserved for WordPress on the term form.', 'fieldmanager' ), $this->fm->name ) );
+			$this->fm->_invalid_definition( sprintf( __( 'The field name %s is reserved for WordPress on the term form.', 'fieldmanager' ), "`{$this->fm->name}`" ) );
 		}
 
 		// Set the data type and ID

--- a/php/context/class-fieldmanager-context-user.php
+++ b/php/context/class-fieldmanager-context-user.php
@@ -72,7 +72,7 @@ class Fieldmanager_Context_User extends Fieldmanager_Context_Storable {
 		}
 
 		if ( ! current_user_can( 'edit_user', $user_id ) ) {
-			$this->fm->_unauthorized_access( __( 'Current user cannot edit this user', 'fieldmanager' ) );
+			$this->fm->_unauthorized_access( __( 'Current user cannot edit this user.', 'fieldmanager' ) );
 			return;
 		}
 

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -40,7 +40,7 @@ abstract class Fieldmanager_Context {
 		}
 
 		if ( ! wp_verify_nonce( $_POST['fieldmanager-' . $this->fm->name . '-nonce'], 'fieldmanager-save-' . $this->fm->name ) ) {
-			$this->fm->_unauthorized_access( __( 'Nonce validation failed', 'fieldmanager' ) );
+			$this->fm->_unauthorized_access( __( 'Nonce validation failed.', 'fieldmanager' ) );
 		}
 
 		return true;

--- a/php/datasource/class-fieldmanager-datasource-post.php
+++ b/php/datasource/class-fieldmanager-datasource-post.php
@@ -217,7 +217,7 @@ class Fieldmanager_Datasource_Post extends Fieldmanager_Datasource {
             if ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) {
                 $post_type_obj = get_post_type_object( get_post_type( $value ) );
                 if ( empty( $post_type_obj->cap->edit_post ) || ! current_user_can( $post_type_obj->cap->edit_post, $value ) ) {
-                    wp_die( esc_html( sprintf( __( 'Tried to alter %s %d through field "%s", which user is not permitted to edit.', 'fieldmanager' ), $post_type_obj->name, $value, $field->name ) ) );
+                    wp_die( esc_html( sprintf( __( 'Tried to alter `%1$s` %2$d through field `%3$s`, which current user cannot edit.', 'fieldmanager' ), $post_type_obj->name, $value, $field->name ) ) );
                 }
             }
             $this->presave_status_transition( $field, $value );

--- a/php/datasource/class-fieldmanager-datasource-post.php
+++ b/php/datasource/class-fieldmanager-datasource-post.php
@@ -217,7 +217,7 @@ class Fieldmanager_Datasource_Post extends Fieldmanager_Datasource {
             if ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) {
                 $post_type_obj = get_post_type_object( get_post_type( $value ) );
                 if ( empty( $post_type_obj->cap->edit_post ) || ! current_user_can( $post_type_obj->cap->edit_post, $value ) ) {
-                	/* translators: 1: post type name, 2: post ID, 3: field name */
+                    /* translators: 1: post type name, 2: post ID, 3: field name */
                     wp_die( esc_html( sprintf( __( 'Tried to alter %1$s %2$d through field %3$s, which current user cannot edit.', 'fieldmanager' ), "`{$post_type_obj->name}`", $value, "`{$field->name}`" ) ) );
                 }
             }

--- a/php/datasource/class-fieldmanager-datasource-post.php
+++ b/php/datasource/class-fieldmanager-datasource-post.php
@@ -217,6 +217,7 @@ class Fieldmanager_Datasource_Post extends Fieldmanager_Datasource {
             if ( ! defined( 'DOING_CRON' ) || ! DOING_CRON ) {
                 $post_type_obj = get_post_type_object( get_post_type( $value ) );
                 if ( empty( $post_type_obj->cap->edit_post ) || ! current_user_can( $post_type_obj->cap->edit_post, $value ) ) {
+                	/* translators: 1: post type name, 2: post ID, 3: field name */
                     wp_die( esc_html( sprintf( __( 'Tried to alter `%1$s` %2$d through field `%3$s`, which current user cannot edit.', 'fieldmanager' ), $post_type_obj->name, $value, $field->name ) ) );
                 }
             }

--- a/php/datasource/class-fieldmanager-datasource-post.php
+++ b/php/datasource/class-fieldmanager-datasource-post.php
@@ -218,7 +218,7 @@ class Fieldmanager_Datasource_Post extends Fieldmanager_Datasource {
                 $post_type_obj = get_post_type_object( get_post_type( $value ) );
                 if ( empty( $post_type_obj->cap->edit_post ) || ! current_user_can( $post_type_obj->cap->edit_post, $value ) ) {
                 	/* translators: 1: post type name, 2: post ID, 3: field name */
-                    wp_die( esc_html( sprintf( __( 'Tried to alter `%1$s` %2$d through field `%3$s`, which current user cannot edit.', 'fieldmanager' ), $post_type_obj->name, $value, $field->name ) ) );
+                    wp_die( esc_html( sprintf( __( 'Tried to alter %1$s %2$d through field %3$s, which current user cannot edit.', 'fieldmanager' ), "`{$post_type_obj->name}`", $value, "`{$field->name}`" ) ) );
                 }
             }
             $this->presave_status_transition( $field, $value );

--- a/php/datasource/class-fieldmanager-datasource-user.php
+++ b/php/datasource/class-fieldmanager-datasource-user.php
@@ -76,8 +76,8 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
 		if ( ! in_array( $this->store_property, $this->allowed_store_properties ) ) {
 			throw new FM_Developer_Exception( sprintf(
 				/* translators: 1: invalid property name, 2: list of valid property names */
-				__( 'Store property `%1$s` is invalid. Must be one of %2$s.', 'fieldmanager' ),
-				$this->store_property,
+				__( 'Store property %1$s is invalid. Must be one of %2$s.', 'fieldmanager' ),
+				"`{$this->store_property}`",
 				/* translators: used between list items, there is a space after the comma */
 				implode( __( ', ', 'fieldmanager' ), array_map(
 					function ( $property ) {
@@ -89,15 +89,21 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
 		}
 
 		if ( ! empty( $this->reciprocal ) && 'ID' != $this->store_property ) {
-			throw new FM_Developer_Exception( __( 'You cannot use reciprocal relationships with `Fieldmanager_Datasource_User` if `store_property` is not set to `ID`.', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( sprintf(
+				/* translators: 1: `Fieldmanager_Datasource_User`, 2: `store_property`, 3: `ID` */
+				__( 'You cannot use reciprocal relationships with %1$s if %2$s is not set to %3$s.', 'fieldmanager' ),
+				'`Fieldmanager_Datasource_User`',
+				'`store_property`',
+				'`ID`'
+			) );
 		}
 
 		// Validate improper usage of display property
 		if ( ! in_array( $this->display_property, $this->allowed_display_properties ) ) {
 			throw new FM_Developer_Exception( sprintf(
 				/* translators: 1: invalid property name, 2: list of valid property names */
-				__( 'Display property `%1$s` is invalid. Must be one of %2$s.', 'fieldmanager' ),
-				$this->display_property,
+				__( 'Display property %1$s is invalid. Must be one of %2$s.', 'fieldmanager' ),
+				"`{$this->display_property}`",
 				/* translators: used between list items, there is a space after the comma */
 				implode( __( ', ', 'fieldmanager' ), array_map(
 					function ( $property ) {
@@ -218,7 +224,7 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
             $value[$i] = $this->sanitize_value( $v );
             if( ! current_user_can( $this->capability, $v ) ) {
             	/* translators: %s: property name */
-                wp_die( esc_html( sprintf( __( 'Tried to refer to user `%s` which current user cannot edit.', 'fieldmanager' ), $v ) ) );
+                wp_die( esc_html( sprintf( __( 'Tried to refer to user %s which current user cannot edit.', 'fieldmanager' ), "`{$v}`" ) ) );
             }
             if ( $this->reciprocal && 'ID' == $this->store_property ) {
                 add_user_meta( $v, $this->reciprocal, $field->data_id );

--- a/php/datasource/class-fieldmanager-datasource-user.php
+++ b/php/datasource/class-fieldmanager-datasource-user.php
@@ -75,22 +75,32 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
 		// Validate improper usage of store property
 		if ( ! in_array( $this->store_property, $this->allowed_store_properties ) ) {
 			throw new FM_Developer_Exception( sprintf(
-				__( 'Store property %s is invalid. Must be one of %s.', 'fieldmanager' ),
+				__( 'Store property `%1$s` is invalid. Must be one of %2$s.', 'fieldmanager' ),
 				$this->store_property,
-				implode( ', ', $this->allowed_store_properties )
+				implode( __( ', ', 'fieldmanager' ), array_map(
+					function ( $property ) {
+						return sprintf( _x( '`%s`', 'property name like `user_nicename`', 'fieldmanager' ), $property );
+					},
+					$this->allowed_store_properties
+				) )
 			) );
 		}
 
 		if ( ! empty( $this->reciprocal ) && 'ID' != $this->store_property ) {
-			throw new FM_Developer_Exception( __( 'You cannot use reciprocal relationships with FM_Datasource_User if store_property is not set to ID.', 'fieldmanager' ) );
+			throw new FM_Developer_Exception( __( 'You cannot use reciprocal relationships with `Fieldmanager_Datasource_User` if `store_property` is not set to `ID`.', 'fieldmanager' ) );
 		}
 
 		// Validate improper usage of display property
 		if ( ! in_array( $this->display_property, $this->allowed_display_properties ) ) {
 			throw new FM_Developer_Exception( sprintf(
-				__( 'Display property %s is invalid. Must be one of %s.', 'fieldmanager' ),
+				__( 'Display property `%1$s` is invalid. Must be one of %2$s.', 'fieldmanager' ),
 				$this->display_property,
-				implode( ', ', $this->allowed_display_properties )
+				implode( __( ', ', 'fieldmanager' ), array_map(
+					function ( $property ) {
+						return sprintf( _x( '`%s`', 'property name like `user_nicename`', 'fieldmanager' ), $property );
+					},
+					$this->allowed_display_properties
+				) )
 			) );
 		}
 	}
@@ -203,7 +213,7 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
         foreach ( $value as $i => $v ) {
             $value[$i] = $this->sanitize_value( $v );
             if( ! current_user_can( $this->capability, $v ) ) {
-                wp_die( esc_html( sprintf( __( 'Tried to refer to user "%s" which current user cannot edit.', 'fieldmanager' ), $v ) ) );
+                wp_die( esc_html( sprintf( __( 'Tried to refer to user `%s` which current user cannot edit.', 'fieldmanager' ), $v ) ) );
             }
             if ( $this->reciprocal && 'ID' == $this->store_property ) {
                 add_user_meta( $v, $this->reciprocal, $field->data_id );

--- a/php/datasource/class-fieldmanager-datasource-user.php
+++ b/php/datasource/class-fieldmanager-datasource-user.php
@@ -75,8 +75,10 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
 		// Validate improper usage of store property
 		if ( ! in_array( $this->store_property, $this->allowed_store_properties ) ) {
 			throw new FM_Developer_Exception( sprintf(
+				/* translators: 1: invalid property name, 2: list of valid property names */
 				__( 'Store property `%1$s` is invalid. Must be one of %2$s.', 'fieldmanager' ),
 				$this->store_property,
+				/* translators: used between list items, there is a space after the comma */
 				implode( __( ', ', 'fieldmanager' ), array_map(
 					function ( $property ) {
 						return sprintf( _x( '`%s`', 'property name like `user_nicename`', 'fieldmanager' ), $property );
@@ -93,8 +95,10 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
 		// Validate improper usage of display property
 		if ( ! in_array( $this->display_property, $this->allowed_display_properties ) ) {
 			throw new FM_Developer_Exception( sprintf(
+				/* translators: 1: invalid property name, 2: list of valid property names */
 				__( 'Display property `%1$s` is invalid. Must be one of %2$s.', 'fieldmanager' ),
 				$this->display_property,
+				/* translators: used between list items, there is a space after the comma */
 				implode( __( ', ', 'fieldmanager' ), array_map(
 					function ( $property ) {
 						return sprintf( _x( '`%s`', 'property name like `user_nicename`', 'fieldmanager' ), $property );
@@ -213,6 +217,7 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
         foreach ( $value as $i => $v ) {
             $value[$i] = $this->sanitize_value( $v );
             if( ! current_user_can( $this->capability, $v ) ) {
+            	/* translators: %s: property name */
                 wp_die( esc_html( sprintf( __( 'Tried to refer to user `%s` which current user cannot edit.', 'fieldmanager' ), $v ) ) );
             }
             if ( $this->reciprocal && 'ID' == $this->store_property ) {

--- a/php/datasource/class-fieldmanager-datasource.php
+++ b/php/datasource/class-fieldmanager-datasource.php
@@ -61,6 +61,7 @@ class Fieldmanager_Datasource {
 				else throw new FM_Developer_Exception; // If the property isn't public, don't set it (rare)
 			} catch ( Exception $e ) {
 				$message = sprintf(
+					/* translators: 1: property name, 2: class name, 3: field name */
 					__( 'You attempted to set a property `%1$s` that is nonexistant or invalid for an instance of `%2$s` named `%3$s`.', 'fieldmanager' ),
 					$k, __CLASS__, !empty( $options['name'] ) ? $options['name'] : 'NULL'
 				);

--- a/php/datasource/class-fieldmanager-datasource.php
+++ b/php/datasource/class-fieldmanager-datasource.php
@@ -62,8 +62,8 @@ class Fieldmanager_Datasource {
 			} catch ( Exception $e ) {
 				$message = sprintf(
 					/* translators: 1: property name, 2: class name, 3: field name */
-					__( 'You attempted to set a property `%1$s` that is nonexistant or invalid for an instance of `%2$s` named `%3$s`.', 'fieldmanager' ),
-					$k, __CLASS__, !empty( $options['name'] ) ? $options['name'] : 'NULL'
+					__( 'You attempted to set a property %1$s that is nonexistant or invalid for an instance of %2$s named %3$s.', 'fieldmanager' ),
+					"`{$k}`", '`' . __CLASS__ . '`', ! empty( $options['name'] ) ? "`{$options['name']}`" : '`NULL`'
 				);
 				$title = esc_html__( 'Nonexistant or invalid option.' );
 				if ( !Fieldmanager_Field::$debug ) {
@@ -75,7 +75,11 @@ class Fieldmanager_Datasource {
 		}
 
 		if ( get_class( $this ) == __CLASS__ && empty( $options ) ) {
-			$message = esc_html__( 'Invalid datasource options; must use the `$options` parameter to supply an array.', 'fieldmanager' );
+			$message = esc_html( sprintf(
+				/* translators: %s: `$options` */
+				__( 'Invalid datasource options; must use the %s parameter to supply an array.', 'fieldmanager' ),
+				'`$options`'
+			) );
 			if ( Fieldmanager_Field::$debug ) {
 				throw new FM_Developer_Exception( $message );
 			} else {

--- a/php/datasource/class-fieldmanager-datasource.php
+++ b/php/datasource/class-fieldmanager-datasource.php
@@ -61,10 +61,10 @@ class Fieldmanager_Datasource {
 				else throw new FM_Developer_Exception; // If the property isn't public, don't set it (rare)
 			} catch ( Exception $e ) {
 				$message = sprintf(
-					__( 'You attempted to set a property "%1$s" that is nonexistant or invalid for an instance of "%2$s" named "%3$s".', 'fieldmanager' ),
+					__( 'You attempted to set a property `%1$s` that is nonexistant or invalid for an instance of `%2$s` named `%3$s`.', 'fieldmanager' ),
 					$k, __CLASS__, !empty( $options['name'] ) ? $options['name'] : 'NULL'
 				);
-				$title = esc_html__( 'Nonexistant or invalid option' );
+				$title = esc_html__( 'Nonexistant or invalid option.' );
 				if ( !Fieldmanager_Field::$debug ) {
 					wp_die( esc_html( $message ), $title );
 				} else {
@@ -74,11 +74,11 @@ class Fieldmanager_Datasource {
 		}
 
 		if ( get_class( $this ) == __CLASS__ && empty( $options ) ) {
-			$message = esc_html__( 'Invalid options for Datasource; must use the options parameter to supply an array.', 'fieldmanager' );
+			$message = esc_html__( 'Invalid datasource options; must use the `$options` parameter to supply an array.', 'fieldmanager' );
 			if ( Fieldmanager_Field::$debug ) {
 				throw new FM_Developer_Exception( $message );
 			} else {
-				wp_die( $message, esc_html__( 'Invalid Datasource Options', 'fieldmanager' ) );
+				wp_die( $message, esc_html__( 'Invalid datasource options.', 'fieldmanager' ) );
 			}
 		}
 

--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -135,7 +135,7 @@ class Fieldmanager_Util_Validation {
 		if ( ! is_array( $fm->validation_rules ) ) {
 			// If a string, the only acceptable value is "required".
 			if ( ! is_string( $fm->validation_rules ) || $fm->validation_rules != 'required' )
-				$fm->_invalid_definition( sprintf( __( 'The validation rule "%s" does not exist.', 'wordpress-fieldmanager' ), $fm->validation_rules ) );
+				$fm->_invalid_definition( sprintf( __( 'The validation rule `%s` does not exist.', 'wordpress-fieldmanager' ), $fm->validation_rules ) );
 
 			// Convert the value to an array since we standardize the Javascript output on this format
 			$fm->validation_rules = array( 'required' => true );
@@ -149,7 +149,7 @@ class Fieldmanager_Util_Validation {
 			foreach ( $fm->validation_rules as $validation_key => $validation_rule ) {
 				if ( ! in_array( $validation_key, $this->valid_rules ) ) {
 					// This is not a rule available in jQuery validation
-					$fm->_invalid_definition( sprintf( __( 'The validation rule "%s" does not exist.', 'wordpress-fieldmanager' ), $validation_key ) );
+					$fm->_invalid_definition( sprintf( __( 'The validation rule `%s` does not exist.', 'wordpress-fieldmanager' ), $validation_key ) );
 				} else {
 					// This rule is valid so check for any messages
 					if ( isset( $fm->validation_messages[$validation_key] ) )

--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -135,7 +135,8 @@ class Fieldmanager_Util_Validation {
 		if ( ! is_array( $fm->validation_rules ) ) {
 			// If a string, the only acceptable value is "required".
 			if ( ! is_string( $fm->validation_rules ) || $fm->validation_rules != 'required' )
-				$fm->_invalid_definition( sprintf( __( 'The validation rule `%s` does not exist.', 'wordpress-fieldmanager' ), $fm->validation_rules ) );
+				/* translators: %s: validation rule name */
+				$fm->_invalid_definition( sprintf( __( 'The validation rule `%s` does not exist.', 'fieldmanager' ), $fm->validation_rules ) );
 
 			// Convert the value to an array since we standardize the Javascript output on this format
 			$fm->validation_rules = array( 'required' => true );
@@ -149,7 +150,8 @@ class Fieldmanager_Util_Validation {
 			foreach ( $fm->validation_rules as $validation_key => $validation_rule ) {
 				if ( ! in_array( $validation_key, $this->valid_rules ) ) {
 					// This is not a rule available in jQuery validation
-					$fm->_invalid_definition( sprintf( __( 'The validation rule `%s` does not exist.', 'wordpress-fieldmanager' ), $validation_key ) );
+					/* translators: %s: validation rule name */
+					$fm->_invalid_definition( sprintf( __( 'The validation rule `%s` does not exist.', 'fieldmanager' ), $validation_key ) );
 				} else {
 					// This rule is valid so check for any messages
 					if ( isset( $fm->validation_messages[$validation_key] ) )

--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -136,7 +136,7 @@ class Fieldmanager_Util_Validation {
 			// If a string, the only acceptable value is "required".
 			if ( ! is_string( $fm->validation_rules ) || $fm->validation_rules != 'required' )
 				/* translators: %s: validation rule name */
-				$fm->_invalid_definition( sprintf( __( 'The validation rule `%s` does not exist.', 'fieldmanager' ), $fm->validation_rules ) );
+				$fm->_invalid_definition( sprintf( __( 'The validation rule %s does not exist.', 'fieldmanager' ), "`{$fm->validation_rules}`" ) );
 
 			// Convert the value to an array since we standardize the Javascript output on this format
 			$fm->validation_rules = array( 'required' => true );
@@ -151,7 +151,7 @@ class Fieldmanager_Util_Validation {
 				if ( ! in_array( $validation_key, $this->valid_rules ) ) {
 					// This is not a rule available in jQuery validation
 					/* translators: %s: validation rule name */
-					$fm->_invalid_definition( sprintf( __( 'The validation rule `%s` does not exist.', 'fieldmanager' ), $validation_key ) );
+					$fm->_invalid_definition( sprintf( __( 'The validation rule %s does not exist.', 'fieldmanager' ), "`{$validation_key}`" ) );
 				} else {
 					// This rule is valid so check for any messages
 					if ( isset( $fm->validation_messages[$validation_key] ) )


### PR DESCRIPTION
This aims to improve Fieldmanager's readiness for translation, such as the Italian translation by @enrico-sorcinelli in #508, and address issues raised in that PR and by PHPCS.

The changes here include:

- Edits to strings (36fc58f).
- Ordering multiple placeholders.
- Adding translator comments (c7f2688, a132972).
- Adding a `.pot` file via `grunt-wp-i18n` (1d07126) and a call to `load_plugin_textdomain()` (cef2b3f).
- Using placeholders for untranslatable strings, particularly strings of code (c138f47). I'm uncertain about whether this change is helpful, but I tried to mirror similar changes to `<code>` tags in core (e.g. https://core.trac.wordpress.org/changeset/39254, https://core.trac.wordpress.org/changeset/35548).
