### PR TITLE
Sanitize post types when adding meta boxes

### DIFF
--- a/php/context/class-fieldmanager-context-post.php
+++ b/php/context/class-fieldmanager-context-post.php
@@ -69,7 +69,9 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context_Storable {
 			$post_types = array( $post_types );
 		}
 
-		$this->post_types = $post_types;
+		$this->post_types = array_map( function( $value ) {
+			return is_string( $value ) ? sanitize_key( $value ) : $value;
+		}, $post_types );
 		$this->title = $title;
 		$this->context = $context;
 		$this->priority = $priority;

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -73,14 +73,16 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 			$post_types = array( $post_types );
 		}
 
-		$this->post_types = $post_types;
+		$this->post_types = array_map( function( $value ) {
+			return is_string( $value ) ? sanitize_key( $value ) : $value;
+		}, $post_types );
 		$this->title = $title;
 		$this->column_title = ! empty( $column_title ) ? $column_title : $title;
 		$this->column_display_callback = $column_display_callback;
 		$this->fm = $fm;
 
 		if ( is_callable( $column_display_callback ) ) {
-			foreach ( $post_types as $post_type ) {
+			foreach ( $this->post_types as $post_type ) {
 				add_action( 'manage_' . $post_type . '_posts_columns', array( $this, 'add_custom_columns' ) );
 			}
 			add_action( 'manage_posts_custom_column', array( $this, 'manage_custom_columns' ), 10, 2 );

--- a/php/context/class-fieldmanager-context-term.php
+++ b/php/context/class-fieldmanager-context-term.php
@@ -153,6 +153,8 @@ class Fieldmanager_Context_Term extends Fieldmanager_Context_Storable {
 			$this->fm           = $fm;
 		}
 
+		$this->taxonomies = array_map( 'sanitize_key', $this->taxonomies );
+
 		// Iterate through the taxonomies and add the fields to the requested forms.
 		// Also add handlers for saving the fields and which forms to validate (if enabled).
 		foreach ( $this->taxonomies as $taxonomy ) {


### PR DESCRIPTION
Recenlty, I added a meta box with a code like that:
```
$fm->add_meta_box( 'test meta box', '   post' );
```
by adding accidentally a blank space in the post type.
I notice that the box is still added, since behind the scenes, the type value is [sanified](https://core.trac.wordpress.org/browser/tags/4.9/src/wp-admin/includes/class-wp-screen.php#L234).
However this is not be done when saving/updating post, so the custom fields are [not updated](https://github.com/alleyinteractive/wordpress-fieldmanager/blob/d401659612fdff785088e731e69538c085dac443/php/context/class-fieldmanager-context-post.php#L196).
I spent some time to understand why :-) so the patch try to solve that by sanitizing `post_types` values on constructors.

I had to check `post_types` type values since, even if the doc says that must be strings, many tests use
`$field->add_meta_box( 'test meta box', $this->post );` and I think they should be fixed (it will simplify also this PR).
Note that command above doesn't fail and doesn't do anyting due to [this](https://core.trac.wordpress.org/browser/tags/4.9/src/wp-admin/includes/template.php#L930).