### PR TITLE
Define Composer package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
       "email": "noreply@alleyinteractive.com"
     }
   ],
+  "type": "wordpress-plugin",
   "require-dev": {
     "squizlabs/php_codesniffer": "2.3.4",
     "wp-coding-standards/wpcs": "0.8.0"


### PR DESCRIPTION
This allows users to easily manage this plugin as a Composer dependency.

https://roots.io/wordpress-plugins-with-composer/