### PR TITLE
Support `display_if` for page templates

### DIFF
--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -240,6 +240,16 @@ $( document ).ready( function () {
 	};
 	$( '.fm-display-if' ).each( fm.init_display_if );
 
+	// Initialize triggers to conditionally show/hide fields based on chosen page template.
+	var pageTemplate = $( '#page_template' ).val();
+	$( '.fm-display-if-page-template' ).each( function() {
+		if ( match_value( getCompareValues( this ), pageTemplate ) ) {
+			$( this ).show();
+		} else {
+			$( this ).hide();
+		}
+	} );
+
 	// Controls the trigger to show or hide fields
 	fm.trigger_display_if = function() {
 		var val;
@@ -270,6 +280,21 @@ $( document ).ready( function () {
 		} );
 	};
 	$( document ).on( 'change', '.display-trigger', fm.trigger_display_if );
+
+	// Trigger show/hide of conditional fields when page template changes.
+	$( document ).on( 'change', '#page_template', function() {
+		var val = $( this ).val();
+
+		$( '.fm-display-if-page-template' ).each( function() {
+			if ( match_value( getCompareValues( this ), val ) ) {
+				$( this ).show();
+			} else {
+				$( this ).hide();
+			}
+
+			$( this ).trigger( 'fm_displayif_toggle' );
+		} );
+	} );
 
 	init_label_macros();
 	init_sortable();

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -522,13 +522,18 @@ abstract class Fieldmanager_Field {
 
 		// Checks to see if element has display_if data values, and inserts the data attributes if it does.
 		if ( isset( $this->display_if ) && ! empty( $this->display_if ) ) {
-			$classes[] = 'fm-display-if';
+			if ( isset( $this->display_if['page_template'] ) ) {
+				$classes[]                              = 'fm-display-if-page-template';
+				$fm_wrapper_attrs['data-display-value'] = $this->display_if['page_template'];
+			} else {
+				$classes[] = 'fm-display-if';
 
-			// For backwards compatibility.
-			$classes[] = 'display-if';
+				// For backwards compatibility.
+				$classes[] = 'display-if';
 
-			$fm_wrapper_attrs['data-display-src'] = $this->display_if['src'];
-			$fm_wrapper_attrs['data-display-value'] = $this->display_if['value'];
+				$fm_wrapper_attrs['data-display-src']   = $this->display_if['src'];
+				$fm_wrapper_attrs['data-display-value'] = $this->display_if['value'];
+			}
 		}
 		$fm_wrapper_attr_string = '';
 		foreach ( $fm_wrapper_attrs as $attr => $val ) {

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -1078,4 +1078,46 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$fm->element_markup( rand_str() );
 		$this->assertSame( 4, $ma->get_call_count(), 'Missing calls to element-markup filters' );
 	}
+
+	public function test_display_if_markup_for_page_template() {
+		$name     = rand_str();
+		$template = 'toaster.php';
+
+		$fm = new Fieldmanager_TextField( [
+			'name' => $name,
+			'display_if' => [
+				'page_template' => $template,
+			],
+		] );
+
+		$html = $this->_get_html_for( $fm );
+
+		$this->assertContains( 'fm-display-if-page-template', $html );
+		$this->assertContains( $template, $html );
+		$this->assertNotContains( 'data-display-src', $html );
+		$this->assertContains( 'data-display-value', $html );
+	}
+
+	public function test_display_if_markup_for_standard_use() {
+		$name = rand_str();
+
+		$source = 'random_thing';
+		$value  = 'another random thing';
+
+		$fm = new Fieldmanager_TextField( [
+			'name'       => $name,
+			'display_if' => [
+				'src'   => $source,
+				'value' => $value,
+			],
+		] );
+
+		$html = $this->_get_html_for( $fm );
+
+		$this->assertNotContains( 'fm-display-if-page-template', $html );
+		$this->assertContains( $source, $html );
+		$this->assertContains( $value, $html );
+		$this->assertContains( 'data-display-src', $html );
+		$this->assertContains( 'data-display-value', $html );
+	}
 }


### PR DESCRIPTION
Page templates are a special field in Core, and rather than requiring hidden fields to support conditioning a field on them, FM should handle them accordingly. 

By specifying the `page_template` key instead of the `src` and `value` keys, this will toggle fields based on the chosen page template.

Fixes #414 