### PR TITLE
watch for visibility change on sortable

### DIFF
--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -29,11 +29,12 @@ var init_sortable = function() {
 			init_sortable_container( this );
 		} else {
 			var sortable = this;
-			$( sortable ).parents( '.fm-group' ).bind( 'fm_collapsible_toggle', function() {
+			var observer = new MutationObserver( function () {
 				if ( $( sortable ).is( ':visible' ) ) {
 					init_sortable_container( sortable );
 				}
 			} );
+			observer.observe( $( sortable )[0], { attributes: true } );
 		}
 	} );
 }


### PR DESCRIPTION
Currently, if a group of sortable elements is hidden by display_if on page load, the sortable functionality is not bound.

This change addresses that issue.