### PR TITLE
Multi select gutenberg fix

### DIFF
--- a/php/class-fieldmanager-select.php
+++ b/php/class-fieldmanager-select.php
@@ -191,9 +191,9 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 				width: '350px'
 			}
 			$('.fm-wrapper').on("fm_added_element fm_collapsible_toggle fm_activate_tab",".fm-item",function(){
-				$(".chosen-select:visible",this).chosen(chosenOpts)
+				$(".chosen-select",this).chosen(chosenOpts)
 			});
-			$(".chosen-select:visible").chosen(chosenOpts);
+			$(".chosen-select").chosen(chosenOpts);
 		});
 		</script>
 		<?php

--- a/php/class-fieldmanager-select.php
+++ b/php/class-fieldmanager-select.php
@@ -188,7 +188,7 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 			var chosenOpts = {
 				allow_single_deselect: true,
 				disable_search_threshold: -1,
-				width: '350px'
+				max_width: '100%'
 			}
 			$('.fm-wrapper').on("fm_added_element fm_collapsible_toggle fm_activate_tab",".fm-item",function(){
 				$(".chosen-select",this).chosen(chosenOpts)


### PR DESCRIPTION
May address #679, but I was unable to replicate the issue in that task, so I'm unclear.

- Resolves render issue with the chosen select field on Gutenberg-enabled posts. Select fields, in Gutenberg posts, are returning `.is(":visible")` or `:visible` generally, as false on load. Whereas it returns `true` for non-Gutenberg posts. Unclear why that would be, but removing the `:visible` qualifier resolves initializing Chosen.js on the sidebar.
- Removes the width of `350px` and replaces with `max_width: '100%'` which works both in Gutenberg and non-Gutenberg posts to prevent the select dropdown from expanding past its bounds. Chosen already sets the width inline, this prevents miscalculation overages.
