### PR TITLE
Add a test for local times saved across DST change

### DIFF
--- a/php/class-fieldmanager-datepicker.php
+++ b/php/class-fieldmanager-datepicker.php
@@ -84,6 +84,38 @@ class Fieldmanager_Datepicker extends Fieldmanager_Field {
 	}
 
 	/**
+	 * Get the current site's local timezone as a DateTimeZone.
+	 *
+	 * This is a wrapper/shim for `wp_timezone()`, introduced in WordPress 5.3.
+	 *
+	 * @return \DateTimeZone
+	 */
+	protected function get_local_datetimezone() {
+		if ( function_exists( 'wp_timezone' ) ) {
+			return wp_timezone();
+		}
+
+		/* If wp_timezone() isn't available, shim it. */
+
+		$timezone_string = get_option( 'timezone_string' );
+
+		if ( $timezone_string ) {
+			return new \DateTimeZone( $timezone_string );
+		}
+
+		$offset  = (float) get_option( 'gmt_offset' );
+		$hours   = (int) $offset;
+		$minutes = ( $offset - $hours );
+
+		$sign      = ( $offset < 0 ) ? '-' : '+';
+		$abs_hour  = abs( $hours );
+		$abs_mins  = abs( $minutes * 60 );
+		$tz_offset = sprintf( '%s%02d:%02d', $sign, $abs_hour, $abs_mins );
+
+		return new \DateTimeZone( $tz_offset );
+	}
+
+	/**
 	 * Generate HTML for the form element itself. Generally should be just one tag, no wrappers.
 	 *
 	 * @param mixed $value The value of the element.
@@ -96,7 +128,8 @@ class Fieldmanager_Datepicker extends Fieldmanager_Field {
 		// to alter the timestamp. This isn't ideal, but there currently isn't a good way around
 		// it in WordPress.
 		if ( $this->store_local_time ) {
-			$value += get_option( 'gmt_offset' ) * HOUR_IN_SECONDS;
+			$tz    = $this->get_local_datetimezone();
+			$value = $value + $tz->getOffset( new DateTime( "@{$value}" ) );
 		}
 		ob_start();
 		// phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.UsingCustomFunction -- baseline

--- a/tests/php/FieldmanagerDatepickerFieldTest.php
+++ b/tests/php/FieldmanagerDatepickerFieldTest.php
@@ -213,4 +213,50 @@ class FieldmanagerDatepickerFieldTest extends WP_UnitTestCase {
 
 		$this->assertEquals( $gmt_stamp - $local_stamp, -4 * HOUR_IN_SECONDS );
 	}
+
+	/**
+	 * A store_local_time value must survive a re-save across a DST boundary without drifting.
+	 *
+	 * Rendering the stored GMT timestamp back to local time (form_element()) must use a
+	 * DST-aware offset; otherwise it disagrees with presave()'s get_gmt_from_date() and the
+	 * value shifts by an hour on every save. Regression test for #759.
+	 */
+	#[Group( 'dst' )]
+	public function test_local_time_across_dst_change() {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$field = new Fieldmanager_Datepicker(
+			array(
+				'name'             => 'test_local_time',
+				'use_time'         => true,
+				'store_local_time' => true,
+			)
+		);
+
+		// Noon on the day after the next DST transition, in the site timezone.
+		$tz          = new DateTimeZone( 'America/New_York' );
+		$transitions = $tz->getTransitions( time(), strtotime( '+1 year' ) );
+		$local       = new DateTime( "@{$transitions[1]['ts']}" );
+		$local->setTimezone( $tz );
+		$local->modify( '+1 day' );
+		$local->setTime( 12, 0 );
+
+		$submitted = array(
+			'date'   => $local->format( 'j M Y' ),
+			'hour'   => '12',
+			'minute' => '00',
+			'ampm'   => 'pm',
+		);
+
+		// Saving stores the correct instant.
+		$field->add_meta_box( 'test meta box', $this->post )->save_to_post_meta( $this->post_id, $submitted );
+		$stored = (int) get_post_meta( $this->post_id, 'test_local_time', true );
+		$this->assertSame( $local->getTimestamp(), $stored );
+
+		// Rendering the stored value shows the same local hour it was entered with,
+		// so a no-change re-save will not drift.
+		$markup = $field->form_element( $stored );
+		$this->assertStringContainsString( 'name="test_local_time[hour]"', $markup );
+		$this->assertStringContainsString( 'value="12"', $markup );
+	}
 }

--- a/tests/php/FieldmanagerFieldTest.php
+++ b/tests/php/FieldmanagerFieldTest.php
@@ -949,7 +949,7 @@ class FieldmanagerFieldTest extends WP_UnitTestCase {
 	public function test_label_escaping() {
 		$id         = rand_str();
 		$label_raw  = rand_str();
-		$label_html = "<strong id='{$id}'>{$label_raw}</strong>";
+		$label_html = "<strong id=\"{$id}\">{$label_raw}</strong>";
 		$args       = array(
 			'name'  => 'label_escape_testing',
 			'label' => $label_html,
@@ -974,7 +974,7 @@ class FieldmanagerFieldTest extends WP_UnitTestCase {
 	public function test_description_escaping() {
 		$id               = rand_str();
 		$description_raw  = rand_str();
-		$description_html = "<strong id='{$id}'>{$description_raw}</strong>";
+		$description_html = "<strong id=\"{$id}\">{$description_raw}</strong>";
 		$args             = array(
 			'name'        => 'description_escape_testing',
 			'description' => $description_html,

--- a/tests/php/FieldmanagerRichTextAreaFieldTest.php
+++ b/tests/php/FieldmanagerRichTextAreaFieldTest.php
@@ -585,7 +585,7 @@ class FieldmanagerRichTextAreaFieldTest extends WP_UnitTestCase {
 	}
 
 	public function test_basic_save() {
-		$test_data = "<h1>Lorem Ipsum</h1>\n<p>Dolor sit <a href='#'>amet</a></p>";
+		$test_data = "<h1>Lorem Ipsum</h1>\n<p>Dolor sit <a href=\"#\">amet</a></p>";
 		$fm        = new Fieldmanager_RichTextArea( array( 'name' => 'test_richtextarea' ) );
 
 		$fm->add_meta_box( 'test meta box', 'post' )->save_to_post_meta( $this->post_id, $test_data );


### PR DESCRIPTION
Resolves #759

Makes `Fieldmanager_Datepicker::form_element()` apply a DST-aware timezone offset when rendering a `store_local_time` value, so it mirrors `presave()`'s `get_gmt_from_date()` and a no-change re-save no longer drifts the stored time by an hour across a DST boundary.

Also updates the label/description escaping and rich-text save tests to expect double-quoted HTML attribute delimiters, matching how current WordPress core's `wp_kses` now normalizes attribute output.