### PR TITLE
Bump version number to 1.2.6

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -3,7 +3,7 @@
  * Fieldmanager Base Plugin File.
  *
  * @package Fieldmanager
- * @version 1.2.5-beta2
+ * @version 1.2.6
  */
 
 /*
@@ -11,14 +11,14 @@ Plugin Name: Fieldmanager
 Plugin URI: https://github.com/alleyinteractive/wordpress-fieldmanager
 Description: Add fields to WordPress programatically.
 Author: Alley
-Version: 1.2.5-beta2
+Version: 1.2.6
 Author URI: https://www.alley.co/
 */
 
 /**
  * Current version of Fieldmanager.
  */
-define( 'FM_VERSION', '1.2.5-beta2' );
+define( 'FM_VERSION', '1.2.6' );
 
 /**
  * Filesystem path to Fieldmanager.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "Fieldmanager",
   "description": "Fieldmanager is a comprehensive toolkit for building forms, metaboxes, and custom admin screens for WordPress.",
-  "version": "1.2.5-beta2",
+  "version": "1.2.6",
   "repository": {
     "type": "git",
     "url": "https://github.com/alleyinteractive/wordpress-fieldmanager"


### PR DESCRIPTION
- Identical to v1.2.5, except instead of using the `-beta2` suffix (which was used for cache busting on VIP Go during version testing) it now uses an updated version number.