### PR TITLE
Adds Button Field Type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -89,3 +89,11 @@ script:
       cd $OG_DIR
       grunt phpcs
     fi
+
+# Xenial image has PHP versions 5.6,7.1,7.2 pre-installed
+dist: xenial
+
+# Xenial does not start mysql by default
+services:
+  - mysql
+  - memcached

--- a/php/class-fieldmanager-button.php
+++ b/php/class-fieldmanager-button.php
@@ -12,6 +12,9 @@ class Fieldmanager_Button extends Fieldmanager_Options {
 
 	/**
 	 * Setup Button Template and Type.
+	 *
+	 * @param string $label   Field label.
+	 * @param array  $options The form options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->input_type = 'button';

--- a/php/class-fieldmanager-button.php
+++ b/php/class-fieldmanager-button.php
@@ -9,6 +9,12 @@
  * Button Field
  */
 class Fieldmanager_Button extends Fieldmanager_Options {
+	/**
+	 * Button content string.
+	 *
+	 * @var string
+	 */
+	public $button_content = '';
 
 	/**
 	 * Setup Button Template and Type.
@@ -17,8 +23,8 @@ class Fieldmanager_Button extends Fieldmanager_Options {
 	 * @param array  $options The form options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
-		$this->input_type = 'button';
-		$this->template = fieldmanager_get_template( 'button' );
+		$this->input_type     = 'button';
+		$this->template       = fieldmanager_get_template( 'button' );
 		parent::__construct( $label, $options );
 	}
 }

--- a/php/class-fieldmanager-button.php
+++ b/php/class-fieldmanager-button.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Button Field
+ * Button Field.
  */
 class Fieldmanager_Button extends Fieldmanager_Options {
 	/**
@@ -20,7 +20,7 @@ class Fieldmanager_Button extends Fieldmanager_Options {
 	 * Setup Button Template and Type.
 	 *
 	 * @param string $label   Field label.
-	 * @param array  $options The form options.
+	 * @param array  $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->input_type     = 'button';

--- a/php/class-fieldmanager-button.php
+++ b/php/class-fieldmanager-button.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Class file for Fieldmanager_Button
+ *
+ * @package Fieldmanager
+ */
+
+/**
+ * Button Field
+ */
+class Fieldmanager_Button extends Fieldmanager_Options {
+
+	/**
+	 * Setup Button Template and Type.
+	 */
+	public function __construct( $label = '', $options = array() ) {
+		$this->input_type = 'button';
+		$this->template = fieldmanager_get_template( 'button' );
+		parent::__construct( $label, $options );
+	}
+}

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -96,6 +96,20 @@ abstract class Fieldmanager_Field {
 	public $label_after_element = false;
 
 	/**
+	 * Button content for the form element.
+	 *
+	 * @var string
+	 */
+	public $button_content = '';
+
+	/**
+	 * If true, the button content will be displayed after the element.
+	 *
+	 * @var bool
+	 */
+	public $button_content_after_element = true;
+
+	/**
 	 * Description for the form element.
 	 *
 	 * @var string
@@ -692,6 +706,10 @@ abstract class Fieldmanager_Field {
 			} else {
 				$render_label_after = true;
 			}
+		}
+
+		if ( isset( $this->button_content ) && ! empty( $this->button_content ) && ! $this->button_content_after_element ) {
+			$out .= sprintf( '<div class="fm-item-button_content">%s</div>', $this->escape( 'button_content' ) );
 		}
 
 		if ( isset( $this->description ) && ! empty( $this->description ) && ! $this->description_after_element ) {

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -96,20 +96,6 @@ abstract class Fieldmanager_Field {
 	public $label_after_element = false;
 
 	/**
-	 * Button content for the form element.
-	 *
-	 * @var string
-	 */
-	public $button_content = '';
-
-	/**
-	 * If true, the button content will be displayed after the element.
-	 *
-	 * @var bool
-	 */
-	public $button_content_after_element = true;
-
-	/**
 	 * Description for the form element.
 	 *
 	 * @var string
@@ -706,10 +692,6 @@ abstract class Fieldmanager_Field {
 			} else {
 				$render_label_after = true;
 			}
-		}
-
-		if ( isset( $this->button_content ) && ! empty( $this->button_content ) && ! $this->button_content_after_element ) {
-			$out .= sprintf( '<div class="fm-item-button_content">%s</div>', $this->escape( 'button_content' ) );
 		}
 
 		if ( isset( $this->description ) && ! empty( $this->description ) && ! $this->description_after_element ) {

--- a/templates/button.php
+++ b/templates/button.php
@@ -6,16 +6,16 @@
  */
 
 // Add additional classnames, if they exist.
-$classnames = array_key_exists( 'class', $this->attributes ) ? $this->attributes['class'] : '';
+$fieldmanager_classnames = array_key_exists( 'class', $this->attributes ) ? $this->attributes['class'] : '';
 ?>
 
 <button
-	class="fm-button-element <?php echo esc_attr( $classnames ); ?>"
+	class="fm-button-element <?php echo esc_attr( $fieldmanager_classnames ); ?>"
 	id="<?php echo esc_attr( $this->get_element_id() ); ?>"
 	name="<?php echo esc_attr( $this->get_form_name() ); ?>"
 	role="<?php echo esc_attr( $this->input_type ); ?>"
 	type="<?php echo esc_attr( $this->input_type ); ?>"
 	<?php echo $this->get_element_attributes(); // Escaped interally. xss ok. ?>
 >
-	<?php echo $this->escape( 'button_content' ); // Escaped interally. xss ok.  ?>
+	<?php echo $this->escape( 'button_content' ); // Escaped interally. xss ok. ?>
 </button>

--- a/templates/button.php
+++ b/templates/button.php
@@ -6,7 +6,7 @@
  */
 ?>
 <input
-	class="fm-button-element button-secondary <?php echo esc_attr( $this->options['classnames'] ); ?>"
+	class="fm-button-element button-secondary <?php echo esc_attr( $this->field_class ); ?>"
 	type="button"
 	name="<?php echo esc_attr( $this->get_form_name() ); ?>"
 	id="<?php echo esc_attr( $this->get_element_id() ); ?>"

--- a/templates/button.php
+++ b/templates/button.php
@@ -10,6 +10,6 @@
 	type="button"
 	name="<?php echo esc_attr( $this->get_form_name() ); ?>"
 	id="<?php echo esc_attr( $this->get_element_id() ); ?>"
-	value="<?php echo esc_attr( $this->options['button_text'] ); ?>"
+	value="<?php echo esc_attr( $this->attributes['button_text'] ); ?>"
 	<?php echo $this->get_element_attributes(); // Escaped interally. xss ok. ?>
 />

--- a/templates/button.php
+++ b/templates/button.php
@@ -4,12 +4,18 @@
  *
  * @package Fieldmanager
  */
+
+// Add additional classnames, if they exist.
+$classnames = array_key_exists( 'class', $this->attributes ) ? $this->attributes['class'] : '';
 ?>
-<input
-	class="fm-button-element button-secondary <?php echo esc_attr( $this->field_class ); ?>"
-	type="button"
-	name="<?php echo esc_attr( $this->get_form_name() ); ?>"
+
+<button
+	class="fm-button-element <?php echo esc_attr( $classnames ); ?>"
 	id="<?php echo esc_attr( $this->get_element_id() ); ?>"
-	value="<?php echo esc_attr( $this->attributes['button_text'] ); ?>"
+	name="<?php echo esc_attr( $this->get_form_name() ); ?>"
+	role="<?php echo esc_attr( $this->input_type ); ?>"
+	type="<?php echo esc_attr( $this->input_type ); ?>"
 	<?php echo $this->get_element_attributes(); // Escaped interally. xss ok. ?>
-/>
+>
+	<?php echo $this->escape( 'button_content' ); // Escaped interally. xss ok.  ?>
+</button>

--- a/templates/button.php
+++ b/templates/button.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Default template for Fieldmanager_Button
+ *
+ * @package Fieldmanager
+ */
+?>
+<input
+	class="fm-button-element button-secondary <?php echo esc_attr( $this->options['classnames'] ); ?>"
+	type="button"
+	name="<?php echo esc_attr( $this->get_form_name() ); ?>"
+	id="<?php echo esc_attr( $this->get_element_id() ); ?>"
+	value="<?php echo esc_attr( $this->options['button_text'] ); ?>"
+	<?php echo $this->get_element_attributes(); // Escaped interally. xss ok. ?>
+/>

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -935,14 +935,14 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		);
 
 		// Ensure that, by default, the description is present without the HTML
-		$field = new Fieldmanager_TextField( $args );
+		$field = new Fieldmanager_Button( $args );
 		$html  = $this->_get_html_for( $field );
 		$this->assertContains( $button_content_raw, $html );
 		$this->assertNotContains( $button_content_html, $html );
 
 		// Ensure that the description has HTML when we change the escaping
 		$args['escape'] = array( 'button_content' => 'wp_kses_post' );
-		$field          = new Fieldmanager_TextField( $args );
+		$field          = new Fieldmanager_Button( $args );
 		$html           = $this->_get_html_for( $field );
 		$this->assertContains( $button_content_html, $html );
 	}

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -926,8 +926,8 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 	}
 
 	public function test_button_content_escaping() {
-		$id                  = rand_str();
-		$button_content_raw  = rand_str();
+		$id                  = 'button-id';
+		$button_content_raw  = 'button content test string';
 		$button_content_html = "<strong id='{$id}'>{$button_content_raw}</strong>";
 		$args                = array(
 			'name'        => 'button_content_escape_testing',

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -930,8 +930,8 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$button_content_raw  = 'button content test string';
 		$button_content_html = "<strong id='{$id}'>{$button_content_raw}</strong>";
 		$args                = array(
-			'name'        => 'button_content_escape_testing',
-			'description' => $button_content_html,
+			'name'           => 'button_content_escape_testing',
+			'button_content' => $button_content_html,
 		);
 
 		// Ensure that, by default, the description is present without the HTML

--- a/tests/php/test_fieldmanager_field.php
+++ b/tests/php/test_fieldmanager_field.php
@@ -925,6 +925,29 @@ class Fieldmanager_Field_Test extends WP_UnitTestCase {
 		$this->assertContains( $description_html, $html );
 	}
 
+	public function test_button_content_escaping() {
+		$id                  = rand_str();
+		$button_content_raw  = rand_str();
+		$button_content_html = "<strong id='{$id}'>{$button_content_raw}</strong>";
+		$args                = array(
+			'name'        => 'button_content_escape_testing',
+			'description' => $button_content_html,
+		);
+
+		// Ensure that, by default, the description is present without the HTML
+		$field = new Fieldmanager_TextField( $args );
+		$html  = $this->_get_html_for( $field );
+		$this->assertContains( $button_content_raw, $html );
+		$this->assertNotContains( $button_content_html, $html );
+
+		// Ensure that the description has HTML when we change the escaping
+		$args['escape'] = array( 'button_content' => 'wp_kses_post' );
+		$field          = new Fieldmanager_TextField( $args );
+		$html           = $this->_get_html_for( $field );
+		$this->assertContains( $button_content_html, $html );
+	}
+
+
 	/**
 	 * @group serialize_data
 	 */


### PR DESCRIPTION
Helps address: #70 
- Adds button field support for Field Manager.

Use:
```
  "FIELDNAME": {
    "label": { "__": "Button Label" },
    "type": "button",
    "field_class": "CUSTOM_CLASSNAME",
    "options": {
      "button_text": { "__": "Button Text" },
    }
  },
```