### PR TITLE
Remove unused private property

### DIFF
--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -352,13 +352,6 @@ abstract class Fieldmanager_Field {
 	protected $is_tab = false;
 
 	/**
-	 * Have we added this field as a meta box yet?
-	 *
-	 * @var bool
-	 */
-	private $meta_box_actions_added = false;
-
-	/**
 	 * Whether or not this field is present on the attachment edit screen.
 	 *
 	 * @var bool


### PR DESCRIPTION
This property was [added in April 2013](https://github.com/alleyinteractive/wordpress-fieldmanager/commit/d1f5e4ea629f8bc3f6876e73f5384e3769fc6312), and while the private function in which it was used was [removed a month later](https://github.com/alleyinteractive/wordpress-fieldmanager/commit/6f8e918e40dfdfcc1bc39e9f6e3b4cf920b81630), the property has remained. 

As a private property, it has been inaccessible to child classes, so I'm not aware of any backwards compatibility concerns with removing it.