### PR TITLE
Compare field display-if value against all checked `Fieldmanager_Checkboxes`

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,8 +24,8 @@ module.exports = function( grunt ) {
 				options: {
 					urls: [
 						'http://localhost:8000/tests/js/index.html',
-						'http://localhost:8000/tests/js/index.html?wp=4.6',
-						'http://localhost:8000/tests/js/index.html?wp=4.5'
+						'http://localhost:8000/tests/js/index.html?wp=4.8',
+						'http://localhost:8000/tests/js/index.html?wp=4.7'
 					]
 				}
 			},

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -134,9 +134,9 @@ var getCompareValues = function( el ) {
 	return values;
 };
 
-var match_value = function( values, match_string ) {
+var match_value = function( values, matchArr ) {
 	for ( var index in values ) {
-		if ( values[index] == match_string ) {
+		if ( matchArr.indexOf( String( values[ index ] ) ) !== -1 ) {
 			return true;
 		}
 	}
@@ -200,13 +200,14 @@ $( document ).ready( function () {
 
 	// Initializes triggers to conditionally hide or show fields
 	fm.init_display_if = function() {
-		var val;
+		var val = [];
 		var src = $( this ).data( 'display-src' );
 		var values = getCompareValues( this );
 		// Wrapper divs sometimes receive .fm-element, but don't use them as
 		// triggers. Also don't use autocomplete inputs as triggers, because the
 		// value is in their sibling hidden fields (which this still matches).
 		var trigger = $( this ).siblings( '.fm-' + src + '-wrapper' ).find( '.fm-element' ).not( 'div, .fm-autocomplete' );
+		var $checkboxGroup;
 
 		// Sanity check before calling `val()` or `split()`.
 		if ( 0 === trigger.length ) {
@@ -214,19 +215,28 @@ $( document ).ready( function () {
 		}
 
 		if ( trigger.is( ':checkbox' ) ) {
-			if ( trigger.is( ':checked' ) ) {
+			$checkboxGroup = trigger.parents( '.fm-checkbox-group' );
+
+			if ( $checkboxGroup.length ) {
+				val = $checkboxGroup
+					.find( '.fm-element[type=checkbox]:checked' )
+					.map(function () {
+						return this.value;
+					})
+					.toArray();
+			} else if ( trigger.is( ':checked' ) ) {
 				// If checked, use the checkbox value.
-				val = trigger.val();
+				val.push( trigger.val() );
 			} else {
 				// Otherwise, use the hidden sibling field with the "unchecked" value.
-				val = trigger.siblings( 'input[type=hidden][name="' + trigger.attr( 'name' ) + '"]' ).val();
+				val.push( trigger.siblings( 'input[type=hidden][name="' + trigger.attr( 'name' ) + '"]' ).val() );
 			}
 		} else if ( trigger.is( ':radio' ) ) {
 			if ( trigger.filter( ':checked' ).length ) {
-				val = trigger.filter( ':checked' ).val();
+				val.push( trigger.filter( ':checked' ).val() );
 			} else {
 				// On load, there might not be any selected radio, in which case call the value blank.
-				val = '';
+				val.push( '' );
 			}
 		} else {
 			val = trigger.val().split( ',' );
@@ -240,17 +250,28 @@ $( document ).ready( function () {
 
 	// Controls the trigger to show or hide fields
 	fm.trigger_display_if = function() {
-		var val;
+		var val = [];
 		var $this = $( this );
 		var name = $this.attr( 'name' );
+		var $checkboxGroup;
+
 		if ( $this.is( ':checkbox' ) ) {
-			if ( $this.is( ':checked' ) ) {
-				val = $this.val();
+			$checkboxGroup = $this.parents( '.fm-checkbox-group' );
+
+			if ( $checkboxGroup.length ) {
+				val = $checkboxGroup
+					.find( '.fm-element[type=checkbox]:checked' )
+					.map(function () {
+						return this.value;
+					})
+					.toArray();
+			} else if ( $this.is( ':checked' ) ) {
+				val.push( $this.val() );
 			} else {
-				val = $this.siblings( 'input[type=hidden][name="' + name + '"]' ).val();
+				val.push( $this.siblings( 'input[type=hidden][name="' + name + '"]' ).val() );
 			}
 		} else if ( $this.is( ':radio' ) ) {
-			val = $this.filter( ':checked' ).val();
+			val.push( $this.filter( ':checked' ).val() );
 		} else {
 			val = $this.val().split( ',' );
 		}
@@ -262,6 +283,7 @@ $( document ).ready( function () {
 					} else {
 						$( this ).hide();
 					}
+
 					$( this ).trigger( 'fm_displayif_toggle' );
 				}
 			}

--- a/tests/js/index.html
+++ b/tests/js/index.html
@@ -100,7 +100,7 @@
 		<div id="displayif-boolean-checkbox">
 			<div class="fm-wrapper fm-test-boolean-checkbox-wrapper">
 				<div class="fm-item fm-test-boolean-checkbox fm-element">
-					<input type="hidden" name="test-boolean-checkbox" value="">
+					<input type="hidden" name="test-boolean-checkbox" value="0">
 					<input class="fm-element display-trigger" type="checkbox" name="test-boolean-checkbox" value="1">
 				</div>
 			</div>


### PR DESCRIPTION
Fixes #498. There is a related bug at play, which is that the `match_string` parameter in `match_value()` is sometimes passed an array, which leads to `==` comparisons against the array instead of a string. This PR would make the parameter an array in all cases.