### PR TITLE
Deprecate `Fieldmanager_Grid`

### DIFF
--- a/php/class-fieldmanager-grid.php
+++ b/php/class-fieldmanager-grid.php
@@ -10,6 +10,8 @@
  *
  * This field uses {@link https://github.com/handsontable/handsontable/
  * Handsontable} to provide a grid interface.
+ *
+ * @deprecated 1.4.0
  */
 class Fieldmanager_Grid extends Fieldmanager_Field {
 
@@ -41,6 +43,8 @@ class Fieldmanager_Grid extends Fieldmanager_Field {
 	 * @param array  $options The form options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
+		_deprecated_function( __METHOD__, '1.4.0' );
+
 		$this->attributes = array(
 			'size' => '50',
 		);
@@ -67,6 +71,8 @@ class Fieldmanager_Grid extends Fieldmanager_Field {
 	 * @return string The HTML string.
 	 */
 	public function form_element( $value = '' ) {
+		_deprecated_function( __METHOD__, '1.4.0' );
+
 		$grid_activate_id = 'grid-activate-' . uniqid( true );
 		if ( ! empty( $value ) && is_callable( $this->grid_sort ) ) {
 			$value = call_user_func( $this->grid_sort, $value );
@@ -96,6 +102,8 @@ class Fieldmanager_Grid extends Fieldmanager_Field {
 	 * @return array Sanitized row/col matrix.
 	 */
 	public function presave( $value, $current_value = array() ) {
+		_deprecated_function( __METHOD__, '1.4.0' );
+
 		$rows = json_decode( stripslashes( $value ), true );
 		if ( ! is_array( $rows ) ) {
 			return array();

--- a/tests/php/test-fieldmanager-script-loading.php
+++ b/tests/php/test-fieldmanager-script-loading.php
@@ -12,7 +12,6 @@ class Test_Fieldmanager_Script_Loading extends Fieldmanager_Assets_Unit_Test_Cas
 		// Instantiate field classes that register scripts.
 		new Fieldmanager_Autocomplete( 'Test', array( 'datasource' => new Fieldmanager_Datasource_Post() ) );
 		new Fieldmanager_Datepicker( 'Test' );
-		new Fieldmanager_Grid( 'Test' );
 		new Fieldmanager_Group( 'Test', array( 'tabbed' => 'horizontal' ) );
 		new Fieldmanager_Media( 'Test' );
 		new Fieldmanager_Select( 'Test' );


### PR DESCRIPTION
Grid has received little attention since its introduction and today appears to be nonfunctional -- see #789. Additionally, Handsontable, on which it is based, is now a commercial product. We can no longer recommend it and so now move to deprecate it with intent to remove it from the repository.