### PR TITLE
Fields extra attributes checks

### DIFF
--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -136,11 +136,12 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 		}
 
 		$element = sprintf(
-			'<input class="fm-autocomplete fm-element fm-incrementable" type="text" id="%s" value="%s"%s %s />',
+			'<input class="fm-autocomplete fm-element fm-incrementable%s" type="text" id="%s" value="%s"%s %s />',
+			$this->get_element_attributes( 'class' ),
 			esc_attr( $this->get_element_id() ),
 			esc_attr( $display_value ),
 			( ! empty( $this->custom_args_js_event ) ) ? ' data-custom-args-js-event="' . esc_attr( $this->custom_args_js_event ) . '"' : '',
-			$this->get_element_attributes()
+			$this->get_element_attributes( '', array( 'data-custom-args-js-event' ) )
 		);
 
 		$element .= sprintf(

--- a/php/class-fieldmanager-checkbox.php
+++ b/php/class-fieldmanager-checkbox.php
@@ -55,14 +55,15 @@ class Fieldmanager_Checkbox extends Fieldmanager_Field {
 		return sprintf(
 			'
 			<input class="fm-checkbox-hidden fm-element" type="hidden" name="%1$s" value="%6$s" />
-			<input class="fm-element" type="checkbox" name="%1$s" value="%2$s" %3$s %4$s id="%5$s" />
+			<input class="fm-element%7$s" type="checkbox" name="%1$s" value="%2$s" %3$s %4$s id="%5$s" />
 			',
 			esc_attr( $this->get_form_name() ),
 			esc_attr( (string) $this->checked_value ),
 			$this->get_element_attributes(),
 			( $value == $this->checked_value ) ? 'checked="checked"' : '',
 			esc_attr( $this->get_element_id() ),
-			$this->unchecked_value
+			$this->unchecked_value,
+			$this->get_element_attributes( 'class' )
 		);
 	}
 

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -58,12 +58,13 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	 */
 	public function form_element( $value = '' ) {
 		return sprintf(
-			'<input class="fm-element fm-colorpicker-popup" name="%1$s" id="%2$s" data-default-color="%3$s" value="%4$s" %5$s />',
+			'<input class="fm-element fm-colorpicker-popup%6$s" name="%1$s" id="%2$s" data-default-color="%3$s" value="%4$s" %5$s />',
 			esc_attr( $this->get_form_name() ),
 			esc_attr( $this->get_element_id() ),
 			esc_attr( $this->default_color ),
 			esc_attr( $value ),
-			$this->get_element_attributes()
+			$this->get_element_attributes( '', array( 'data-default-color' ) ),
+			$this->get_element_attributes( 'class' )
 		);
 	}
 }

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -1056,12 +1056,26 @@ abstract class Fieldmanager_Field {
 	/**
 	 * Generates an HTML attribute string based on the value of $this->attributes.
 	 *
+	 * @param string $attr          Attribute name.
+	 * @param array  $attr_exclude  Add attributes to black list. Default to ('class',
+	 *                              'type', 'name', 'id', 'value', 'checked').
+	 *
 	 * @see Fieldmanager_Field::$attributes
-	 * @return string attributes ready to insert into an HTML tag.
+	 * @return string Attributes or single attribute value ready to insert into an HTML tag.
 	 */
-	public function get_element_attributes() {
+	public function get_element_attributes( $attr = '', $attr_exclude = array() ) {
+
+		if ( ! empty( $attr ) ) {
+			return array_key_exists( $attr, $this->attributes ) ? ' ' . esc_attr( $this->attributes[$attr] ) : '';
+		}
+
+		$attr_exclude = array_merge( is_array( $attr_exclude ) ? $attr_exclude : array(), array( 'class', 'type', 'name', 'id', 'value', 'checked' ) );
+
 		$attr_str = array();
 		foreach ( $this->attributes as $attr => $val ) {
+			if ( in_array( $attr, $attr_exclude ) ) {
+				continue;
+			}
 			if ( true === $val ) {
 				$attr_str[] = sanitize_key( $attr );
 			} else {

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -181,7 +181,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 			esc_attr( $this->modal_title ),
 			esc_attr( $this->modal_button_label ),
 			esc_attr( $this->mime_type ),
-			$this->get_element_attributes()
+			$this->get_element_attributes( '', array( 'data-choose', 'data-update', 'data-preview-size', 'data-mime-type' ) )
 		);
 	}
 

--- a/php/class-fieldmanager-textarea.php
+++ b/php/class-fieldmanager-textarea.php
@@ -43,7 +43,8 @@ class Fieldmanager_TextArea extends Fieldmanager_Field {
 	 */
 	public function form_element( $value = '' ) {
 		return sprintf(
-			'<textarea class="fm-element" name="%s" id="%s" %s >%s</textarea>',
+			'<textarea class="fm-element%s" name="%s" id="%s" %s >%s</textarea>',
+			$this->get_element_attributes( 'class' ),
 			esc_attr( $this->get_form_name() ),
 			esc_attr( $this->get_element_id() ),
 			$this->get_element_attributes(),

--- a/templates/datepicker.php
+++ b/templates/datepicker.php
@@ -8,7 +8,7 @@
 ?>
 
 <input
-	class="fm-element fm-datepicker-popup"
+	class="fm-element fm-datepicker-popup<?php echo $this->get_element_attributes( 'class' ); ?>"
 	type="text"
 	data-datepicker-opts="<?php echo esc_attr( json_encode( $this->js_opts ) ); ?>"
 	name="<?php echo esc_attr( $this->get_form_name( '[date]' ) ); ?>"
@@ -24,11 +24,11 @@
 <?php if ( $this->use_time ) : ?>
 	<span class="fm-datepicker-time-wrapper">
 		@
-		<input class="fm-element fm-datepicker-time" type="text" value="<?php echo esc_attr( $this->get_hour( $value ) ); ?>" name="<?php echo esc_attr( $this->get_form_name( '[hour]' ) ); ?>" />
+		<input class="fm-element fm-datepicker-time<?php echo $this->get_element_attributes( 'class' ); ?>" type="text" value="<?php echo esc_attr( $this->get_hour( $value ) ); ?>" name="<?php echo esc_attr( $this->get_form_name( '[hour]' ) ); ?>" />
 		:
-		<input class="fm-element fm-datepicker-time" type="text" value="<?php echo esc_attr( $this->get_minute( $value ) ); ?>" name="<?php echo esc_attr( $this->get_form_name( '[minute]' ) ); ?>" />
+		<input class="fm-element fm-datepicker-time<?php echo $this->get_element_attributes( 'class' ); ?>" type="text" value="<?php echo esc_attr( $this->get_minute( $value ) ); ?>" name="<?php echo esc_attr( $this->get_form_name( '[minute]' ) ); ?>" />
 		<?php if ( $this->use_am_pm ) : ?>
-			<select class="fm-element" name="<?php echo esc_attr( $this->get_form_name( '[ampm]' ) ); ?>">
+			<select class="fm-element<?php echo $this->get_element_attributes( 'class' ); ?>" name="<?php echo esc_attr( $this->get_form_name( '[ampm]' ) ); ?>">
 				<option value="am"<?php selected( $this->get_am_pm( $value ), 'am' ); ?>>A.M.</option>
 				<option value="pm"<?php selected( $this->get_am_pm( $value ), 'pm' ); ?>>P.M.</option>
 			</select>

--- a/templates/options-checkboxes.php
+++ b/templates/options-checkboxes.php
@@ -10,7 +10,7 @@ $fm_cb_id = $this->get_element_id() . '-' . sanitize_text_field( $data_row['valu
 
 <div class="fm-option">
 	<input
-		class="fm-element"
+		class="fm-element<?php echo $this->get_element_attributes( 'class' ); ?>"
 		type="checkbox"
 		value="<?php echo esc_attr( $data_row['value'] ); ?>"
 		name="<?php echo esc_attr( $this->get_form_name( '[]' ) ); ?>"

--- a/templates/options-radios.php
+++ b/templates/options-radios.php
@@ -10,7 +10,7 @@ $fm_cb_id = $this->get_element_id() . '-' . esc_attr( sanitize_text_field( $data
 
 <div class="fm-option">
 	<input
-		class="fm-element"
+		class="fm-element<?php echo $this->get_element_attributes( 'class' ); ?>"
 		type="radio"
 		value="<?php echo esc_attr( $data_row['value'] ); ?>"
 		name="<?php echo esc_attr( $this->get_form_name() ); ?>"

--- a/templates/textfield.php
+++ b/templates/textfield.php
@@ -7,7 +7,7 @@
 
 ?>
 <input
-	class="fm-element"
+	class="fm-element<?php echo $this->get_element_attributes( 'class' ); ?>"
 	type="<?php echo esc_attr( $this->input_type ); ?>"
 	name="<?php echo esc_attr( $this->get_form_name() ); ?>"
 	id="<?php echo esc_attr( $this->get_element_id() ); ?>"

--- a/tests/php/test-fieldmanager-checkbox-field.php
+++ b/tests/php/test-fieldmanager-checkbox-field.php
@@ -338,4 +338,32 @@ class Test_Fieldmanager_Checkbox_Field extends WP_UnitTestCase {
 		$html = $this->render( $group, $this->post );
 		$this->assertNotContains( 'checked', $html );
 	}
+
+	/**
+	 * Test element attributes
+	 */
+	public function test_attributes () {
+		$checkbox = new Fieldmanager_Checkbox( array(
+			'name' => 'test_checkbox',
+			'attributes' => array(
+				'id' => 'foo',
+				'class' => 'baz',
+				'name' => 'foo',
+				'value' => 10,
+				'type' => 'text',
+				'checked' => true,
+				'data-bar' => 'bar'
+			),
+		) );
+		$html = $this->render( $checkbox, $this->post );
+		$this->assertNotContains( 'id="foo"', $html );
+		$this->assertNotContains( 'class="baz"', $html );
+		$this->assertNotContains( 'name="foo"', $html );
+		$this->assertNotContains( 'value="10"', $html );
+		$this->assertNotContains( 'type="text"', $html );
+		$this->assertNotContains( 'checked', $html );
+		$this->assertRegExp( '/class="[^"]+baz"/', $html );
+		$this->assertContains( 'data-bar="bar"', $html );
+	}
+
 }


### PR DESCRIPTION
This PR aims to solve following problems:

- prevent overriding attributes causing wrong behaviours. For example, adding a checkbox field like:
```
new Fieldmanager_Checkbox( 'Check test', array(
   'name' => 'test_checkbox',
   'attributes' => array(
      'checked' => true
   )
) );
```
cause the element to be always checked independently of previously saved value. Similarly, setting `id` attribute cause some problem on labels handling and so on.
This is because extra HTML attributes are printed out before `id` and `checked`.

- avoid duplication of attributes by setting attributes like `class`, `type`, `name`, `id`, `value`, `checked` and some `data-*`.  In [HTML5](https://www.w3.org/TR/html5/syntax.html#elements-attributes ) it's not allowed to have two or more identical attributes on the same tag. What happens in practice is that browsers ignore the latter attribute. Well, future browsers might do otherwise (that is, the parser is allowed to stop when it encounters an error).
This was done by adding an attributes black list to `get_element_attributes()`.

- allow to add classes to `class` attribute of field itself (not only to his container).
This can be useful in some situation if you want to reuse of CSS classes without adding the same rules in specific selectors. In practice:

```
new Fieldmanager_Textfield( 'Input test', array(
   'name' => 'test_input',
   'attributes' => array(
      'class' => 'my-class'
   )
) );
```
will append ` my-class` to element class.

PS: I added unit tests only to checkbox field (I think is sufficiently, but I can add to others too).