### PR TITLE
Test against PHP 7.1 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 matrix:
   include:
     - php: 5.3
-      env: WP_VERSION=4.4.4
+      env: WP_VERSION=4.4.11
       dist: precise
     - php: 5.3
       env: WP_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,13 +12,19 @@ matrix:
       dist: precise
     - php: 5.6
       env: WP_VERSION=latest
-    - php: 7.1
-      env: WP_VERSION=latest
-    - php: 5.6
-      env: WP_VERSION=nightly
     - php: 5.6
       env: WP_TRAVISCI=phpcs
+    - php: 7.0
+      env: WP_VERSION=latest
+    - php: 7.0
+      env: WP_VERSION=nightly
+    - php: 7.1
+      env: WP_VERSION=latest
+    - php: 7.2
+      env: WP_VERSION=latest
   fast_finish: true
+  allow_failures:
+    - php: 7.2
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       dist: precise
     - php: 5.6
       env: WP_VERSION=latest
-    - php: 7.0
+    - php: 7.1
       env: WP_VERSION=latest
     - php: 5.6
       env: WP_VERSION=nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ branches:
     - master
 
 before_script:
+  # Turn off Xdebug. See https://core.trac.wordpress.org/changeset/40138.
+  - phpenv config-rm xdebug.ini || echo "Xdebug not available"
+
   - |
     if [[ ! -z "$WP_VERSION" ]] ; then
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION


### PR DESCRIPTION
WordPress core has not allowed its tests to fail on PHP 7.1 [since December 2016](https://core.trac.wordpress.org/changeset/39424). Accordingly, this requires Fieldmanager to run against 7.1 per the reasoning in #462.