### PR TITLE
$messages is used as an array, so it should be created as one.

### DIFF
--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -142,7 +142,7 @@ class Fieldmanager_Util_Validation {
 
 		// Determine if the rules are a string or an array and ensure they are valid.
 		// Also aggregate any messages that were set for the rules, ignoring any messages that don't match a rule.
-		$messages = '';
+		$messages = array();
 		if ( ! is_array( $fm->validation_rules ) ) {
 			// If a string, the only acceptable value is "required".
 			if ( ! is_string( $fm->validation_rules ) || 'required' !== $fm->validation_rules ) {


### PR DESCRIPTION
A coworker noticed this bug. $messages is being created as a string, but used like:

```
$messages['required'] = $fm->validation_messages;
```