### PR TITLE
Add action hook 'fm_post_before_update_meta'

### DIFF
--- a/php/context/class-fieldmanager-context-post.php
+++ b/php/context/class-fieldmanager-context-post.php
@@ -310,6 +310,11 @@ class Fieldmanager_Context_Post extends Fieldmanager_Context_Storable {
 	 *                                Default empty.
 	 */
 	protected function update_data( $post_id, $meta_key, $meta_value, $data_prev_value = '' ) {
+		/**
+		 * Last chance to do something with data before update.
+		 */
+		do_action( 'fm_post_before_update_meta', $post_id, $meta_key, $meta_value, $data_prev_value );
+
 		$meta_value = $this->sanitize_scalar_value( $meta_value );
 		return update_post_meta( $post_id, $meta_key, $meta_value, $data_prev_value );
 	}


### PR DESCRIPTION
Needed a hook to create/update a separate meta field.

Example:
Event calendar that allows for URL parameter based on `YYY-MM-DD` format to query and display events on that date.

Built two separate `Fieldmanager_Datepicker` fields for an Event, `event_start` and `event_end` saved as UNIX timestamps (default behavior for `Fieldmanager_Datepicker`).

To easily display the date, and query dates through the URL parameter, save/update a new meta field on the fly `event_date` on event date updates.

This hook allows for this, and many other implementations.