### PR TITLE
Use the new wp.domReady helper if it is available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ matrix:
       env: WP_VERSION=latest
     - php: '7.2'
       env: WP_VERSION=latest
-	- php: '7.3'
-	  env: WP_VERSION=latest
-	- php: '7.3'
-	  env: WP_VERSION=nightly
+    - php: '7.3'
+      env: WP_VERSION=latest
+    - php: '7.3'
+      env: WP_VERSION=nightly
   fast_finish: true
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,27 @@ language: php
 
 matrix:
   include:
-    - php: 5.3
+    - php: '5.3'
       env: WP_VERSION=4.7.6
       dist: precise
-    - php: 5.3
+    - php: '5.3'
       env: WP_VERSION=latest
       dist: precise
-    - php: 5.6
+    - php: '5.6'
       env: WP_VERSION=latest
-    - php: 5.6
+    - php: '5.6'
       env: WP_TRAVISCI=phpcs
-    - php: 7.0
+    - php: '7.0'
       env: WP_VERSION=latest
-    - php: 7.0
-      env: WP_VERSION=nightly
-    - php: 7.1
+    - php: '7.1'
       env: WP_VERSION=latest
-    - php: 7.2
+    - php: '7.2'
       env: WP_VERSION=latest
+	- php: '7.3'
+	  env: WP_VERSION=latest
+	- php: '7.3'
+	  env: WP_VERSION=nightly
   fast_finish: true
-  allow_failures:
-    - php: 7.2
 
 branches:
   only:

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -3,7 +3,7 @@
  * Fieldmanager Base Plugin File.
  *
  * @package Fieldmanager
- * @version 1.2.4
+ * @version 1.2.5
  */
 
 /*
@@ -11,14 +11,14 @@ Plugin Name: Fieldmanager
 Plugin URI: https://github.com/alleyinteractive/wordpress-fieldmanager
 Description: Add fields to WordPress programatically.
 Author: Alley
-Version: 1.2.4
+Version: 1.2.5
 Author URI: https://www.alley.co/
 */
 
 /**
  * Current version of Fieldmanager.
  */
