### PR TITLE
Fix issues with only_save_to_taxonomy

### DIFF
--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -145,7 +145,7 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 
 			// If not found, bail out.
 			if ( empty( $terms ) || is_wp_error( $terms ) ) {
-				return [];
+				return array();
 			}
 
 			// Attempt to sort the list by term_order.

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -143,8 +143,13 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 			$taxonomies = $this->get_taxonomies();
 			$terms = get_the_terms( $field->data_id, $taxonomies[0] );
 
+			// If not found, bail out.
+			if ( empty( $terms ) || is_wp_error( $terms ) ) {
+				return [];
+			}
+
 			// Attempt to sort the list by term_order.
-			$terms = usort( $terms, array( $this, 'sort_terms' ) );
+			usort( $terms, array( $this, 'sort_terms' ) );
 
 			if ( count( $terms ) > 0 ) {
 				if ( 1 == $field->limit && empty( $field->multiple ) ) {


### PR DESCRIPTION
When `$only_save_to_taxonomy` is set to true, some errors can occur. `get_the_terms()` can return false when creating a new post. This (when passed to `usort()` throws an error since it's not an array.

We should not use the return value of  `usort() ` as it sorts the array by reference.