### PR TITLE
Add Readonly to the Password field if not changed (in focus)

### DIFF
--- a/templates/textfield.php
+++ b/templates/textfield.php
@@ -13,6 +13,11 @@
 	id="<?php echo esc_attr( $this->get_element_id() ); ?>"
 	value="<?php echo esc_attr( $value ); ?>"
 	<?php
+        if('password' === $this->input_type){
+            echo " readonly onfocus=\"this.removeAttribute('readonly');\" ";
+        }
+	?>
+	<?php
 	echo $this->get_element_attributes(); // Escaped internally. WPCS XSS okay.
 	?>
 />


### PR DESCRIPTION
When changing other fields, but not the `Fieldmanager_Password` one, the password value got lost. 
When set to __readonly__, original value was preserved and re-saved.