### PR TITLE
Custom template directory

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -127,9 +127,9 @@ function fieldmanager_get_baseurl() {
 /**
  * Get the path to a field template.
  *
- * @param string $tpl_dir The template directory.
  * @param string $tpl_slug The name of a template file inside the template
  *     directory, excluding ".php".
+ * @param string $tpl_dir The template directory.
  * @return string The template path, or the path to "textfield.php" if the
  *     requested template is not found.
  */

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -127,16 +127,21 @@ function fieldmanager_get_baseurl() {
 /**
  * Get the path to a field template.
  *
- * @param string $tpl_slug The name of a template file inside the "templates/"
+ * @param string $tpl_dir The template directory.
+ * @param string $tpl_slug The name of a template file inside the template
  *     directory, excluding ".php".
  * @return string The template path, or the path to "textfield.php" if the
  *     requested template is not found.
  */
-function fieldmanager_get_template( $tpl_slug ) {
-	if ( ! file_exists( plugin_dir_path( __FILE__ ) . 'templates/' . $tpl_slug . '.php' ) ) {
+function fieldmanager_get_template( $tpl_slug, $tpl_dir = '' ) {
+	$template_directory = plugin_dir_path( __FILE__ ) . 'templates';
+	if ( ! empty( $tpl_dir ) && file_exists( $tpl_dir ) ) {
+		$template_directory = $tpl_dir;
+	}
+	if ( ! file_exists( trailingslashit( $template_directory ) . $tpl_slug . '.php' ) ) {
 		$tpl_slug = 'textfield';
 	}
-	return plugin_dir_path( __FILE__ ) . 'templates/' . $tpl_slug . '.php';
+	return trailingslashit( $template_directory ) . $tpl_slug . '.php';
 }
 
 /**


### PR DESCRIPTION
Although the form element can be rendered by overriding `Fieldmanager_Field::form_element()`, it would be nice to just provide a custom directory for templates as the second parameter of `fieldmanager_get_template()` for reusability.

For example, I'm building custom admin interfaces that need buttons with specific data-attributes, and it would be nice to just set the options, attributes, etc., and call the `button.php` template, which is being placed outside the default Fieldmanager `/templates` directory, like so...

```$this->template = fieldmanager_get_template( 'button', 'some_custom_dir' );```

This modifies the `fieldmanager_get_template()` function with a second parameter to allow for this.