### PR TITLE
Allow consistent filtering of datasource items

### DIFF
--- a/php/datasource/class-fieldmanager-datasource-post.php
+++ b/php/datasource/class-fieldmanager-datasource-post.php
@@ -178,7 +178,7 @@ class Fieldmanager_Datasource_Post extends Fieldmanager_Datasource {
 			}
 			$ret[ $p->ID ] = $p->post_title . $date_pad;
 		}
-		return $ret;
+		return apply_filters( 'fm_datasource_post_get_items', $ret, $posts, $this, $fragment );
 	}
 
 	/**

--- a/php/datasource/class-fieldmanager-datasource-user.php
+++ b/php/datasource/class-fieldmanager-datasource-user.php
@@ -171,7 +171,7 @@ class Fieldmanager_Datasource_User extends Fieldmanager_Datasource {
 			$ret[ $u->{$this->store_property} ] = $u->{$this->display_property};
 		}
 
-		return $ret;
+		return apply_filters( 'fm_datasource_user_get_items', $ret, $users, $this, $fragment );
 	}
 
 	/**

--- a/php/datasource/class-fieldmanager-datasource.php
+++ b/php/datasource/class-fieldmanager-datasource.php
@@ -148,7 +148,7 @@ class Fieldmanager_Datasource {
 				$ret[ $k ] = $v;
 			}
 		}
-		return $ret;
+		return apply_filters( 'fm_datasource_get_items', $ret, $this->options, $this, $fragment );
 	}
 
 	/**

--- a/php/datasource/class-fieldmanager-datasource.php
+++ b/php/datasource/class-fieldmanager-datasource.php
@@ -180,7 +180,7 @@ class Fieldmanager_Datasource {
 			);
 		}
 
-		return $return;
+		return apply_filters( 'fm_datasource_get_items_for_ajax', $return, $items, $this, $fragment );
 	}
 
 	/**


### PR DESCRIPTION
The term datasource already includes a filter on its `get_items()` return value; this carries that to the remaining datasources. Additionally, I've introduced a filter on `get_items_for_ajax()` in case that output needs to be modified in response to changes made via the `get_items()` filters.

#575 is related, but more-narrowly focused. If this PR is accepted, #575 can likely be closed.