### PR TITLE
Simplify version number passed to `_doing_it_wrong()`

### DIFF
--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -1223,7 +1223,7 @@ abstract class Fieldmanager_Field {
 	public function add_term_meta_box( $title, $taxonomies, $show_on_add = true, $show_on_edit = true, $parent = '' ) {
 		// Bail if term meta table is not installed.
 		if ( get_option( 'db_version' ) < 34370 ) {
-			_doing_it_wrong( __METHOD__, esc_html__( 'This method requires WordPress 4.4 or above', 'fieldmanager' ), 'Fieldmanager-1.0.0-beta.3' );
+			_doing_it_wrong( __METHOD__, esc_html__( 'This method requires WordPress 4.4 or above', 'fieldmanager' ), '1.0.0' );
 			return false;
 		}
 


### PR DESCRIPTION
This particular call is an outlier relative to other version numbers FM passes to WordPress functions:

- Calls to `_doing_it_wrong()` [added in 1.0.0-rc](https://github.com/alleyinteractive/wordpress-fieldmanager/pull/467) don't include `-rc`.
- Calls to `_deprecated_function()` [added in 1.2.0](https://github.com/alleyinteractive/wordpress-fieldmanager/pull/653) don't include anything other than the numbers.