### PR TITLE
Move the array `[]` appended to form names to `Fieldmanager_Options`

### DIFF
--- a/php/class-fieldmanager-options.php
+++ b/php/class-fieldmanager-options.php
@@ -200,6 +200,24 @@ abstract class Fieldmanager_Options extends Fieldmanager_Field {
 	}
 
 	/**
+	 * Override the default HTML form name to allow denoting arrays.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return string Form name.
+	 */
+	public function get_form_name( $multiple = '' ) {
+		// Don't override anything passed to subclasses before this was implemented.
+		if ( ! $multiple ) {
+			if ( $this->multiple ) {
+				$multiple = '[]';
+			}
+		}
+
+		return parent::get_form_name( $multiple );
+	}
+
+	/**
 	 * Helper for output functions to toggle a selected options.
 	 *
 	 * @param  string $current_option This option.

--- a/php/class-fieldmanager-select.php
+++ b/php/class-fieldmanager-select.php
@@ -89,12 +89,6 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 
 		$select_classes = array( 'fm-element' );
 
-		// If this is a multiple select, need to handle differently.
-		$do_multiple = '';
-		if ( $this->multiple ) {
-			$do_multiple = '[]';
-		}
-
 		// Handle type-ahead based fields using the chosen library.
 		if ( $this->type_ahead ) {
 			$select_classes[] = 'chosen-select';
@@ -119,7 +113,7 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 		return sprintf(
 			'<select class="%s" name="%s" id="%s" %s>%s</select>',
 			esc_attr( implode( ' ', $select_classes ) ),
-			esc_attr( $this->get_form_name( $do_multiple ) ),
+			esc_attr( $this->get_form_name() ),
 			esc_attr( $this->get_element_id() ),
 			$this->get_element_attributes(),
 			$opts

--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -261,7 +261,7 @@ class Fieldmanager_Util_Validation {
 
 			// Add the ignore, rules and messages to final validate method with form ID, wrap in script tags and output.
 			echo sprintf( // WPCS: XSS ok.
-				"\t<script type='text/javascript'>\n\t\t( function( $ ) {\n\t\t$( document ).ready( function () {\n\t\t\tvar validator = $( '#%s' ).validate( {\n\t\t\t\tinvalidHandler: function( event, validator ) { fm_validation.invalidHandler( event, validator ); },\n\t\t\t\tsubmitHandler: function( form ) { fm_validation.submitHandler( form ); },\n\t\t\t\terrorClass: \"fm-js-error\",\n\t\t\t\tignore: \"%s\",\n%s%s\n\t\t\t} );\n\t\t} );\n\t\t} )( jQuery );\n\t</script>\n",
+				"\t<script type='text/javascript'>\n\t\t( function( $ ) {\n\t\t$( document ).ready( function () {\n\t\t\tvar validator = $( '#%s' ).validate( {\n\t\t\t\tinvalidHandler: function( event, validator ) { fm_validation.invalidHandler( event, validator ); },\n\t\t\t\tsubmitHandler: function( form ) { fm_validation.submitHandler( form ); },\n\t\t\t\terrorPlacement: function ( label, element ) { var closestFmItem = element.closest( '.fm-item' ); if ( closestFmItem.length && ! closestFmItem.hasClass( 'fm-group' ) ) { label.appendTo( element.closest( '.fm-item' ) ); } else { label.insertAfter( element.get() ); } },\n\t\t\t\terrorClass: \"fm-js-error\",\n\t\t\t\tignore: \"%s\",\n%s%s\n\t\t\t} );\n\t\t} );\n\t\t} )( jQuery );\n\t</script>\n",
 				esc_attr( $this->form_id ),
 				esc_js( $ignore_js ),
 				$rules_js, // Escaped in $this->array_to_js().

--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -261,7 +261,7 @@ class Fieldmanager_Util_Validation {
 
 			// Add the ignore, rules and messages to final validate method with form ID, wrap in script tags and output.
 			echo sprintf( // WPCS: XSS ok.
-				"\t<script type='text/javascript'>\n\t\t( function( $ ) {\n\t\t$( document ).ready( function () {\n\t\t\tvar validator = $( '#%s' ).validate( {\n\t\t\t\tinvalidHandler: function( event, validator ) { fm_validation.invalidHandler( event, validator ); },\n\t\t\t\tsubmitHandler: function( form ) { fm_validation.submitHandler( form ); },\n\t\t\t\terrorPlacement: function ( label, element ) { var closestFmItem = element.closest( '.fm-item' ); if ( closestFmItem.length && ! closestFmItem.hasClass( 'fm-group' ) ) { label.appendTo( element.closest( '.fm-item' ) ); } else { label.insertAfter( element.get() ); } },\n\t\t\t\terrorClass: \"fm-js-error\",\n\t\t\t\tignore: \"%s\",\n%s%s\n\t\t\t} );\n\t\t} );\n\t\t} )( jQuery );\n\t</script>\n",
+				"\t<script type='text/javascript'>\n\t\t( function( $ ) {\n\t\t$( document ).ready( function () {\n\t\t\tvar validator = $( '#%s' ).validate( {\n\t\t\t\tinvalidHandler: function( event, validator ) { fm_validation.invalidHandler( event, validator ); },\n\t\t\t\tsubmitHandler: function( form ) { fm_validation.submitHandler( form ); },\n\t\t\t\terrorPlacement: function ( label, element ) { var closestFmItem = element.closest( '.fm-item' ); if ( closestFmItem.length && ! closestFmItem.hasClass( 'fm-group' ) ) { label.appendTo( closestFmItem ); } else { label.insertAfter( element.get() ); } },\n\t\t\t\terrorClass: \"fm-js-error\",\n\t\t\t\tignore: \"%s\",\n%s%s\n\t\t\t} );\n\t\t} );\n\t\t} )( jQuery );\n\t</script>\n",
 				esc_attr( $this->form_id ),
 				esc_js( $ignore_js ),
 				$rules_js, // Escaped in $this->array_to_js().

--- a/templates/options-checkboxes.php
+++ b/templates/options-checkboxes.php
@@ -13,7 +13,7 @@ $fm_cb_id = $this->get_element_id() . '-' . sanitize_text_field( $data_row['valu
 		class="fm-element"
 		type="checkbox"
 		value="<?php echo esc_attr( $data_row['value'] ); ?>"
-		name="<?php echo esc_attr( $this->get_form_name( '[]' ) ); ?>"
+		name="<?php echo esc_attr( $this->get_form_name() ); ?>"
 		id="<?php echo esc_attr( $fm_cb_id ); ?>"
 		<?php
 		echo $this->get_element_attributes(); // Escaped interally. xss ok.


### PR DESCRIPTION
Fixes #622. The `[]` had been appended manually to `Fieldmanager_Select` and `Fieldmanager_Checkboxes` form names. But, `Fieldmanager_Util_Validation` relies only on `Fieldmanager_Field::get_form_name()` for determining the name, which wouldn't include `[]`.

With this change, the `[]` in multi-selects and checkboxes is generated by overriding `Fieldmanager_Field::get_form_name()` and checking the `$multiple` property, which ensures `[]` is also returned to other callers like `Fieldmanager_Util_Validation`.

However, this change assumes that any field with `'multiple' => true` should in fact be represented as an array in its form name, which happens to be true for the bundled fields but might not be true for custom classes or future bundled fields. Those fields would need to override `get_form_name()` to ensure it behaved as expected.

An alternative approach with fewer backwards-compatibility concerns might be to override `get_form_name()` on `Fieldmanager_Select` and `Fieldmanager_Checkboxes`. The primary downside would be that `get_form_name()` would need to be similarly overridden on future subclasses of `Fieldmanager_Options` that were arrays.