### PR TITLE
Allow autocomplete field validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "Fieldmanager",
   "description": "Fieldmanager is a comprehensive toolkit for building forms, metaboxes, and custom admin screens for WordPress.",
   "version": "1.2.4",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/alleyinteractive/wordpress-fieldmanager"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alleyinteractive/wordpress-fieldmanager"
   },
   "license": "GPL-2.0",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-connect": "~0.11.0",
-    "grunt-contrib-qunit": "~0.7.0",
+    "grunt-contrib-qunit": "~1.0.0",
     "grunt-phpcs": "^0.4.0"
   }
 }

--- a/php/util/class-fieldmanager-util-validation.php
+++ b/php/util/class-fieldmanager-util-validation.php
@@ -222,9 +222,9 @@ class Fieldmanager_Util_Validation {
 			}
 
 			// Fields that should always be ignored.
-			$ignore[] = '.fm-autocomplete';
 			$ignore[] = "input[type='button']";
-			$ignore[] = ':hidden';
+			// Let autocomplete validate by allowing its associated hidden field.
+			$ignore[] = ':not(\'.fm-autocomplete\') + :hidden';
 
 			// Certain fields need to be ignored depending on the context.
 			switch ( $this->context ) {


### PR DESCRIPTION
https://github.com/alleyinteractive/wordpress-fieldmanager/issues/321

Allows validation on autocomplete fields. It was excluding `.fm-autocomplete` and `:hidden`; this change allows `.fm-autocomplete` and the `:hidden` field directly after it.