-define( 'FM_VERSION', '1.2.4' );
+define( 'FM_VERSION', '1.2.5' );
 
 /**
  * Filesystem path to Fieldmanager.

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -160,6 +160,17 @@ function fieldmanager_get_template( $tpl_slug ) {
  * @param bool        $admin       Deprecated.
  */
 function fm_add_script( $handle, $path = false, $deps = array(), $ver = false, $in_footer = false, $data_object = '', $data = array(), $plugin_dir = '', $admin = true ) {
+	// Ensure the Fieldmanager loader has been enqueued.
+	if ( ! wp_script_is( 'fm_loader', 'enqueued' ) ) {
+		Fieldmanager_Util_Assets::instance()->add_script( [
+			'handle' => 'fm_loader',
+			'path'   => 'js/fieldmanager-loader.js',
+			'deps'   => array( 'jquery' ),
+			'ver'    => FM_VERSION,
+		] );
+	}
+
+	// Enqueue the requested script.
 	Fieldmanager_Util_Assets::instance()->add_script( compact( 'handle', 'path', 'deps', 'ver', 'in_footer', 'data_object', 'data', 'plugin_dir' ) );
 }
 

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -161,16 +161,14 @@ function fieldmanager_get_template( $tpl_slug ) {
  */
 function fm_add_script( $handle, $path = false, $deps = array(), $ver = false, $in_footer = false, $data_object = '', $data = array(), $plugin_dir = '', $admin = true ) {
 	// Ensure the Fieldmanager loader has been enqueued.
-	if ( ! wp_script_is( 'fm_loader', 'enqueued' ) ) {
-		Fieldmanager_Util_Assets::instance()->add_script(
-			array(
-				'handle' => 'fm_loader',
-				'path'   => 'js/fieldmanager-loader.js',
-				'deps'   => array( 'jquery' ),
-				'ver'    => FM_VERSION,
-			)
-		);
-	}
+	Fieldmanager_Util_Assets::instance()->add_script(
+		array(
+			'handle' => 'fm_loader',
+			'path'   => 'js/fieldmanager-loader.js',
+			'deps'   => array( 'jquery' ),
+			'ver'    => FM_VERSION,
+		)
+	);
 
 	// Enqueue the requested script.
 	Fieldmanager_Util_Assets::instance()->add_script( compact( 'handle', 'path', 'deps', 'ver', 'in_footer', 'data_object', 'data', 'plugin_dir' ) );

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -162,12 +162,14 @@ function fieldmanager_get_template( $tpl_slug ) {
 function fm_add_script( $handle, $path = false, $deps = array(), $ver = false, $in_footer = false, $data_object = '', $data = array(), $plugin_dir = '', $admin = true ) {
 	// Ensure the Fieldmanager loader has been enqueued.
 	if ( ! wp_script_is( 'fm_loader', 'enqueued' ) ) {
-		Fieldmanager_Util_Assets::instance()->add_script( [
-			'handle' => 'fm_loader',
-			'path'   => 'js/fieldmanager-loader.js',
-			'deps'   => array( 'jquery' ),
-			'ver'    => FM_VERSION,
-		] );
+		Fieldmanager_Util_Assets::instance()->add_script(
+			array(
+				'handle' => 'fm_loader',
+				'path'   => 'js/fieldmanager-loader.js',
+				'deps'   => array( 'jquery' ),
+				'ver'    => FM_VERSION,
+			)
+		);
 	}
 
 	// Enqueue the requested script.

--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -3,7 +3,7 @@
  * Fieldmanager Base Plugin File.
  *
  * @package Fieldmanager
- * @version 1.2.5
+ * @version 1.2.5-beta2
  */
 
 /*
@@ -11,14 +11,14 @@ Plugin Name: Fieldmanager
 Plugin URI: https://github.com/alleyinteractive/wordpress-fieldmanager
 Description: Add fields to WordPress programatically.
 Author: Alley
-Version: 1.2.5
+Version: 1.2.5-beta2
 Author URI: https://www.alley.co/
 */
 
 /**
  * Current version of Fieldmanager.
  */
-define( 'FM_VERSION', '1.2.5' );
+define( 'FM_VERSION', '1.2.5-beta2' );
 
 /**
  * Filesystem path to Fieldmanager.

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -80,9 +80,10 @@ fm.autocomplete = {
 			}
 		} );
 	}
-}
+};
 
-$( document ).ready( fm.autocomplete.enable_autocomplete );
+fmLoadModule( fm.autocomplete.enable_autocomplete );
+
 $( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.autocomplete.enable_autocomplete );
 
 } ) ( jQuery );

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -82,7 +82,7 @@ fm.autocomplete = {
 	}
 }
 
-$( document ).ready( fm.autocomplete.enable_autocomplete );
+fm_domready( fm.autocomplete.enable_autocomplete );
 $( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.autocomplete.enable_autocomplete );
 
 } ) ( jQuery );

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -82,7 +82,7 @@ fm.autocomplete = {
 	}
 }
 
-fm_domready( fm.autocomplete.enable_autocomplete );
+$( document ).ready( fm.autocomplete.enable_autocomplete );
 $( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.autocomplete.enable_autocomplete );
 
 } ) ( jQuery );

--- a/js/fieldmanager-colorpicker.js
+++ b/js/fieldmanager-colorpicker.js
@@ -6,7 +6,7 @@
 		}
 	}
 
-	$( document ).ready( fm.colorpicker.init );
+	fm_domready( fm.colorpicker.init );
 	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.colorpicker.init );
 
 } )( jQuery );

--- a/js/fieldmanager-colorpicker.js
+++ b/js/fieldmanager-colorpicker.js
@@ -6,7 +6,7 @@
 		}
 	}
 
-	fm_domready( fm.colorpicker.init );
+	$( document ).ready( fm.colorpicker.init );
 	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.colorpicker.init );
 
 } )( jQuery );

--- a/js/fieldmanager-colorpicker.js
+++ b/js/fieldmanager-colorpicker.js
@@ -4,9 +4,10 @@
 		init: function() {
 			$( '.fm-colorpicker-popup:visible' ).wpColorPicker();
 		}
-	}
+	};
 
-	$( document ).ready( fm.colorpicker.init );
+	fmLoadModule( fm.colorpicker.init );
+
 	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.colorpicker.init );
 
 } )( jQuery );

--- a/js/fieldmanager-datepicker.js
+++ b/js/fieldmanager-datepicker.js
@@ -8,8 +8,9 @@
 				}
 			} );
 		}
-	}
+	};
 
-	$( document ).ready( fm.datepicker.add_datepicker );
+	fmLoadModule( fm.datepicker.add_datepicker );
+
 	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.datepicker.add_datepicker );
 } ) ( jQuery );

--- a/js/fieldmanager-datepicker.js
+++ b/js/fieldmanager-datepicker.js
@@ -10,6 +10,6 @@
 		}
 	}
 
-	fm_domready( fm.datepicker.add_datepicker );
+	$( document ).ready( fm.datepicker.add_datepicker );
 	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.datepicker.add_datepicker );
 } ) ( jQuery );

--- a/js/fieldmanager-datepicker.js
+++ b/js/fieldmanager-datepicker.js
@@ -10,6 +10,6 @@
 		}
 	}
 
-	$( document ).ready( fm.datepicker.add_datepicker );
+	fm_domready( fm.datepicker.add_datepicker );
 	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.datepicker.add_datepicker );
 } ) ( jQuery );

--- a/js/fieldmanager-draggablepost.js
+++ b/js/fieldmanager-draggablepost.js
@@ -1,5 +1,5 @@
 (function($) {
-	fm_domready(function() {
+	$(document).ready(function() {
 		resetEmptyMessages();
 		$('.sortables').sortable({
 			connectWith: '.sortables',

--- a/js/fieldmanager-draggablepost.js
+++ b/js/fieldmanager-draggablepost.js
@@ -1,5 +1,5 @@
 (function($) {
-	$(document).ready(function() {
+	fm_domready(function() {
 		resetEmptyMessages();
 		$('.sortables').sortable({
 			connectWith: '.sortables',

--- a/js/fieldmanager-draggablepost.js
+++ b/js/fieldmanager-draggablepost.js
@@ -1,5 +1,5 @@
 (function($) {
-	$(document).ready(function() {
+	function draggablePostInit() {
 		resetEmptyMessages();
 		$('.sortables').sortable({
 			connectWith: '.sortables',
@@ -19,7 +19,7 @@
 				setTimeout(function() { resetEmptyMessages(); populateHiddenElements(); }, 10);
 			}
 		});
-	});
+	}
 	function resetEmptyMessages() {
 		$('.post-bin').each(function(i) {
 			if ($(this).find('.draggable-post').length > 0) {
@@ -40,4 +40,6 @@
 			$('#' + input_name).val(post_ids.join(','));
 		});
 	}
+
+	fmLoadModule( draggablePostInit );
 })(jQuery);

--- a/js/fieldmanager-group-tabs.js
+++ b/js/fieldmanager-group-tabs.js
@@ -164,10 +164,5 @@ var FieldmanagerGroupTabs;
 
 	};
 
-	$(document).ready( function(){
-
-		FieldmanagerGroupTabs.init();
-
-	});
-
+	fmLoadModule( FieldmanagerGroupTabs.init );
 } )( jQuery );

--- a/js/fieldmanager-group-tabs.js
+++ b/js/fieldmanager-group-tabs.js
@@ -8,9 +8,9 @@ var FieldmanagerGroupTabs;
 		 */
 		init: function() {
 
-			this.bindEvents();
+			FieldmanagerGroupTabs.bindEvents();
 
-			this.restoreSelectedTabs();
+			FieldmanagerGroupTabs.restoreSelectedTabs();
 
 		},
 

--- a/js/fieldmanager-group-tabs.js
+++ b/js/fieldmanager-group-tabs.js
@@ -164,7 +164,7 @@ var FieldmanagerGroupTabs;
 
 	};
 
-	$(document).ready( function(){
+	fm_domready( function(){
 
 		FieldmanagerGroupTabs.init();
 

--- a/js/fieldmanager-group-tabs.js
+++ b/js/fieldmanager-group-tabs.js
@@ -164,7 +164,7 @@ var FieldmanagerGroupTabs;
 
 	};
 
-	fm_domready( function(){
+	$(document).ready( function(){
 
 		FieldmanagerGroupTabs.init();
 

--- a/js/fieldmanager-loader.js
+++ b/js/fieldmanager-loader.js
@@ -1,0 +1,46 @@
+/**
+ * A wrapper for DOM ready handlers in the global wp object and jQuery,
+ * with a shim fallback that mimics the behavior of wp.domReady.
+ * Ensures that metaboxes have loaded before initializing functionality.
+ * @param {function} callback - The callback function to execute when the DOM is ready.
+ */
+function fmLoadModule( callback ) {
+	// Use a Gutenberg subscription to listen for metaboxes being ready.
+	if ( wp && wp.data && wp.data.subscribe ) {
+		var unsubscribe = wp.data.subscribe(
+			function () {
+				// Attempt to get an instance of core/edit-post.
+				var editPost = wp.data.select( 'core/edit-post' );
+				if ( ! editPost ) {
+					return;
+				}
+
+				// Check for metaboxes in normal and side locations.
+				if ( editPost.isMetaBoxLocationVisible( 'normal' ) ) {
+					if ( document.querySelector( '.edit-post-meta-boxes-area.is-normal' ) ) {
+						unsubscribe();
+						callback();
+					}
+				} else if ( editPost.isMetaBoxLocationVisible( 'side' ) ) {
+					if ( document.querySelector( '.edit-post-meta-boxes-area.is-side' ) ) {
+						unsubscribe();
+						callback();
+					}
+				}
+			}
+		);
+	} else if ( jQuery ) {
+		jQuery( document ).ready( callback );
+	} else {
+		// Shim wp.domReady.
+		if (
+			document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+			document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+		) {
+			callback();
+		}
+
+		// DOMContentLoaded has not fired yet, delay callback until then.
+		document.addEventListener( 'DOMContentLoaded', callback );
+	}
+}

--- a/js/fieldmanager-loader.js
+++ b/js/fieldmanager-loader.js
@@ -16,6 +16,7 @@ function fmLoadModule( callback ) {
 			document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
 		) {
 			callback();
+			return;
 		}
 
 		// DOMContentLoaded has not fired yet, delay callback until then.

--- a/js/fieldmanager-loader.js
+++ b/js/fieldmanager-loader.js
@@ -5,30 +5,8 @@
  * @param {function} callback - The callback function to execute when the DOM is ready.
  */
 function fmLoadModule( callback ) {
-	// Use a Gutenberg subscription to listen for metaboxes being ready.
-	if ( wp && wp.data && wp.data.subscribe ) {
-		var unsubscribe = wp.data.subscribe(
-			function () {
-				// Attempt to get an instance of core/edit-post.
-				var editPost = wp.data.select( 'core/edit-post' );
-				if ( ! editPost ) {
-					return;
-				}
-
-				// Check for metaboxes in normal and side locations.
-				if ( editPost.isMetaBoxLocationVisible( 'normal' ) ) {
-					if ( document.querySelector( '.edit-post-meta-boxes-area.is-normal' ) ) {
-						unsubscribe();
-						callback();
-					}
-				} else if ( editPost.isMetaBoxLocationVisible( 'side' ) ) {
-					if ( document.querySelector( '.edit-post-meta-boxes-area.is-side' ) ) {
-						unsubscribe();
-						callback();
-					}
-				}
-			}
-		);
+	if ( wp && wp.domReady ) {
+		wp.domReady( callback );
 	} else if ( jQuery ) {
 		jQuery( document ).ready( callback );
 	} else {

--- a/js/fieldmanager-loader.js
+++ b/js/fieldmanager-loader.js
@@ -5,7 +5,7 @@
  * @param {function} callback - The callback function to execute when the DOM is ready.
  */
 function fmLoadModule( callback ) {
-	if ( wp && wp.domReady ) {
+	if ( 'object' === typeof wp && 'function' === typeof wp.domReady ) {
 		wp.domReady( callback );
 	} else if ( jQuery ) {
 		jQuery( document ).ready( callback );

--- a/js/fieldmanager-post.js
+++ b/js/fieldmanager-post.js
@@ -12,7 +12,7 @@ var fm_show_post_type = function( $element, post_type ) {
 var fm_show_post_date = function( $element, post_date ) {
 	if ( $element.data( 'showPostDate' ) == 1 ) {
 		$element.parent().siblings('.fmjs-post-date').remove();
-		$element.parent().siblings(".fmjs-remove, .fmjs-clear").after('<div class="fmjs-post-date">' + post_date + '</div>');	
+		$element.parent().siblings(".fmjs-remove, .fmjs-clear").after('<div class="fmjs-post-date">' + post_date + '</div>');
 	}
 }
 
@@ -35,22 +35,22 @@ var fm_typeahead_action = function( $element ) {
 				});
 			}
 		},
-		updater: function ( item ) {		
+		updater: function ( item ) {
 			// Get the post ID and post type and store them in data attributes
 			$element.data( 'id', fm_typeahead_results[item]['id'] );
 			$element.data( 'postType', fm_typeahead_results[item]['post_type'] );
 			$element.data( 'postDate', fm_typeahead_results[item]['post_date'] );
-			
+
 			// If the clear handle is enabled, show it
 			$element.parent().siblings('.fmjs-clear').show();
-			
+
 			// Show the selected post type and/or date after the clear/remove handle
 			fm_show_post_type($element, fm_typeahead_results[item]['post_type']);
 			fm_show_post_date($element, fm_typeahead_results[item]['post_date']);
-			
+
 			// Trigger that the update happened in case any other functions want to execute something here
 			$element.trigger( 'fm_post_update', [item, fm_typeahead_results[item]] );
-			
+
 			// Remove the post type and/or date from the title and return the title for the text field
 			return fm_typeahead_results[item]['post_title'];
 		},
@@ -58,24 +58,24 @@ var fm_typeahead_action = function( $element ) {
 	} );
 }
 
-$( document ).ready( function () {
+fm_domready( function () {
 	$( '.fm-post-element' ).each( function( index ) {
 		// Enable typeahead for each post field
     	fm_typeahead_action( $( this ) );
-    	
+
     	// Show the post type, date and/or clear handle (if exists) if the field is not empty and those fields are specified for display
-    	if ( $( this ).data('postType') != '' ) { 
+    	if ( $( this ).data('postType') != '' ) {
     		fm_show_post_type( $( this ), $( this ).data('postType') );
     	}
-    	
-    	if ( $( this ).data('postDate') != '' ) { 
+
+    	if ( $( this ).data('postDate') != '' ) {
     		fm_show_post_date( $( this ), $( this ).data('postDate') );
     	}
-    	
-    	if ( $( this ).data('id') != '' ) { 
+
+    	if ( $( this ).data('id') != '' ) {
     		$( this ).parent().siblings('.fmjs-clear').show();
     	}
-    	
+
 	} );
 	$( "#post" ).submit( function( e ) {
 		$( '.fm-post-element' ).each( function( index ) {

--- a/js/fieldmanager-post.js
+++ b/js/fieldmanager-post.js
@@ -12,7 +12,7 @@ var fm_show_post_type = function( $element, post_type ) {
 var fm_show_post_date = function( $element, post_date ) {
 	if ( $element.data( 'showPostDate' ) == 1 ) {
 		$element.parent().siblings('.fmjs-post-date').remove();
-		$element.parent().siblings(".fmjs-remove, .fmjs-clear").after('<div class="fmjs-post-date">' + post_date + '</div>');	
+		$element.parent().siblings(".fmjs-remove, .fmjs-clear").after('<div class="fmjs-post-date">' + post_date + '</div>');
 	}
 }
 
@@ -35,22 +35,22 @@ var fm_typeahead_action = function( $element ) {
 				});
 			}
 		},
-		updater: function ( item ) {		
+		updater: function ( item ) {
 			// Get the post ID and post type and store them in data attributes
 			$element.data( 'id', fm_typeahead_results[item]['id'] );
 			$element.data( 'postType', fm_typeahead_results[item]['post_type'] );
 			$element.data( 'postDate', fm_typeahead_results[item]['post_date'] );
-			
+
 			// If the clear handle is enabled, show it
 			$element.parent().siblings('.fmjs-clear').show();
-			
+
 			// Show the selected post type and/or date after the clear/remove handle
 			fm_show_post_type($element, fm_typeahead_results[item]['post_type']);
 			fm_show_post_date($element, fm_typeahead_results[item]['post_date']);
-			
+
 			// Trigger that the update happened in case any other functions want to execute something here
 			$element.trigger( 'fm_post_update', [item, fm_typeahead_results[item]] );
-			
+
 			// Remove the post type and/or date from the title and return the title for the text field
 			return fm_typeahead_results[item]['post_title'];
 		},
@@ -58,24 +58,24 @@ var fm_typeahead_action = function( $element ) {
 	} );
 }
 
-$( document ).ready( function () {
+function fm_post_init() {
 	$( '.fm-post-element' ).each( function( index ) {
 		// Enable typeahead for each post field
     	fm_typeahead_action( $( this ) );
-    	
+
     	// Show the post type, date and/or clear handle (if exists) if the field is not empty and those fields are specified for display
-    	if ( $( this ).data('postType') != '' ) { 
+    	if ( $( this ).data('postType') != '' ) {
     		fm_show_post_type( $( this ), $( this ).data('postType') );
     	}
-    	
-    	if ( $( this ).data('postDate') != '' ) { 
+
+    	if ( $( this ).data('postDate') != '' ) {
     		fm_show_post_date( $( this ), $( this ).data('postDate') );
     	}
-    	
-    	if ( $( this ).data('id') != '' ) { 
+
+    	if ( $( this ).data('id') != '' ) {
     		$( this ).parent().siblings('.fmjs-clear').show();
     	}
-    	
+
 	} );
 	$( "#post" ).submit( function( e ) {
 		$( '.fm-post-element' ).each( function( index ) {
@@ -90,6 +90,8 @@ $( document ).ready( function () {
   		$post_element = $(event.target).find( '.fm-post-element' );
 		if ( $post_element.length != 0 ) fm_typeahead_action( $post_element );
 	} );
-} );
+}
+
+fmLoadModule( fm_post_init );
 
 } )( jQuery );

--- a/js/fieldmanager-post.js
+++ b/js/fieldmanager-post.js
@@ -12,7 +12,7 @@ var fm_show_post_type = function( $element, post_type ) {
 var fm_show_post_date = function( $element, post_date ) {
 	if ( $element.data( 'showPostDate' ) == 1 ) {
 		$element.parent().siblings('.fmjs-post-date').remove();
-		$element.parent().siblings(".fmjs-remove, .fmjs-clear").after('<div class="fmjs-post-date">' + post_date + '</div>');
+		$element.parent().siblings(".fmjs-remove, .fmjs-clear").after('<div class="fmjs-post-date">' + post_date + '</div>');	
 	}
 }
 
@@ -35,22 +35,22 @@ var fm_typeahead_action = function( $element ) {
 				});
 			}
 		},
-		updater: function ( item ) {
+		updater: function ( item ) {		
 			// Get the post ID and post type and store them in data attributes
 			$element.data( 'id', fm_typeahead_results[item]['id'] );
 			$element.data( 'postType', fm_typeahead_results[item]['post_type'] );
 			$element.data( 'postDate', fm_typeahead_results[item]['post_date'] );
-
+			
 			// If the clear handle is enabled, show it
 			$element.parent().siblings('.fmjs-clear').show();
-
+			
 			// Show the selected post type and/or date after the clear/remove handle
 			fm_show_post_type($element, fm_typeahead_results[item]['post_type']);
 			fm_show_post_date($element, fm_typeahead_results[item]['post_date']);
-
+			
 			// Trigger that the update happened in case any other functions want to execute something here
 			$element.trigger( 'fm_post_update', [item, fm_typeahead_results[item]] );
-
+			
 			// Remove the post type and/or date from the title and return the title for the text field
 			return fm_typeahead_results[item]['post_title'];
 		},
@@ -58,24 +58,24 @@ var fm_typeahead_action = function( $element ) {
 	} );
 }
 
-fm_domready( function () {
+$( document ).ready( function () {
 	$( '.fm-post-element' ).each( function( index ) {
 		// Enable typeahead for each post field
     	fm_typeahead_action( $( this ) );
-
+    	
     	// Show the post type, date and/or clear handle (if exists) if the field is not empty and those fields are specified for display
-    	if ( $( this ).data('postType') != '' ) {
+    	if ( $( this ).data('postType') != '' ) { 
     		fm_show_post_type( $( this ), $( this ).data('postType') );
     	}
-
-    	if ( $( this ).data('postDate') != '' ) {
+    	
+    	if ( $( this ).data('postDate') != '' ) { 
     		fm_show_post_date( $( this ), $( this ).data('postDate') );
     	}
-
-    	if ( $( this ).data('id') != '' ) {
+    	
+    	if ( $( this ).data('id') != '' ) { 
     		$( this ).parent().siblings('.fmjs-clear').show();
     	}
-
+    	
 	} );
 	$( "#post" ).submit( function( e ) {
 		$( '.fm-post-element' ).each( function( index ) {

--- a/js/fieldmanager-quickedit.js
+++ b/js/fieldmanager-quickedit.js
@@ -1,6 +1,6 @@
 ( function( $ ) {
 
-	$( document ).ready( function() {
+	fm_domready( function() {
 		if ( typeof( inlineEditPost ) == 'undefined' ) {
 			return;
 		}

--- a/js/fieldmanager-quickedit.js
+++ b/js/fieldmanager-quickedit.js
@@ -1,6 +1,6 @@
 ( function( $ ) {
 
-	$( document ).ready( function() {
+	function fm_quickedit_init() {
 		if ( typeof( inlineEditPost ) == 'undefined' ) {
 			return;
 		}
@@ -29,6 +29,7 @@
 				} );
 			}
 		}
-	} );
+	}
 
+	fmLoadModule( fm_quickedit_init );
 } )( jQuery );

--- a/js/fieldmanager-quickedit.js
+++ b/js/fieldmanager-quickedit.js
@@ -1,6 +1,6 @@
 ( function( $ ) {
 
-	fm_domready( function() {
+	$( document ).ready( function() {
 		if ( typeof( inlineEditPost ) == 'undefined' ) {
 			return;
 		}

--- a/js/fieldmanager-select.js
+++ b/js/fieldmanager-select.js
@@ -42,7 +42,7 @@ fm_reset_chosen = function( $fm_text_field, fm_text_field_val ) {
 	} );
 }
 
-$( document ).ready( function() {
+function fm_select_init() {
 
 	// Track changes to the chosen text field linked to the select in order to update options via Ajax
 	// Used for taxonomy-based fields where preload is disabled
@@ -99,6 +99,8 @@ $( document ).ready( function() {
 		if( $this_select_field.data("taxonomy") != "" && $this_select_field.data("taxonomyPreload") == false ) fm_select_clear_terms( $this_select_field, $(this).parents('.chosen-choices'), true );
 	} );
 
-} );
+}
+
+fmLoadModule( fm_select_init );
 
 } )( jQuery );

--- a/js/fieldmanager-select.js
+++ b/js/fieldmanager-select.js
@@ -42,7 +42,7 @@ fm_reset_chosen = function( $fm_text_field, fm_text_field_val ) {
 	} );
 }
 
-$( document ).ready( function() {
+fm_domready( function() {
 
 	// Track changes to the chosen text field linked to the select in order to update options via Ajax
 	// Used for taxonomy-based fields where preload is disabled

--- a/js/fieldmanager-select.js
+++ b/js/fieldmanager-select.js
@@ -42,7 +42,7 @@ fm_reset_chosen = function( $fm_text_field, fm_text_field_val ) {
 	} );
 }
 
-fm_domready( function() {
+$( document ).ready( function() {
 
 	// Track changes to the chosen text field linked to the select in order to update options via Ajax
 	// Used for taxonomy-based fields where preload is disabled

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -278,11 +278,6 @@ var fm_init = function () {
 	$( document ).on( 'fm_activate_tab', init_sortable );
 };
 
-// Use the wp.domReady helper, if it is available.
-if (wp && wp.domReady) {
-	wp.domReady(fm_init);
-} else {
-	$(document).ready(fm_init);
-}
+fmLoadModule( fm_init );
 
 } )( jQuery );

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -278,19 +278,11 @@ var fm_init = function () {
 	$( document ).on( 'fm_activate_tab', init_sortable );
 };
 
-/**
- * A wrapper for either wp.domReady or jQuery's ready function.
- * @param {function} callback - A callback function to execute on DOM ready.
- */
-var fm_domready = function ( callback ) {
-	if ( wp && wp.domReady ) {
-		wp.domReady( callback );
-	} else {
-		$( document ).ready( callback );
-	}
+// Use the wp.domReady helper, if it is available.
+if (wp && wp.domReady) {
+	wp.domReady(fm_init);
+} else {
+	$(document).ready(fm_init);
 }
-
-// Initialize Fieldmanager when the DOM is ready.
-fm_domready( fm_init );
 
 } )( jQuery );

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -278,11 +278,19 @@ var fm_init = function () {
 	$( document ).on( 'fm_activate_tab', init_sortable );
 };
 
-// Use the wp.domReady helper, if it is available.
-if (wp && wp.domReady) {
-	wp.domReady(fm_init);
-} else {
-	$(document).ready(fm_init);
+/**
+ * A wrapper for either wp.domReady or jQuery's ready function.
+ * @param {function} callback - A callback function to execute on DOM ready.
+ */
+var fm_domready = function ( callback ) {
+	if ( wp && wp.domReady ) {
+		wp.domReady( callback );
+	} else {
+		$( document ).ready( callback );
+	}
 }
+
+// Initialize Fieldmanager when the DOM is ready.
+fm_domready( fm_init );
 
 } )( jQuery );

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -173,7 +173,7 @@ fm_remove = function( $element ) {
 	fm_renumber( $wrapper );
 }
 
-$( document ).ready( function () {
+var fm_init = function () {
 	$( document ).on( 'click', '.fm-add-another', function( e ) {
 		e.preventDefault();
 		fm_add_another( $( this ) );
@@ -276,6 +276,13 @@ $( document ).ready( function () {
 	init_sortable();
 
 	$( document ).on( 'fm_activate_tab', init_sortable );
-} );
+};
+
+// Use the wp.domReady helper, if it is available.
+if (wp && wp.domReady) {
+	wp.domReady(fm_init);
+} else {
+	$(document).ready(fm_init);
+}
 
 } )( jQuery );

--- a/js/grid.js
+++ b/js/grid.js
@@ -107,8 +107,6 @@ $( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm
 	$.fm_grid_init();
 } );
 
-$( document ).ready( function() {
-	$.fm_grid_init();
-} );
+fmLoadModule( $.fm_grid_init );
 
 })( jQuery );

--- a/js/grid.js
+++ b/js/grid.js
@@ -107,7 +107,7 @@ $( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm
 	$.fm_grid_init();
 } );
 
-fm_domready( function() {
+$( document ).ready( function() {
 	$.fm_grid_init();
 } );
 

--- a/js/grid.js
+++ b/js/grid.js
@@ -107,7 +107,7 @@ $( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm
 	$.fm_grid_init();
 } );
 
-$( document ).ready( function() {
+fm_domready( function() {
 	$.fm_grid_init();
 } );
 

--- a/js/richtext.js
+++ b/js/richtext.js
@@ -151,10 +151,12 @@
 	 * On document.load, init the editors and make the global meta box drag-drop
 	 * event reload the editors.
 	 */
-	$( function() {
-		fm.richtextarea.add_rte_to_visible_textareas();
-		$( '.meta-box-sortables' ).on( 'sortstop', function( e, obj ) {
-			fm.richtextarea.reload_editors( e, obj.item[0] );
-		} );
-	} );
+	fmLoadModule(
+		function() {
+			fm.richtextarea.add_rte_to_visible_textareas();
+			$( '.meta-box-sortables' ).on( 'sortstop', function( e, obj ) {
+				fm.richtextarea.reload_editors( e, obj.item[0] );
+			} );
+		}
+	);
 } ) ( jQuery );

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "Fieldmanager",
   "description": "Fieldmanager is a comprehensive toolkit for building forms, metaboxes, and custom admin screens for WordPress.",
   "version": "1.2.4",
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/alleyinteractive/wordpress-fieldmanager"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alleyinteractive/wordpress-fieldmanager"
   },
   "license": "GPL-2.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Fieldmanager",
   "description": "Fieldmanager is a comprehensive toolkit for building forms, metaboxes, and custom admin screens for WordPress.",
-  "version": "1.2.4",
+  "version": "1.2.5-beta2",
   "repository": {
     "type": "git",
     "url": "https://github.com/alleyinteractive/wordpress-fieldmanager"

--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -78,7 +78,7 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 			'fm_autocomplete_js',
 			'js/fieldmanager-autocomplete.js',
 			array( 'fieldmanager_script', 'jquery-ui-autocomplete' ),
-			'1.0.6',
+			FM_VERSION,
 			false,
 			'fm_search',
 			array(

--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -79,7 +79,7 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 			'js/fieldmanager-autocomplete.js',
 			array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-autocomplete' ),
 			FM_VERSION,
-			false,
+			true,
 			'fm_search',
 			array(
 				'nonce' => wp_create_nonce( 'fm_search_nonce' ),

--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -79,7 +79,7 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 			'js/fieldmanager-autocomplete.js',
 			array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-autocomplete' ),
 			FM_VERSION,
-			true,
+			false,
 			'fm_search',
 			array(
 				'nonce' => wp_create_nonce( 'fm_search_nonce' ),

--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -77,9 +77,9 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 		fm_add_script(
 			'fm_autocomplete_js',
 			'js/fieldmanager-autocomplete.js',
-			array( 'fieldmanager_script', 'jquery-ui-autocomplete' ),
+			array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-autocomplete' ),
 			FM_VERSION,
-			false,
+			true,
 			'fm_search',
 			array(
 				'nonce' => wp_create_nonce( 'fm_search_nonce' ),

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -36,7 +36,7 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	 * @param array  $options The options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
-		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'fm_loader', 'jquery', 'wp-color-picker' ), FM_VERSION, true );
+		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'fm_loader', 'jquery', 'wp-color-picker' ), FM_VERSION );
 		fm_add_style( 'wp-color-picker' );
 
 		$this->sanitize = 'sanitize_hex_color';

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -36,7 +36,7 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	 * @param array  $options The options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
-		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'fieldmanager_script', 'jquery', 'wp-color-picker' ), FM_VERSION, true );
+		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'jquery', 'wp-color-picker' ), FM_VERSION, true );
 		fm_add_style( 'wp-color-picker' );
 
 		$this->sanitize = 'sanitize_hex_color';

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -36,7 +36,7 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	 * @param array  $options The options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
-		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'jquery', 'wp-color-picker' ), FM_VERSION, true );
+		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'fieldmanager_script', 'jquery', 'wp-color-picker' ), FM_VERSION, true );
 		fm_add_style( 'wp-color-picker' );
 
 		$this->sanitize = 'sanitize_hex_color';

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -36,7 +36,7 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	 * @param array  $options The options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
-		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'fm_loader', 'jquery', 'wp-color-picker' ), FM_VERSION );
+		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'fm_loader', 'jquery', 'wp-color-picker' ), FM_VERSION, true );
 		fm_add_style( 'wp-color-picker' );
 
 		$this->sanitize = 'sanitize_hex_color';

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -36,7 +36,7 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	 * @param array  $options The options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
-		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'jquery', 'wp-color-picker' ), FM_VERSION, true );
+		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'fm_loader', 'jquery', 'wp-color-picker' ), FM_VERSION, true );
 		fm_add_style( 'wp-color-picker' );
 
 		$this->sanitize = 'sanitize_hex_color';

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -36,7 +36,7 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	 * @param array  $options The options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
-		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'jquery', 'wp-color-picker' ), '1.0', true );
+		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'jquery', 'wp-color-picker' ), FM_VERSION, true );
 		fm_add_style( 'wp-color-picker' );
 
 		$this->sanitize = 'sanitize_hex_color';

--- a/php/class-fieldmanager-datepicker.php
+++ b/php/class-fieldmanager-datepicker.php
@@ -70,7 +70,7 @@ class Fieldmanager_Datepicker extends Fieldmanager_Field {
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		fm_add_style( 'fm-jquery-ui', 'css/jquery-ui/jquery-ui-1.10.2.custom.min.css' );
-		fm_add_script( 'fm_datepicker', 'js/fieldmanager-datepicker.js', array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-datepicker' ), FM_VERSION );
+		fm_add_script( 'fm_datepicker', 'js/fieldmanager-datepicker.js', array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-datepicker' ), FM_VERSION, true );
 		parent::__construct( $label, $options );
 
 		if ( empty( $this->js_opts ) ) {

--- a/php/class-fieldmanager-datepicker.php
+++ b/php/class-fieldmanager-datepicker.php
@@ -70,7 +70,7 @@ class Fieldmanager_Datepicker extends Fieldmanager_Field {
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		fm_add_style( 'fm-jquery-ui', 'css/jquery-ui/jquery-ui-1.10.2.custom.min.css' );
-		fm_add_script( 'fm_datepicker', 'js/fieldmanager-datepicker.js', array( 'fieldmanager_script', 'jquery-ui-datepicker' ) );
+		fm_add_script( 'fm_datepicker', 'js/fieldmanager-datepicker.js', array( 'fieldmanager_script', 'jquery-ui-datepicker' ), FM_VERSION );
 		parent::__construct( $label, $options );
 
 		if ( empty( $this->js_opts ) ) {

--- a/php/class-fieldmanager-datepicker.php
+++ b/php/class-fieldmanager-datepicker.php
@@ -70,7 +70,7 @@ class Fieldmanager_Datepicker extends Fieldmanager_Field {
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		fm_add_style( 'fm-jquery-ui', 'css/jquery-ui/jquery-ui-1.10.2.custom.min.css' );
-		fm_add_script( 'fm_datepicker', 'js/fieldmanager-datepicker.js', array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-datepicker' ), FM_VERSION, true );
+		fm_add_script( 'fm_datepicker', 'js/fieldmanager-datepicker.js', array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-datepicker' ), FM_VERSION );
 		parent::__construct( $label, $options );
 
 		if ( empty( $this->js_opts ) ) {

--- a/php/class-fieldmanager-datepicker.php
+++ b/php/class-fieldmanager-datepicker.php
@@ -70,7 +70,7 @@ class Fieldmanager_Datepicker extends Fieldmanager_Field {
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		fm_add_style( 'fm-jquery-ui', 'css/jquery-ui/jquery-ui-1.10.2.custom.min.css' );
-		fm_add_script( 'fm_datepicker', 'js/fieldmanager-datepicker.js', array( 'fieldmanager_script', 'jquery-ui-datepicker' ), FM_VERSION );
+		fm_add_script( 'fm_datepicker', 'js/fieldmanager-datepicker.js', array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-datepicker' ), FM_VERSION, true );
 		parent::__construct( $label, $options );
 
 		if ( empty( $this->js_opts ) ) {

--- a/php/class-fieldmanager-draggablepost.php
+++ b/php/class-fieldmanager-draggablepost.php
@@ -57,7 +57,7 @@ class Fieldmanager_DraggablePost extends Fieldmanager_Field {
 		// Refuse to allow more than one instance of this field type.
 		$this->limit = 1;
 
-		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION );
+		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'fm_loader', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION, true );
 		fm_add_style( 'fm_draggablepost_css', 'css/fieldmanager-draggablepost.css', array(), FM_VERSION );
 	}
 

--- a/php/class-fieldmanager-draggablepost.php
+++ b/php/class-fieldmanager-draggablepost.php
@@ -57,7 +57,7 @@ class Fieldmanager_DraggablePost extends Fieldmanager_Field {
 		// Refuse to allow more than one instance of this field type.
 		$this->limit = 1;
 
-		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION );
+		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'fieldmanager_script', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION );
 		fm_add_style( 'fm_draggablepost_css', 'css/fieldmanager-draggablepost.css', array(), FM_VERSION );
 	}
 

--- a/php/class-fieldmanager-draggablepost.php
+++ b/php/class-fieldmanager-draggablepost.php
@@ -57,7 +57,7 @@ class Fieldmanager_DraggablePost extends Fieldmanager_Field {
 		// Refuse to allow more than one instance of this field type.
 		$this->limit = 1;
 
-		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'fm_loader', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION );
+		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'fm_loader', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION, true );
 		fm_add_style( 'fm_draggablepost_css', 'css/fieldmanager-draggablepost.css', array(), FM_VERSION );
 	}
 

--- a/php/class-fieldmanager-draggablepost.php
+++ b/php/class-fieldmanager-draggablepost.php
@@ -57,8 +57,8 @@ class Fieldmanager_DraggablePost extends Fieldmanager_Field {
 		// Refuse to allow more than one instance of this field type.
 		$this->limit = 1;
 
-		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ) );
-		fm_add_style( 'fm_draggablepost_css', 'css/fieldmanager-draggablepost.css' );
+		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION );
+		fm_add_style( 'fm_draggablepost_css', 'css/fieldmanager-draggablepost.css', array(), FM_VERSION );
 	}
 
 	/**

--- a/php/class-fieldmanager-draggablepost.php
+++ b/php/class-fieldmanager-draggablepost.php
@@ -57,7 +57,7 @@ class Fieldmanager_DraggablePost extends Fieldmanager_Field {
 		// Refuse to allow more than one instance of this field type.
 		$this->limit = 1;
 
-		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'fm_loader', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION, true );
+		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'fm_loader', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION );
 		fm_add_style( 'fm_draggablepost_css', 'css/fieldmanager-draggablepost.css', array(), FM_VERSION );
 	}
 

--- a/php/class-fieldmanager-draggablepost.php
+++ b/php/class-fieldmanager-draggablepost.php
@@ -57,7 +57,7 @@ class Fieldmanager_DraggablePost extends Fieldmanager_Field {
 		// Refuse to allow more than one instance of this field type.
 		$this->limit = 1;
 
-		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'fieldmanager_script', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION );
+		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION );
 		fm_add_style( 'fm_draggablepost_css', 'css/fieldmanager-draggablepost.css', array(), FM_VERSION );
 	}
 

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -409,7 +409,7 @@ abstract class Fieldmanager_Field {
 
 		// Only enqueue base assets once, and only when we have a field.
 		if ( ! self::$enqueued_base_assets ) {
-			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'fieldmanager_script', 'jquery', 'jquery-ui-sortable' ), FM_VERSION );
+			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'jquery', 'jquery-ui-sortable' ), FM_VERSION );
 			fm_add_style( 'fieldmanager_style', 'css/fieldmanager.css', array(), FM_VERSION );
 			self::$enqueued_base_assets = true;
 		}

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -409,7 +409,7 @@ abstract class Fieldmanager_Field {
 
 		// Only enqueue base assets once, and only when we have a field.
 		if ( ! self::$enqueued_base_assets ) {
-			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'jquery', 'jquery-ui-sortable' ), FM_VERSION );
+			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'fieldmanager_script', 'jquery', 'jquery-ui-sortable' ), FM_VERSION );
 			fm_add_style( 'fieldmanager_style', 'css/fieldmanager.css', array(), FM_VERSION );
 			self::$enqueued_base_assets = true;
 		}

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -409,7 +409,7 @@ abstract class Fieldmanager_Field {
 
 		// Only enqueue base assets once, and only when we have a field.
 		if ( ! self::$enqueued_base_assets ) {
-			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'jquery', 'jquery-ui-sortable' ), FM_VERSION );
+			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'fm_loader', 'jquery', 'jquery-ui-sortable' ), FM_VERSION, true );
 			fm_add_style( 'fieldmanager_style', 'css/fieldmanager.css', array(), FM_VERSION );
 			self::$enqueued_base_assets = true;
 		}

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -409,7 +409,7 @@ abstract class Fieldmanager_Field {
 
 		// Only enqueue base assets once, and only when we have a field.
 		if ( ! self::$enqueued_base_assets ) {
-			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'fm_loader', 'jquery', 'jquery-ui-sortable' ), FM_VERSION, true );
+			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'fm_loader', 'jquery', 'jquery-ui-sortable' ), FM_VERSION );
 			fm_add_style( 'fieldmanager_style', 'css/fieldmanager.css', array(), FM_VERSION );
 			self::$enqueued_base_assets = true;
 		}

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -409,8 +409,8 @@ abstract class Fieldmanager_Field {
 
 		// Only enqueue base assets once, and only when we have a field.
 		if ( ! self::$enqueued_base_assets ) {
-			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'jquery', 'jquery-ui-sortable' ), '1.2.1' );
-			fm_add_style( 'fieldmanager_style', 'css/fieldmanager.css', array(), '1.0.4' );
+			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'jquery', 'jquery-ui-sortable' ), FM_VERSION );
+			fm_add_style( 'fieldmanager_style', 'css/fieldmanager.css', array(), FM_VERSION );
 			self::$enqueued_base_assets = true;
 		}
 	}

--- a/php/class-fieldmanager-grid.php
+++ b/php/class-fieldmanager-grid.php
@@ -55,7 +55,7 @@ class Fieldmanager_Grid extends Fieldmanager_Field {
 		fm_add_script( 'handsontable', 'js/grid/jquery.handsontable.js' );
 		fm_add_script( 'contextmenu', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.js' );
 		fm_add_script( 'ui_position', 'js/grid/lib/jQuery-contextMenu/jquery.ui.position.js' );
-		fm_add_script( 'grid', 'js/grid.js', array( 'fieldmanager_script', 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION );
+		fm_add_script( 'grid', 'js/grid.js', array( 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION );
 		fm_add_style( 'context_menu_css', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.css' );
 		fm_add_style( 'handsontable_css', 'js/grid/jquery.handsontable.css' );
 	}

--- a/php/class-fieldmanager-grid.php
+++ b/php/class-fieldmanager-grid.php
@@ -55,7 +55,7 @@ class Fieldmanager_Grid extends Fieldmanager_Field {
 		fm_add_script( 'handsontable', 'js/grid/jquery.handsontable.js' );
 		fm_add_script( 'contextmenu', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.js' );
 		fm_add_script( 'ui_position', 'js/grid/lib/jQuery-contextMenu/jquery.ui.position.js' );
-		fm_add_script( 'grid', 'js/grid.js', array( 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION );
+		fm_add_script( 'grid', 'js/grid.js', array( 'fm_loader', 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION, true );
 		fm_add_style( 'context_menu_css', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.css' );
 		fm_add_style( 'handsontable_css', 'js/grid/jquery.handsontable.css' );
 	}

--- a/php/class-fieldmanager-grid.php
+++ b/php/class-fieldmanager-grid.php
@@ -55,7 +55,7 @@ class Fieldmanager_Grid extends Fieldmanager_Field {
 		fm_add_script( 'handsontable', 'js/grid/jquery.handsontable.js' );
 		fm_add_script( 'contextmenu', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.js' );
 		fm_add_script( 'ui_position', 'js/grid/lib/jQuery-contextMenu/jquery.ui.position.js' );
-		fm_add_script( 'grid', 'js/grid.js', array( 'fm_loader', 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION );
+		fm_add_script( 'grid', 'js/grid.js', array( 'fm_loader', 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION, true );
 		fm_add_style( 'context_menu_css', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.css' );
 		fm_add_style( 'handsontable_css', 'js/grid/jquery.handsontable.css' );
 	}

--- a/php/class-fieldmanager-grid.php
+++ b/php/class-fieldmanager-grid.php
@@ -55,7 +55,7 @@ class Fieldmanager_Grid extends Fieldmanager_Field {
 		fm_add_script( 'handsontable', 'js/grid/jquery.handsontable.js' );
 		fm_add_script( 'contextmenu', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.js' );
 		fm_add_script( 'ui_position', 'js/grid/lib/jQuery-contextMenu/jquery.ui.position.js' );
-		fm_add_script( 'grid', 'js/grid.js', array( 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION );
+		fm_add_script( 'grid', 'js/grid.js', array( 'fieldmanager_script', 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION );
 		fm_add_style( 'context_menu_css', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.css' );
 		fm_add_style( 'handsontable_css', 'js/grid/jquery.handsontable.css' );
 	}

--- a/php/class-fieldmanager-grid.php
+++ b/php/class-fieldmanager-grid.php
@@ -55,7 +55,7 @@ class Fieldmanager_Grid extends Fieldmanager_Field {
 		fm_add_script( 'handsontable', 'js/grid/jquery.handsontable.js' );
 		fm_add_script( 'contextmenu', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.js' );
 		fm_add_script( 'ui_position', 'js/grid/lib/jQuery-contextMenu/jquery.ui.position.js' );
-		fm_add_script( 'grid', 'js/grid.js', array( 'fm_loader', 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION, true );
+		fm_add_script( 'grid', 'js/grid.js', array( 'fm_loader', 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION );
 		fm_add_style( 'context_menu_css', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.css' );
 		fm_add_style( 'handsontable_css', 'js/grid/jquery.handsontable.css' );
 	}

--- a/php/class-fieldmanager-grid.php
+++ b/php/class-fieldmanager-grid.php
@@ -55,7 +55,7 @@ class Fieldmanager_Grid extends Fieldmanager_Field {
 		fm_add_script( 'handsontable', 'js/grid/jquery.handsontable.js' );
 		fm_add_script( 'contextmenu', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.js' );
 		fm_add_script( 'ui_position', 'js/grid/lib/jQuery-contextMenu/jquery.ui.position.js' );
-		fm_add_script( 'grid', 'js/grid.js' );
+		fm_add_script( 'grid', 'js/grid.js', array( 'handsontable', 'contextmenu', 'ui_position' ), FM_VERSION );
 		fm_add_style( 'context_menu_css', 'js/grid/lib/jQuery-contextMenu/jquery.contextMenu.css' );
 		fm_add_style( 'handsontable_css', 'js/grid/jquery.handsontable.css' );
 	}

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -196,7 +196,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		// Add the tab JS and CSS if it is needed.
 		if ( $this->tabbed ) {
 			fm_add_script( 'jquery-hoverintent', 'js/jquery.hoverIntent.js', array( 'jquery' ), '1.8.1' );
-			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'jquery', 'jquery-hoverintent' ), FM_VERSION );
+			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'fieldmanager_script', 'jquery', 'jquery-hoverintent' ), FM_VERSION );
 			fm_add_style( 'fm_group_tabs_css', 'css/fieldmanager-group-tabs.css', array(), FM_VERSION );
 		}
 	}

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -196,7 +196,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		// Add the tab JS and CSS if it is needed.
 		if ( $this->tabbed ) {
 			fm_add_script( 'jquery-hoverintent', 'js/jquery.hoverIntent.js', array( 'jquery' ), '1.8.1' );
-			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'jquery', 'jquery-hoverintent' ), FM_VERSION );
+			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'fm_loader', 'jquery', 'jquery-hoverintent' ), FM_VERSION, true );
 			fm_add_style( 'fm_group_tabs_css', 'css/fieldmanager-group-tabs.css', array(), FM_VERSION );
 		}
 	}

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -196,7 +196,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		// Add the tab JS and CSS if it is needed.
 		if ( $this->tabbed ) {
 			fm_add_script( 'jquery-hoverintent', 'js/jquery.hoverIntent.js', array( 'jquery' ), '1.8.1' );
-			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'fm_loader', 'jquery', 'jquery-hoverintent' ), FM_VERSION );
+			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'fm_loader', 'jquery', 'jquery-hoverintent' ), FM_VERSION, true );
 			fm_add_style( 'fm_group_tabs_css', 'css/fieldmanager-group-tabs.css', array(), FM_VERSION );
 		}
 	}

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -196,7 +196,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		// Add the tab JS and CSS if it is needed.
 		if ( $this->tabbed ) {
 			fm_add_script( 'jquery-hoverintent', 'js/jquery.hoverIntent.js', array( 'jquery' ), '1.8.1' );
-			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'fieldmanager_script', 'jquery', 'jquery-hoverintent' ), FM_VERSION );
+			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'jquery', 'jquery-hoverintent' ), FM_VERSION );
 			fm_add_style( 'fm_group_tabs_css', 'css/fieldmanager-group-tabs.css', array(), FM_VERSION );
 		}
 	}

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -196,7 +196,7 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		// Add the tab JS and CSS if it is needed.
 		if ( $this->tabbed ) {
 			fm_add_script( 'jquery-hoverintent', 'js/jquery.hoverIntent.js', array( 'jquery' ), '1.8.1' );
-			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'fm_loader', 'jquery', 'jquery-hoverintent' ), FM_VERSION, true );
+			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'fm_loader', 'jquery', 'jquery-hoverintent' ), FM_VERSION );
 			fm_add_style( 'fm_group_tabs_css', 'css/fieldmanager-group-tabs.css', array(), FM_VERSION );
 		}
 	}

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -196,8 +196,8 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		// Add the tab JS and CSS if it is needed.
 		if ( $this->tabbed ) {
 			fm_add_script( 'jquery-hoverintent', 'js/jquery.hoverIntent.js', array( 'jquery' ), '1.8.1' );
-			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'jquery', 'jquery-hoverintent' ), '1.0.4' );
-			fm_add_style( 'fm_group_tabs_css', 'css/fieldmanager-group-tabs.css', array(), '1.0.5' );
+			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'jquery', 'jquery-hoverintent' ), FM_VERSION );
+			fm_add_style( 'fm_group_tabs_css', 'css/fieldmanager-group-tabs.css', array(), FM_VERSION );
 		}
 	}
 

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -107,7 +107,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 		$this->remove_media_label   = __( 'remove', 'fieldmanager' );
 
 		if ( ! self::$has_registered_media ) {
-			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), FM_VERSION );
+			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'fieldmanager_script', 'jquery' ), FM_VERSION );
 			if ( did_action( 'admin_print_scripts' ) ) {
 				$this->admin_print_scripts();
 			} else {

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -107,7 +107,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 		$this->remove_media_label   = __( 'remove', 'fieldmanager' );
 
 		if ( ! self::$has_registered_media ) {
-			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), FM_VERSION );
+			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), FM_VERSION, true );
 			if ( did_action( 'admin_print_scripts' ) ) {
 				$this->admin_print_scripts();
 			} else {

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -107,7 +107,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 		$this->remove_media_label   = __( 'remove', 'fieldmanager' );
 
 		if ( ! self::$has_registered_media ) {
-			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'fieldmanager_script', 'jquery' ), FM_VERSION );
+			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), FM_VERSION );
 			if ( did_action( 'admin_print_scripts' ) ) {
 				$this->admin_print_scripts();
 			} else {

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -107,7 +107,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 		$this->remove_media_label   = __( 'remove', 'fieldmanager' );
 
 		if ( ! self::$has_registered_media ) {
-			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), '1.0.4' );
+			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), FM_VERSION );
 			if ( did_action( 'admin_print_scripts' ) ) {
 				$this->admin_print_scripts();
 			} else {

--- a/php/class-fieldmanager-options.php
+++ b/php/class-fieldmanager-options.php
@@ -76,7 +76,7 @@ abstract class Fieldmanager_Options extends Fieldmanager_Field {
 		}
 
 		// Add the options CSS.
-		fm_add_style( 'fm_options_css', 'css/fieldmanager-options.css' );
+		fm_add_style( 'fm_options_css', 'css/fieldmanager-options.css', array(), FM_VERSION );
 	}
 
 	/**

--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -104,7 +104,7 @@ class Fieldmanager_RichTextArea extends Fieldmanager_Field {
 		$this->sanitize = array( $this, 'sanitize' );
 
 		// 'utils' provides getUserSetting().
-		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'fm_loader', 'jquery', 'fieldmanager_script', 'utils' ), FM_VERSION, true );
+		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'fm_loader', 'jquery', 'fieldmanager_script', 'utils' ), FM_VERSION );
 
 		parent::__construct( $label, $options );
 	}

--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -104,7 +104,7 @@ class Fieldmanager_RichTextArea extends Fieldmanager_Field {
 		$this->sanitize = array( $this, 'sanitize' );
 
 		// 'utils' provides getUserSetting().
-		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'jquery', 'fieldmanager_script', 'utils' ), FM_VERSION );
+		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'fm_loader', 'jquery', 'fieldmanager_script', 'utils' ), FM_VERSION, true );
 
 		parent::__construct( $label, $options );
 	}

--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -104,7 +104,7 @@ class Fieldmanager_RichTextArea extends Fieldmanager_Field {
 		$this->sanitize = array( $this, 'sanitize' );
 
 		// 'utils' provides getUserSetting().
-		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'fm_loader', 'jquery', 'fieldmanager_script', 'utils' ), FM_VERSION );
+		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'fm_loader', 'jquery', 'fieldmanager_script', 'utils' ), FM_VERSION, true );
 
 		parent::__construct( $label, $options );
 	}

--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -104,7 +104,7 @@ class Fieldmanager_RichTextArea extends Fieldmanager_Field {
 		$this->sanitize = array( $this, 'sanitize' );
 
 		// 'utils' provides getUserSetting().
-		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'jquery', 'fieldmanager_script', 'utils' ), '1.0.8' );
+		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'jquery', 'fieldmanager_script', 'utils' ), FM_VERSION );
 
 		parent::__construct( $label, $options );
 	}

--- a/php/class-fieldmanager-select.php
+++ b/php/class-fieldmanager-select.php
@@ -61,7 +61,7 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 			'js/fieldmanager-select.js',
 			array( 'fm_loader' ),
 			FM_VERSION,
-			false,
+			true,
 			'fm_select',
 			array(
 				'nonce' => wp_create_nonce( 'fm_search_terms_nonce' ),

--- a/php/class-fieldmanager-select.php
+++ b/php/class-fieldmanager-select.php
@@ -59,7 +59,7 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 		fm_add_script(
 			'fm_select_js',
 			'js/fieldmanager-select.js',
-			array(),
+			array( 'fm_loader' ),
 			FM_VERSION,
 			false,
 			'fm_select',

--- a/php/class-fieldmanager-select.php
+++ b/php/class-fieldmanager-select.php
@@ -60,7 +60,7 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 			'fm_select_js',
 			'js/fieldmanager-select.js',
 			array(),
-			'1.0.2',
+			FM_VERSION,
 			false,
 			'fm_select',
 			array(

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -93,7 +93,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 		$post_type = ! isset( $_GET['post_type'] ) ? 'post' : sanitize_text_field( wp_unslash( $_GET['post_type'] ) ); // WPCS: input var okay.
 
 		if ( in_array( $post_type, $this->post_types ) ) {
-			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array( 'fieldmanager_script' ), FM_VERSION );
+			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array(), FM_VERSION );
 		}
 	}
 

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -93,7 +93,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 		$post_type = ! isset( $_GET['post_type'] ) ? 'post' : sanitize_text_field( wp_unslash( $_GET['post_type'] ) ); // WPCS: input var okay.
 
 		if ( in_array( $post_type, $this->post_types ) ) {
-			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js' );
+			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array(), FM_VERSION );
 		}
 	}
 

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -93,7 +93,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 		$post_type = ! isset( $_GET['post_type'] ) ? 'post' : sanitize_text_field( wp_unslash( $_GET['post_type'] ) ); // WPCS: input var okay.
 
 		if ( in_array( $post_type, $this->post_types ) ) {
-			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array(), FM_VERSION );
+			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array( 'fieldmanager_script' ), FM_VERSION );
 		}
 	}
 

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -93,7 +93,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 		$post_type = ! isset( $_GET['post_type'] ) ? 'post' : sanitize_text_field( wp_unslash( $_GET['post_type'] ) ); // WPCS: input var okay.
 
 		if ( in_array( $post_type, $this->post_types ) ) {
-			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array( 'fm_loader' ), FM_VERSION, true );
+			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array( 'fm_loader' ), FM_VERSION );
 		}
 	}
 

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -93,7 +93,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 		$post_type = ! isset( $_GET['post_type'] ) ? 'post' : sanitize_text_field( wp_unslash( $_GET['post_type'] ) ); // WPCS: input var okay.
 
 		if ( in_array( $post_type, $this->post_types ) ) {
-			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array(), FM_VERSION );
+			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array( 'fm_loader' ), FM_VERSION, true );
 		}
 	}
 

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -93,7 +93,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 		$post_type = ! isset( $_GET['post_type'] ) ? 'post' : sanitize_text_field( wp_unslash( $_GET['post_type'] ) ); // WPCS: input var okay.
 
 		if ( in_array( $post_type, $this->post_types ) ) {
-			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array( 'fm_loader' ), FM_VERSION );
+			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array( 'fm_loader' ), FM_VERSION, true );
 		}
 	}
 

--- a/php/util/class-fieldmanager-util-assets.php
+++ b/php/util/class-fieldmanager-util-assets.php
@@ -93,7 +93,10 @@ class Fieldmanager_Util_Assets {
 	 */
 	protected function pre_enqueue_script( $args ) {
 		if ( did_action( 'admin_enqueue_scripts' ) || did_action( 'wp_enqueue_scripts' ) ) {
-			$this->enqueue_script( $args );
+			// Ensure the script isn't already enqueued before performing the enqueue action.
+			if ( ! wp_script_is( $args['handle'], 'enqueued' ) ) {
+				$this->enqueue_script( $args );
+			}
 		} else {
 			$this->scripts[ $args['handle'] ] = $args;
 			$this->hook_enqueue();

--- a/tests/php/test-fieldmanager-script-loading.php
+++ b/tests/php/test-fieldmanager-script-loading.php
@@ -33,15 +33,15 @@ class Test_Fieldmanager_Script_Loading extends Fieldmanager_Assets_Unit_Test_Cas
 	 */
 	public function script_data() {
 		return array(
-			array( 'fieldmanager_script', array( 'jquery', 'jquery-ui-sortable' ) ),
-			array( 'fm_autocomplete_js', array( 'fieldmanager_script', 'jquery-ui-autocomplete' ) ),
-			array( 'fm_datepicker', array( 'fieldmanager_script', 'jquery-ui-datepicker' ) ),
-			array( 'fm_group_tabs_js', array( 'jquery', 'jquery-hoverintent' ) ),
+			array( 'fieldmanager_script', array( 'fm_loader', 'jquery', 'jquery-ui-sortable' ) ),
+			array( 'fm_autocomplete_js', array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-autocomplete' ) ),
+			array( 'fm_datepicker', array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-datepicker' ) ),
+			array( 'fm_group_tabs_js', array( 'fm_loader', 'jquery', 'jquery-hoverintent' ) ),
 			array( 'fm_media', array( 'jquery' ) ),
-			array( 'fm_richtext', array( 'jquery', 'fieldmanager_script', 'utils' ) ),
-			array( 'fm_select_js', array() ),
-			array( 'grid', array() ),
-			array( 'fm_colorpicker', array( 'jquery', 'wp-color-picker' ) ),
+			array( 'fm_richtext', array( 'fm_loader', 'jquery', 'fieldmanager_script', 'utils' ) ),
+			array( 'fm_select_js', array( 'fm_loader' ) ),
+			array( 'grid', array( 'fm_loader', 'handsontable', 'contextmenu', 'ui_position' ) ),
+			array( 'fm_colorpicker', array( 'fm_loader', 'jquery', 'wp-color-picker' ) ),
 		);
 	}
 


### PR DESCRIPTION
Fixes issues with Fieldmanager fields, which require JavaScript hooks, not initializing properly when Gutenberg is active. `wp.domReady` fires later than jQuery's `document.ready`, so this, combined with moving most FM scripts to the footer, should resolve race conditions that prevent initialization of dynamic fields across the board in Fieldmanager.

Additionally, uses `FM_VERSION` to set version numbers for Fieldmanager JS and CSS to ensure cache busting when shipping a new version of Fieldmanager to aggressively cached sites, such as VIP Go. Accordingly, bumps the version to 1.2.5.

Finally, moves script load for most FM scripts to the footer, which is required for proper initialization of fields in a Gutenberg context, and is generally a best practice. This move should not break anything in practice, but may require a change to the qunit tests in order for them to pass.

This PR obviates the need for the following PRs:

#745 
#744 
#717 

It also resolves the following issues:

Fixes #753 #730 #720 #713 #710