### PR TITLE
Fieldmanager Webpack setup for JS and CSS minification

### DIFF
--- a/css/fieldmanager-group-tabs.css
+++ b/css/fieldmanager-group-tabs.css
@@ -91,7 +91,6 @@
 	border-top: solid 1px #dfdfdf;
 }
 
-/* Vertical Tabs */
 .fm-tabbed-vertical {
 	margin: -6px -12px -12px;
 	background: url(../images/vertical-tab-bg.png) 0 0 repeat-y;

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -1,3 +1,7 @@
+if ('undefined' === typeof fm) {
+	var fm = {};
+}
+
 ( function( $ ) {
 
 fm.autocomplete = {

--- a/js/fieldmanager-datepicker.js
+++ b/js/fieldmanager-datepicker.js
@@ -1,3 +1,7 @@
+if ('undefined' === typeof fm) {
+	var fm = {};
+}
+
 ( function( $ ) {
 	fm.datepicker = {
 		add_datepicker: function() {

--- a/js/fieldmanager-group-tabs.js
+++ b/js/fieldmanager-group-tabs.js
@@ -166,3 +166,5 @@ var FieldmanagerGroupTabs;
 
 	fmLoadModule( FieldmanagerGroupTabs.init );
 } )( jQuery );
+
+export default FieldmanagerGroupTabs;

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -83,7 +83,7 @@ var fm_renumber = function( $wrappers ) {
 					var fname = $(this).attr( 'name' );
 					if ( fname ) {
 						fname = fname.replace( /\]/g, '' );
-						parts = fname.split( '[' );
+						var parts = fname.split( '[' );
 						if ( parts[ level_pos ] != order ) {
 							parts[ level_pos ] = order;
 							var new_fname = parts[ 0 ] + '[' + parts.slice( 1 ).join( '][' ) + ']';
@@ -145,7 +145,7 @@ var match_value = function( values, match_string ) {
 	return false;
 }
 
-fm_add_another = function( $element ) {
+var fm_add_another = function( $element ) {
 	var el_name = $element.data( 'related-element' )
 		, limit = $element.data( 'limit' ) - 0
 		, siblings = $element.parent().siblings( '.fm-item' ).not( '.fmjs-proto' )
@@ -167,8 +167,8 @@ fm_add_another = function( $element ) {
 	init_sortable();
 }
 
-fm_remove = function( $element ) {
-	$wrapper = $element.parents( '.fm-wrapper' ).first();
+var fm_remove = function( $element ) {
+	var $wrapper = $element.parents( '.fm-wrapper' ).first();
 	$element.parents( '.fm-item' ).first().remove();
 	fm_renumber( $wrapper );
 }
@@ -281,3 +281,5 @@ var fm_init = function () {
 fmLoadModule( fm_init );
 
 } )( jQuery );
+
+export default fm;

--- a/js/richtext.js
+++ b/js/richtext.js
@@ -1,3 +1,7 @@
+if ('undefined' === typeof fm) {
+	var fm = {};
+}
+
 ( function( $ ) {
 	fm.richtextarea = {
 		add_rte_to_visible_textareas: function() {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,23 @@
   },
   "license": "GPL-2.0",
   "devDependencies": {
-    "grunt": "^0.4.5",
+    "css-loader": "^5.0.1",
+    "css-minimizer-webpack-plugin": "^1.1.5",
+    "grunt": "^1.3.0",
     "grunt-contrib-connect": "~0.11.0",
-    "grunt-contrib-qunit": "~0.7.0",
-    "grunt-phpcs": "^0.4.0"
+    "grunt-contrib-qunit": "^4.0.0",
+    "grunt-phpcs": "^0.4.0",
+    "mini-css-extract-plugin": "^1.3.1",
+    "webpack-cli": "^4.2.0"
+  },
+  "scripts": {
+    "build": "webpack --mode=production"
+  },
+  "dependencies": {
+    "clean-webpack-plugin": "^3.0.0",
+    "postcss": "^8.1.7",
+    "postcss-loader": "^4.0.4",
+    "postcss-preset-env": "^6.7.0",
+    "webpack": "^5.4.0"
   }
 }

--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -76,7 +76,7 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 
 		fm_add_script(
 			'fm_autocomplete_js',
-			'js/fieldmanager-autocomplete.js',
+			'build/js/fieldmanager-autocomplete.bundle.min.js',
 			array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-autocomplete' ),
 			FM_VERSION,
 			true,

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -36,7 +36,7 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	 * @param array  $options The options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
-		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'fm_loader', 'jquery', 'wp-color-picker' ), FM_VERSION, true );
+		fm_add_script( 'fm_colorpicker', 'build/js/fieldmanager-colorpicker.bundle.min.js', array( 'fm_loader', 'jquery', 'wp-color-picker' ), FM_VERSION, true );
 		fm_add_style( 'wp-color-picker' );
 
 		$this->sanitize = 'sanitize_hex_color';

--- a/php/class-fieldmanager-datepicker.php
+++ b/php/class-fieldmanager-datepicker.php
@@ -70,7 +70,7 @@ class Fieldmanager_Datepicker extends Fieldmanager_Field {
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		fm_add_style( 'fm-jquery-ui', 'css/jquery-ui/jquery-ui-1.10.2.custom.min.css' );
-		fm_add_script( 'fm_datepicker', 'js/fieldmanager-datepicker.js', array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-datepicker' ), FM_VERSION, true );
+		fm_add_script( 'fm_datepicker', 'build/js/fieldmanager-datepicker.bundle.min.js', array( 'fm_loader', 'fieldmanager_script', 'jquery-ui-datepicker' ), FM_VERSION, true );
 		parent::__construct( $label, $options );
 
 		if ( empty( $this->js_opts ) ) {

--- a/php/class-fieldmanager-draggablepost.php
+++ b/php/class-fieldmanager-draggablepost.php
@@ -57,8 +57,8 @@ class Fieldmanager_DraggablePost extends Fieldmanager_Field {
 		// Refuse to allow more than one instance of this field type.
 		$this->limit = 1;
 
-		fm_add_script( 'fm_draggablepost_js', 'js/fieldmanager-draggablepost.js', array( 'fm_loader', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION, true );
-		fm_add_style( 'fm_draggablepost_css', 'css/fieldmanager-draggablepost.css', array(), FM_VERSION );
+		fm_add_script( 'fm_draggablepost_js', 'build/js/fieldmanager-draggablepost.bundle.min.js', array( 'fm_loader', 'jquery-ui-draggable', 'jquery-ui-droppable', 'jquery-ui-sortable' ), FM_VERSION, true );
+		fm_add_style( 'fm_draggablepost_css', 'build/css/fieldmanager-draggablepost.min.css', array(), FM_VERSION );
 	}
 
 	/**

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -409,8 +409,8 @@ abstract class Fieldmanager_Field {
 
 		// Only enqueue base assets once, and only when we have a field.
 		if ( ! self::$enqueued_base_assets ) {
-			fm_add_script( 'fieldmanager_script', 'js/fieldmanager.js', array( 'fm_loader', 'jquery', 'jquery-ui-sortable' ), FM_VERSION );
-			fm_add_style( 'fieldmanager_style', 'css/fieldmanager.css', array(), FM_VERSION );
+			fm_add_script( 'fieldmanager_script', 'build/js/fieldmanager.bundle.min.js', array( 'fm_loader', 'jquery', 'jquery-ui-sortable' ), FM_VERSION );
+			fm_add_style( 'fieldmanager_style', 'build/css/fieldmanager.min.css', array(), FM_VERSION );
 			self::$enqueued_base_assets = true;
 		}
 	}

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -196,8 +196,8 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 		// Add the tab JS and CSS if it is needed.
 		if ( $this->tabbed ) {
 			fm_add_script( 'jquery-hoverintent', 'js/jquery.hoverIntent.js', array( 'jquery' ), '1.8.1' );
-			fm_add_script( 'fm_group_tabs_js', 'js/fieldmanager-group-tabs.js', array( 'fm_loader', 'jquery', 'jquery-hoverintent' ), FM_VERSION, true );
-			fm_add_style( 'fm_group_tabs_css', 'css/fieldmanager-group-tabs.css', array(), FM_VERSION );
+			fm_add_script( 'fm_group_tabs_js', 'build/js/fieldmanager-group-tabs.bundle.min.js', array( 'fm_loader', 'jquery', 'jquery-hoverintent' ), FM_VERSION, true );
+			fm_add_style( 'fm_group_tabs_css', 'build/css/fieldmanager-group-tabs.min.css', array(), FM_VERSION );
 		}
 	}
 

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -107,7 +107,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 		$this->remove_media_label   = __( 'remove', 'fieldmanager' );
 
 		if ( ! self::$has_registered_media ) {
-			fm_add_script( 'fm_media', 'js/media/fieldmanager-media.js', array( 'jquery' ), FM_VERSION, true );
+			fm_add_script( 'fm_media', 'build/js/fieldmanager-media.bundle.min.js', array( 'jquery' ), FM_VERSION, true );
 			if ( did_action( 'admin_print_scripts' ) ) {
 				$this->admin_print_scripts();
 			} else {

--- a/php/class-fieldmanager-options.php
+++ b/php/class-fieldmanager-options.php
@@ -76,7 +76,7 @@ abstract class Fieldmanager_Options extends Fieldmanager_Field {
 		}
 
 		// Add the options CSS.
-		fm_add_style( 'fm_options_css', 'css/fieldmanager-options.css', array(), FM_VERSION );
+		fm_add_style( 'fm_options_css', 'build/css/fieldmanager-options.min.css', array(), FM_VERSION );
 	}
 
 	/**

--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -104,7 +104,7 @@ class Fieldmanager_RichTextArea extends Fieldmanager_Field {
 		$this->sanitize = array( $this, 'sanitize' );
 
 		// 'utils' provides getUserSetting().
-		fm_add_script( 'fm_richtext', 'js/richtext.js', array( 'fm_loader', 'jquery', 'fieldmanager_script', 'utils' ), FM_VERSION, true );
+		fm_add_script( 'fm_richtext', 'build/js/richtext.bundle.min.js', array( 'fm_loader', 'jquery', 'fieldmanager_script', 'utils' ), FM_VERSION, true );
 
 		parent::__construct( $label, $options );
 	}

--- a/php/class-fieldmanager-select.php
+++ b/php/class-fieldmanager-select.php
@@ -58,7 +58,7 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 		// Add the Fieldmanager Select Javascript library.
 		fm_add_script(
 			'fm_select_js',
-			'js/fieldmanager-select.js',
+			'build/js/fieldmanager-select.bundle.min.js',
 			array( 'fm_loader' ),
 			FM_VERSION,
 			true,

--- a/php/context/class-fieldmanager-context-quickedit.php
+++ b/php/context/class-fieldmanager-context-quickedit.php
@@ -93,7 +93,7 @@ class Fieldmanager_Context_QuickEdit extends Fieldmanager_Context_Storable {
 		$post_type = ! isset( $_GET['post_type'] ) ? 'post' : sanitize_text_field( wp_unslash( $_GET['post_type'] ) ); // WPCS: input var okay.
 
 		if ( in_array( $post_type, $this->post_types ) ) {
-			fm_add_script( 'quickedit-js', 'js/fieldmanager-quickedit.js', array( 'fm_loader' ), FM_VERSION, true );
+			fm_add_script( 'quickedit-js', 'build/js/fieldmanager-quickedit.bundle.min.js', array( 'fm_loader' ), FM_VERSION, true );
 		}
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,99 @@
+const path = require('path');
+const webpack = require('webpack');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin');
+
+module.exports = (env, argv) => {
+  const { mode } = argv;
+
+  return {
+    devtool: mode === 'production'
+      ? 'source-map'
+      : 'cheap-module-eval-source-map',
+    entry: {
+      'fieldmanager': [
+        './js/fieldmanager.js',
+        './css/fieldmanager.css',
+        './css/fieldmanager-options.css',
+      ],
+      'fieldmanager-autocomplete': './js/fieldmanager-autocomplete.js',
+      'fieldmanager-colorpicker': './js/fieldmanager-colorpicker.js',
+      'fieldmanager-datepicker': './js/fieldmanager-datepicker.js',
+      'fieldmanager-draggablepost': [
+        './js/fieldmanager-draggablepost.js',
+        './css/fieldmanager-draggablepost.css',
+      ],
+      'fieldmanager-group-tabs': [
+        './js/fieldmanager-group-tabs.js',
+        './css/fieldmanager-group-tabs.css',
+      ],
+      'fieldmanager-media': './js/media/fieldmanager-media.js',
+      'fieldmanager-select': './js/fieldmanager-select.js',
+      'fieldmanager-quickedit': './js/fieldmanager-quickedit.js',
+      'fieldmanager-options': './css/fieldmanager-options.css',
+      'richtext': './js/richtext.js',
+    },
+    output: {
+      filename: mode === 'production'
+        ? 'js/[name].bundle.min.js'
+        : 'js/[name].js',
+      path: path.join(__dirname, 'build'),
+    },
+    module: {
+      rules: [
+        {
+          test: /.css$/,
+          use: [
+            MiniCssExtractPlugin.loader,
+            'css-loader',
+            {
+              loader: 'postcss-loader',
+              options: {
+                postcssOptions: {
+                  plugins: [
+                    [
+                      // postcss-preset-env includes autoprefixer
+                      'postcss-preset-env',
+                      {
+                        browsers: 'last 2 versions',
+                      },
+                    ],
+                  ],
+                },
+              },
+            },
+          ],
+        },
+      ],
+    },
+    plugins: [
+      ...(mode === 'production'
+        ? [
+          new MiniCssExtractPlugin({
+            filename: 'css/[name].min.css',
+          }),
+          new CleanWebpackPlugin(),
+          new webpack.ProvidePlugin({
+            $: 'jquery',
+            jQuery: 'jquery',
+          }),
+        ] : []
+      ),
+    ],
+    optimization: {
+      minimize: true,
+      minimizer: [
+        '...', // Load existing minimizers in order to minimize JS with terser-webpack-plugin.
+        new CssMinimizerPlugin(),
+      ],
+    },
+    resolve: {
+      extensions: ['.js', '.css'],
+    },
+    externals: {
+      // Enable require('jquery') where jquery is already a global
+      jquery: 'jQuery',
+    },
+  };
+};


### PR DESCRIPTION
This PR should serve as a springboard to using Webpack as a build system. This PR has the following characteristics:
* Minification of JS files into the `build` directory
* Minification of the CSS files into the build directory
* Apply `autoprefixer` to CSS properties using PostCSS
* Address existing NPM audit vulnerabilities

Future efforts may want to include:
- style linting
- Javascript linting
- JS Unit tests with Jest
- SASS integration