### PR TITLE
Get datasource terms with `'orderby' => 'term_order'`

### DIFF
--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -170,7 +170,7 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	/**
 	 * Sort function for `get_the_terms` result set.
 	 *
-	 * @deprecated 1.x.y Handled with get_terms() in Fieldmanager_Datasource_Term::preload_alter_values().
+	 * @deprecated 1.2.2 Handled with get_terms() in Fieldmanager_Datasource_Term::preload_alter_values().
 	 *
 	 * @param  WP_Term $term_a First term.
 	 * @param  WP_Term $term_b Second term.

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -141,15 +141,16 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	public function preload_alter_values( Fieldmanager_Field $field, $values ) {
 		if ( $this->only_save_to_taxonomy ) {
 			$taxonomies = $this->get_taxonomies();
-			$terms = get_the_terms( $field->data_id, $taxonomies[0] );
+			$terms = get_terms( array(
+				'object_ids' => array( $field->data_id ),
+				'orderby' => 'term_order',
+				'taxonomy' => array( $taxonomies[0] ),
+			) );
 
 			// If not found, bail out.
 			if ( empty( $terms ) || is_wp_error( $terms ) ) {
 				return array();
 			}
-
-			// Attempt to sort the list by term_order.
-			usort( $terms, array( $this, 'sort_terms' ) );
 
 			if ( count( $terms ) > 0 ) {
 				if ( 1 == $field->limit && empty( $field->multiple ) ) {
@@ -168,6 +169,8 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 
 	/**
 	 * Sort function for `get_the_terms` result set.
+	 *
+	 * @deprecated Handled with get_terms() in Fieldmanager_Datasource_Term::preload_alter_values().
 	 *
 	 * @param  WP_Term $term_a First term.
 	 * @param  WP_Term $term_b Second term.

--- a/php/datasource/class-fieldmanager-datasource-term.php
+++ b/php/datasource/class-fieldmanager-datasource-term.php
@@ -170,7 +170,7 @@ class Fieldmanager_Datasource_Term extends Fieldmanager_Datasource {
 	/**
 	 * Sort function for `get_the_terms` result set.
 	 *
-	 * @deprecated Handled with get_terms() in Fieldmanager_Datasource_Term::preload_alter_values().
+	 * @deprecated 1.x.y Handled with get_terms() in Fieldmanager_Datasource_Term::preload_alter_values().
 	 *
 	 * @param  WP_Term $term_a First term.
 	 * @param  WP_Term $term_b Second term.

--- a/tests/php/test-fieldmanager-datasource-term.php
+++ b/tests/php/test-fieldmanager-datasource-term.php
@@ -349,6 +349,29 @@ class Test_Fieldmanager_Datasource_Term extends WP_UnitTestCase {
 		$this->assertTrue( $wp_taxonomies['post_tag']->sort );
 	}
 
+	public function test_sortable_terms_retrieved_in_order() {
+		$taxonomy = $this->term->taxonomy;
+
+		$fm = new \Fieldmanager_Autocomplete( array(
+			'name' => 'sortable_terms',
+			'limit' => 0,
+			'sortable' => true,
+			'datasource' => new \Fieldmanager_Datasource_Term( array(
+				'taxonomy'              => $taxonomy,
+				'only_save_to_taxonomy' => true,
+			) ),
+		) );
+		$context = $fm->add_meta_box( 'Sortable Terms', 'post' );
+
+		$order = array( $this->term_2->term_id, $this->term->term_id );
+		$context->save_to_post_meta( $this->post->ID, $order );
+		$this->assertSame( $order, $fm->preload_alter_values( array() ) );
+
+		$order = array( $this->term->term_id, $this->term_2->term_id );
+		$context->save_to_post_meta( $this->post->ID, $order );
+		$this->assertSame( $order, $fm->preload_alter_values( array() ) );
+	}
+
 	public function test_append_true_after_first_save() {
 		$fm = new Fieldmanager_Group( array(
 			'name'     => 'author_data',

--- a/tests/php/test-fieldmanager-datasource-term.php
+++ b/tests/php/test-fieldmanager-datasource-term.php
@@ -368,7 +368,7 @@ class Test_Fieldmanager_Datasource_Term extends WP_UnitTestCase {
 		$this->assertSame( $order, $fm->preload_alter_values( array() ) );
 
 		// Clear caches.
-		$context->save_to_post_meta( $this->post->ID, [] );
+		$context->save_to_post_meta( $this->post->ID, array() );
 
 		$order = array( $this->term->term_id, $this->term_2->term_id );
 		$context->save_to_post_meta( $this->post->ID, $order );

--- a/tests/php/test-fieldmanager-datasource-term.php
+++ b/tests/php/test-fieldmanager-datasource-term.php
@@ -367,6 +367,9 @@ class Test_Fieldmanager_Datasource_Term extends WP_UnitTestCase {
 		$context->save_to_post_meta( $this->post->ID, $order );
 		$this->assertSame( $order, $fm->preload_alter_values( array() ) );
 
+		// Clear caches.
+		$context->save_to_post_meta( $this->post->ID, [] );
+
 		$order = array( $this->term->term_id, $this->term_2->term_id );
 		$context->save_to_post_meta( $this->post->ID, $order );
 		$this->assertSame( $order, $fm->preload_alter_values( array() ) );


### PR DESCRIPTION
See #698.