### PR TITLE
Allow using display-if with an arbitrary selector

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,8 +24,8 @@ module.exports = function( grunt ) {
 				options: {
 					urls: [
 						'http://localhost:8000/tests/js/index.html',
-						'http://localhost:8000/tests/js/index.html?wp=4.6',
-						'http://localhost:8000/tests/js/index.html?wp=4.5'
+						'http://localhost:8000/tests/js/index.html?wp=4.8',
+						'http://localhost:8000/tests/js/index.html?wp=4.7'
 					]
 				}
 			},

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -200,13 +200,20 @@ $( document ).ready( function () {
 
 	// Initializes triggers to conditionally hide or show fields
 	fm.init_display_if = function() {
-		var val;
-		var src = $( this ).data( 'display-src' );
-		var values = getCompareValues( this );
-		// Wrapper divs sometimes receive .fm-element, but don't use them as
-		// triggers. Also don't use autocomplete inputs as triggers, because the
-		// value is in their sibling hidden fields (which this still matches).
-		var trigger = $( this ).siblings( '.fm-' + src + '-wrapper' ).find( '.fm-element' ).not( 'div, .fm-autocomplete' );
+		var val, src, values, trigger;
+
+		src = $( this ).data( 'display-src' );
+
+		if ( src ) {
+			// Wrapper divs sometimes receive .fm-element, but don't use them as
+			// triggers. Also don't use autocomplete inputs as triggers, because the
+			// value is in their sibling hidden fields (which this still matches).
+			trigger = $( this ).siblings( '.fm-' + src + '-wrapper' ).find( '.fm-element' ).not( 'div, .fm-autocomplete' );
+		} else {
+			trigger = $( $( this ).data( 'display-selector' ) );
+		}
+
+		values = getCompareValues( this );
 
 		// Sanity check before calling `val()` or `split()`.
 		if ( 0 === trigger.length ) {
@@ -218,8 +225,10 @@ $( document ).ready( function () {
 				// If checked, use the checkbox value.
 				val = trigger.val();
 			} else {
-				// Otherwise, use the hidden sibling field with the "unchecked" value.
-				val = trigger.siblings( 'input[type=hidden][name="' + trigger.attr( 'name' ) + '"]' ).val();
+				if ( src ) {
+					// Otherwise, use the hidden sibling field with the "unchecked" value.
+					val = trigger.siblings( 'input[type=hidden][name="' + trigger.attr( 'name' ) + '"]' ).val();
+				}
 			}
 		} else if ( trigger.is( ':radio' ) ) {
 			if ( trigger.filter( ':checked' ).length ) {
@@ -240,32 +249,49 @@ $( document ).ready( function () {
 
 	// Controls the trigger to show or hide fields
 	fm.trigger_display_if = function() {
-		var val;
-		var $this = $( this );
-		var name = $this.attr( 'name' );
-		if ( $this.is( ':checkbox' ) ) {
-			if ( $this.is( ':checked' ) ) {
-				val = $this.val();
-			} else {
-				val = $this.siblings( 'input[type=hidden][name="' + name + '"]' ).val();
+		var val, $trigger, name, $closestFmWrapper, affectedFields;
+
+		$trigger = $( this );
+		name = $trigger.attr( 'name' );
+		$closestFmWrapper = $trigger.closest( '.fm-wrapper' );
+
+		if ( $trigger.is( ':checkbox' ) ) {
+			if ( $trigger.is( ':checked' ) ) {
+				val = $trigger.val();
+			} else if ( $closestFmWrapper.length ) {
+				// Assume an FM wrapper indicates this hidden checkbox value exists.
+				val = $trigger.siblings( 'input[type=hidden][name="' + name + '"]' ).val();
 			}
-		} else if ( $this.is( ':radio' ) ) {
-			val = $this.filter( ':checked' ).val();
+		} else if ( $trigger.is( ':radio' ) ) {
+			val = $trigger.filter( ':checked' ).val();
 		} else {
-			val = $this.val().split( ',' );
+			val = $trigger.val().split( ',' );
 		}
-		$( this ).closest( '.fm-wrapper' ).siblings().each( function() {
+
+		affectedFields = [];
+
+		$closestFmWrapper.siblings().each( function() {
 			if ( $( this ).hasClass( 'display-if' ) ) {
 				if ( name && name.match( $( this ).data( 'display-src' ) ) != null ) {
-					if ( match_value( getCompareValues( this ), val ) ) {
-						$( this ).show();
-					} else {
-						$( this ).hide();
-					}
-					$( this ).trigger( 'fm_displayif_toggle' );
+					affectedFields.push( this );
 				}
 			}
 		} );
+
+		$( '[data-display-selector]' ).each(function ( index, field ) {
+			if ( $trigger.is( $( field ).data( 'display-selector' ) ) ) {
+				affectedFields.push( field );
+			}
+		});
+
+		affectedFields.forEach(function ( field ) {
+			if ( match_value( getCompareValues( field ), val ) ) {
+				$( field ).show();
+			} else {
+				$( field ).hide();
+			}
+			$( field ).trigger( 'fm_displayif_toggle' );
+		});
 	};
 	$( document ).on( 'change', '.display-trigger', fm.trigger_display_if );
 

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -285,12 +285,15 @@ $( document ).ready( function () {
 		});
 
 		affectedFields.forEach(function ( field ) {
+			var $field = $( field );
+
 			if ( match_value( getCompareValues( field ), val ) ) {
-				$( field ).show();
+				$field.show();
 			} else {
-				$( field ).hide();
+				$field.hide();
 			}
-			$( field ).trigger( 'fm_displayif_toggle' );
+
+			$field.trigger( 'fm_displayif_toggle' );
 		});
 	};
 	$( document ).on( 'change', '.display-trigger', fm.trigger_display_if );

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "Fieldmanager",
   "description": "Fieldmanager is a comprehensive toolkit for building forms, metaboxes, and custom admin screens for WordPress.",
   "version": "1.1.0-beta.1",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/alleyinteractive/wordpress-fieldmanager"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alleyinteractive/wordpress-fieldmanager"
   },
   "license": "GPL-2.0",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-connect": "~0.11.0",
-    "grunt-contrib-qunit": "~0.7.0",
+    "grunt-contrib-qunit": "~1.3.0",
     "grunt-phpcs": "^0.4.0"
   }
 }

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -203,18 +203,29 @@ abstract class Fieldmanager_Field {
 	public $datasource = Null;
 
 	/**
-	 * @var array[]
 	 * Field name and value on which to display element. Sample:
+	 *
 	 * $element->display_if = array(
-	 *	'src' => 'display-if-src-element',
-	 *	'value' => 'display-if-src-value'
+	 *     'src' => 'display-if-src-element',
+	 *     'value' => 'display-if-src-value',
 	 * );
 	 *
-	 * Multiple values are allowed if comma-separated. Sample:
+	 * Multiple values are allowed if they're comma-separated. Sample:
+	 *
 	 * $element->display_if = array(
-	 *	'src' => 'display-if-src-element',
-	 *	'value' => 'display-if-src-value1,display-if-src-value2'
+	 *     'src' => 'display-if-src-element',
+	 *     'value' => 'display-if-src-value1,display-if-src-value2',
 	 * );
+	 *
+	 * Use a selector instead of `src` to show or hide the field based on the
+	 * value of elements matching the selector. Sample:
+	 *
+	 * $element->display_if = array(
+	 *     'selector' => '#page_template',
+	 *     'value' => 'my-page-template.php',
+	 * );
+	 *
+	 * @var array
 	 */
 	public $display_if = array();
 
@@ -452,9 +463,29 @@ abstract class Fieldmanager_Field {
 		}
 
 		// Checks to see if element has display_if data values, and inserts the data attributes if it does
-		if ( isset( $this->display_if ) && !empty( $this->display_if ) ) {
+		if ( ! empty( $this->display_if ) ) {
 			$classes[] = 'display-if';
-			$fm_wrapper_attrs['data-display-src'] = $this->display_if['src'];
+
+			if ( isset( $this->display_if['src'] ) && isset( $this->display_if['selector'] ) ) {
+				throw new \FM_Developer_Exception(
+					esc_html( sprintf(
+						/* translators: 1: 'display-if', 2: `src`, 3: `selector` */
+						__( 'A field cannot have both a %1$s %2$s and a %1$s %3$s', 'fieldmanager' ),
+						'`$display_if`',
+						'`src`',
+						'`selector`'
+					) )
+				);
+			}
+
+			if ( isset( $this->display_if['src'] ) ) {
+				$fm_wrapper_attrs['data-display-src'] = $this->display_if['src'];
+			}
+
+			if ( isset( $this->display_if['selector'] ) ) {
+				$fm_wrapper_attrs['data-display-selector'] = $this->display_if['selector'];
+			}
+
 			$fm_wrapper_attrs['data-display-value'] = $this->display_if['value'];
 		}
 		$fm_wrapper_attr_string = '';

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -209,6 +209,12 @@ abstract class Fieldmanager_Field {
 	 *	'src' => 'display-if-src-element',
 	 *	'value' => 'display-if-src-value'
 	 * );
+	 *
+	 * Multiple values are allowed if comma-separated. Sample:
+	 * $element->display_if = array(
+	 *	'src' => 'display-if-src-element',
+	 *	'value' => 'display-if-src-value1,display-if-src-value2'
+	 * );
 	 */
 	public $display_if = array();
 

--- a/tests/js/index.html
+++ b/tests/js/index.html
@@ -130,6 +130,11 @@
 			<div id="di-when-displayif-radio-b" class="display-if" data-display-src="test-displayif-radio" data-display-value="b">Display when radio is "b"</div>
 		</div>
 
+		<div id="displayif-selector">
+			<input id="test-displayif-selector" class="display-trigger" value="" />
+			<div id="di-show-when-selector-is-b" class="display-if" data-display-selector="#test-displayif-selector" data-display-value="b">Display when element with custom selector is "b"</div>
+		</div>
+
 		<!-- This markup should also not cause a TypeError -->
 		<div id="displayif-zerolength">
 			<div id="di-when-trigger-length-is-zero" class="fm-test-displayif-zerolength-wrapper"></div>

--- a/tests/js/test-fieldmanager.js
+++ b/tests/js/test-fieldmanager.js
@@ -89,6 +89,15 @@
 		$( '.fm-test-displayif-radio' ).find( 'input[value=c]' ).prop( 'checked', true ).trigger( 'change' );
 		assert.notOk( $( '#di-when-displayif-radio-b:visible' ).length, "hide 'b' when 'c' selected" );
 
+		// Test the field that is hidden or shown based on a selector.
+		assert.notOk( $( '#di-show-when-selector-is-b:visible' ).length, "hide 'b' when custom selector is ''" );
+		$( '#test-displayif-selector' ).val( 'a' ).trigger( 'change' );
+		assert.notOk( $( '#di-show-when-selector-is-b:visible' ).length, "hide 'b' when custom selector is 'a'" );
+		$( '#test-displayif-selector' ).val( 'b' ).trigger( 'change' );
+		assert.ok( $( '#di-show-when-selector-is-b:visible' ).length, "show 'b' when custom selector is 'b'" );
+		$( '#test-displayif-selector' ).val( 'c' ).trigger( 'change' );
+		assert.notOk( $( '#di-show-when-selector-is-b:visible' ).length, "hide 'b' when custom selector is 'c'" );
+
 		// Test when a wrapper has a class that qualifies as a display trigger but has no eligible siblings.
 		assert.ok( ! $( '#di-when-trigger-length-is-zero' ).hasClass( 'display-trigger' ) );
 	});


### PR DESCRIPTION
For example, to control whether a field displays based on the selected page template:

```
$fm = new \Fieldmanager_TextField( [
	'name' => 'my_template_specific_field',
	'display_if' => [
		'selector' => '#page_template',
		'value' => 'my-page-template.php',
	],
] );
$fm->add_meta_box( 'Page Template-Specific Field', fm_get_context()[1] );
```

The assumed use case with this approach is for controlling field visibility based on only one other element. If `selector` matches multiple elements, the resulting behavior would be unpredictable because the field would toggle based on the last-changed element.

Also brings in the nearby changes from #619.