### PR TITLE
Add confirm message when deleting a repeater field

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -18,7 +18,7 @@ Author URI: https://www.alley.co/
 /**
  * Current version of Fieldmanager.
  */
-define( 'FM_VERSION', '1.3.0' );
+define( 'FM_VERSION', '1.3.1' );
 
 /**
  * Filesystem path to Fieldmanager.

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -168,9 +168,11 @@ fm_add_another = function( $element ) {
 }
 
 fm_remove = function( $element ) {
-	$wrapper = $element.parents( '.fm-wrapper' ).first();
-	$element.parents( '.fm-item' ).first().remove();
-	fm_renumber( $wrapper );
+	if (window.confirm('Do you want to delete this field?')) {
+		$wrapper = $element.parents( '.fm-wrapper' ).first();
+		$element.parents( '.fm-item' ).first().remove();
+		fm_renumber( $wrapper );
+	}
 }
 
 var fm_init = function () {
@@ -186,7 +188,11 @@ var fm_init = function () {
 	} );
 
 	// Handle collapse events
-	$( document ).on( 'click', '.fmjs-collapsible-handle', function() {
+	$( document ).on( 'click', '.fmjs-collapsible-handle', function(event) {
+		if ($(event.target).hasClass('fmjs-remove')) {
+			return;
+		}
+
 		$( this ).parents( '.fm-group' ).first().children( '.fm-group-inner' ).slideToggle( 'fast' );
 		fm_renumber( $( this ).parents( '.fm-wrapper' ).first() );
 		$( this ).parents( '.fm-group' ).first().trigger( 'fm_collapsible_toggle' );


### PR DESCRIPTION
Relates to - https://github.com/alleyinteractive/wordpress-fieldmanager/issues/743

Ensures that a confirmation dialog is presented to the user whenever they attempt to delete a repeater field 