### PR TITLE
Remove reference to undefined $user_id in Fieldmanager_Context_Page::save_page_form()

### DIFF
--- a/php/context/class-fieldmanager-context-page.php
+++ b/php/context/class-fieldmanager-context-page.php
@@ -43,7 +43,6 @@ class Fieldmanager_Context_Page extends Fieldmanager_Context {
 		if( !wp_verify_nonce( $_POST['fieldmanager-' . $this->fm->name . '-nonce'], 'fieldmanager-save-' . $this->fm->name ) ) {
 			$this->fm->_unauthorized_access( __( 'Nonce validation failed', 'fieldmanager' ) );
 		}
-		$this->fm->data_id = $user_id;
 		$value = isset( $_POST[ $this->fm->name ] ) ? $_POST[ $this->fm->name ] : "";
 		if ( empty( $this->fm->data_type ) ) $this->fm->data_type = 'page';
 		if ( empty( $this->fm->data_id ) ) $this->fm->data_id = $this->uniqid;


### PR DESCRIPTION
When calling `Fieldmanager_Context_Page::save_page_form()`, a notice is
thrown for the undefined `$user_id` variable. There's no need for
accessing a user ID here.