### PR TITLE
Use `sanitize_post_field()` to sanitize RichTextAreas

### DIFF
--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -116,7 +116,8 @@ class Fieldmanager_RichTextArea extends Fieldmanager_Field {
 	 * @return string sanitized content.
 	 */
 	public function sanitize( $value ) {
-		return wp_filter_post_kses( wpautop( $value ) ); // run through wpautop first to preserve breaks.
+		// Run through wpautop first to preserve breaks.
+		return sanitize_post_field( 'post_content', wpautop( $value ), 0, 'db' );
 	}
 
 	/**

--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -112,6 +112,8 @@ class Fieldmanager_RichTextArea extends Fieldmanager_Field {
 	/**
 	 * Default sanitization function for RichTextAreas.
 	 *
+	 * @since 1.2.0 Uses `sanitize_post_field()` by default.
+	 *
 	 * @param  string $value Raw content for this field.
 	 * @return string sanitized content.
 	 */


### PR DESCRIPTION
Fixes #231, but with a heavy hammer.

`sanitize_post_field()` as called here eventually applies the `'content_save_pre'` filter to the passed value. `wp_filter_post_kses()` is conditionally hooked to `'content_save_pre'` based on whether the user has the `'unfiltered_html'` capability (see `kses_init()`).

However, `sanitize_post_field()` as called here also passes the value through every other filter and function that the `'post_content'` field is passed through. That would be more processing than `RichTextArea`s have received to date, which is a backwards-compatibility concern, but the effect might also be closer to what users (or even developers) assume will happen with content in a `RichTextArea`.

Another solution would be to just check `current_user_can( 'unfiltered_html' )` before applying `wp_filter_post_kses()` to the value.

On passing `0` for the post ID, see the precedent in `post_exists()`.