### PR TITLE
Allow creating Autocompletes with `'show_view_link' => true`

### DIFF
--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -29,6 +29,13 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 	public $show_edit_link = false;
 
 	/**
+	 * Whether to show a "View" link for the selected item.
+	 *
+	 * @var bool
+	 */
+	public $show_view_link = false;
+
+	/**
 	 * Key for reciprocal relationship; if defined will add an entry to postmeta on the mirrored post.
 	 *
 	 * @var string


### PR DESCRIPTION
This field currently generates a `FM_Developer_Exception`:

```
add_action( 'fm_post', function ( $type ) {
	$fm = new \Fieldmanager_Autocomplete( 'Foo', [
		'name' => 'foo',
		'show_view_link' => true,
		'datasource' => new \Fieldmanager_Datasource_Post(),
	] );
	$fm->add_meta_box( 'Bar', $type );
} );
```

because `show_view_link` is not a property on ` \Fieldmanager_Autocomplete`. But everything else seems to be set up for it to work (with posts and terms, anyway).

A workaround is to just set `$fm->show_view_link = true` after instantiating the class.