### PR TITLE
Normalize printing 'checked' and 'selected' via `option_selected()`

### DIFF
--- a/php/class-fieldmanager-select.php
+++ b/php/class-fieldmanager-select.php
@@ -137,12 +137,12 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 
 		// For taxonomy-based selects, only return selected options if taxonomy preload is disabled.
 		// Additional terms will be provided by Ajax for typeahead to avoid overpopulating the select for large taxonomies.
-		$option_selected = $this->option_selected( $data_row['value'], $value, 'selected' );
+		$option_selected = $this->option_selected( $data_row['value'], $value, true );
 
 		return sprintf(
 			'<option value="%s" %s>%s</option>',
 			esc_attr( $data_row['value'] ),
-			$option_selected,
+			$option_selected ? 'selected' : '',
 			esc_html( $data_row['name'] )
 		);
 

--- a/templates/options-checkboxes.php
+++ b/templates/options-checkboxes.php
@@ -17,7 +17,7 @@ $fm_cb_id = $this->get_element_id() . '-' . sanitize_text_field( $data_row['valu
 		id="<?php echo esc_attr( $fm_cb_id ); ?>"
 		<?php
 		echo $this->get_element_attributes(); // Escaped interally. xss ok.
-		echo esc_attr( $this->option_selected( $data_row['value'], $value, 'checked' ) );
+		echo $this->option_selected( $data_row['value'], $value, true ) ? 'checked' : '';
 		?>
 	/>
 	<label for="<?php echo esc_attr( $fm_cb_id ); ?>" class="fm-option-label">

--- a/templates/options-radios.php
+++ b/templates/options-radios.php
@@ -19,7 +19,7 @@ $fm_cb_id = $this->get_element_id() . '-' . esc_attr( sanitize_text_field( $data
 		echo $this->get_element_attributes(); // Escaped interally. xss ok.
 		?>
 		<?php
-		echo $this->option_selected( $data_row['value'], $value, 'checked' ); // Escaped interally. xss ok.
+		echo $this->option_selected( $data_row['value'], $value, true ) ? 'checked' : '';
 		?>
 	/>
 	<label for="<?php echo esc_attr( $fm_cb_id ); ?>" class="fm-option-label">


### PR DESCRIPTION
`Fieldmanager_Checkboxes::option_selected()` and `Fieldmanager_Options::option_selected()` are echoed in slightly different ways. One is escaped with `esc_attr()`,  but `esc_attr()` is technically incorrect because the escaped value isn't being used as an attribute value.

This PR attempts to normalize the usages of `option_selected()`. As far as I can tell, there isn't a great option in core for sanitizing a valueless attribute. I instead used the `$attribute` parameter as a boolean and output the string directly, but that's not quite what `option_selected()` was intended for, so I'm open to other ideas.