### PR TITLE
Reinit $messages as an array if validation_rules is not a string

### DIFF
--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -142,7 +142,7 @@ class Fieldmanager_Util_Validation {
 
 		// Determine if the rules are a string or an array and ensure they are valid.
 		// Also aggregate any messages that were set for the rules, ignoring any messages that don't match a rule.
-		$messages = '';
+		$messages = array();
 		if ( ! is_array( $fm->validation_rules ) ) {
 			// If a string, the only acceptable value is "required".
 			if ( ! is_string( $fm->validation_rules ) || 'required' !== $fm->validation_rules ) {
@@ -159,7 +159,6 @@ class Fieldmanager_Util_Validation {
 				$messages['required'] = $fm->validation_messages;
 			}
 		} else {
-			$messages = array();
 			// Verify each rule defined in the array is valid and also check for any messages that were defined for each.
 			foreach ( $fm->validation_rules as $validation_key => $validation_rule ) {
 				if ( ! in_array( $validation_key, $this->valid_rules ) ) {

--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -159,6 +159,7 @@ class Fieldmanager_Util_Validation {
 				$messages['required'] = $fm->validation_messages;
 			}
 		} else {
+		    $messages = [];
 			// Verify each rule defined in the array is valid and also check for any messages that were defined for each.
 			foreach ( $fm->validation_rules as $validation_key => $validation_rule ) {
 				if ( ! in_array( $validation_key, $this->valid_rules ) ) {

--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -159,7 +159,7 @@ class Fieldmanager_Util_Validation {
 				$messages['required'] = $fm->validation_messages;
 			}
 		} else {
-		    $messages = [];
+			$messages = array();
 			// Verify each rule defined in the array is valid and also check for any messages that were defined for each.
 			foreach ( $fm->validation_rules as $validation_key => $validation_rule ) {
 				if ( ! in_array( $validation_key, $this->valid_rules ) ) {


### PR DESCRIPTION
I have a field with these validation rules:

```
'validation_rules'   => ['required' => true, 'min' => 1]
```

and I wanted to customise the error message for the `min` rule not being met, which I tried with

```
'validation_messages' => [
  'min' => 'You must select an image'
]
```

which did not work, and gave me this warning:

```
Warning: Illegal string offset 'min' in /vagrant/wordpress/plugins/fieldmanager/php/util/class-fieldmanager-util-validation.php on line 172
```

Investigating `class-fieldmanager-util-validation.php` showed that `$messages` is initialised as a string, but if `$fm->validation_rules` is not a string the code tries to treat `$messages` as an associative array.