### PR TITLE
DateField/AutoComplete Gutenberg Patch

### DIFF
--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -1,4 +1,4 @@
-( function( $ ) {
+(function( $ ) {
 
 fm.autocomplete = {
 
@@ -84,9 +84,9 @@ fm.autocomplete = {
 
 fmLoadModule( fm.autocomplete.enable_autocomplete );
 
-$( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.autocomplete.enable_autocomplete );
-$( document ).on( 'focus',
+$( document ).on(
+	'focus',
 	'input[class*="fm-autocomplete"]:not(.fm-autocomplete-enabled)',
 	fm.autocomplete.enable_autocomplete
 );
-} ) ( jQuery );
+})( jQuery );

--- a/js/fieldmanager-autocomplete.js
+++ b/js/fieldmanager-autocomplete.js
@@ -85,5 +85,8 @@ fm.autocomplete = {
 fmLoadModule( fm.autocomplete.enable_autocomplete );
 
 $( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.autocomplete.enable_autocomplete );
-
+$( document ).on( 'focus',
+	'input[class*="fm-autocomplete"]:not(.fm-autocomplete-enabled)',
+	fm.autocomplete.enable_autocomplete
+);
 } ) ( jQuery );

--- a/js/fieldmanager-datepicker.js
+++ b/js/fieldmanager-datepicker.js
@@ -1,10 +1,12 @@
-( function( $ ) {
+(function( $ ) {
 	fm.datepicker = {
 		add_datepicker: function() {
 			$( '.fm-datepicker-popup:visible' ).each( function() {
-				if ( !$( this ).hasClass( 'fm-has-date-picker' ) ) {
-					var opts = $( this ).data( 'datepicker-opts' );
-					$( this ).datepicker( opts ).addClass( 'fm-has-date-picker' );
+				var $el = $( this );
+
+				if ( ! $el.hasClass( 'fm-has-date-picker' ) ) {
+					var opts = $el.data( 'datepicker-opts' );
+					$el.datepicker( opts ).addClass( 'fm-has-date-picker' );
 				}
 			} );
 		}
@@ -12,7 +14,9 @@
 
 	fmLoadModule( fm.datepicker.add_datepicker );
 
-	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.datepicker.add_datepicker );
-	$( document ).on( 'focus', 'input[class*="fm-datepicker-group"]:not(.fm-has-date-picker)', fm.autocomplete.add_datepicker );
-
-} ) ( jQuery );
+	$( document ).on(
+		'focus',
+		'input[class*="fm-datepicker-popup"]:not(.fm-has-date-picker)',
+		fm.datepicker.add_datepicker
+	);
+})( jQuery );

--- a/js/fieldmanager-datepicker.js
+++ b/js/fieldmanager-datepicker.js
@@ -13,4 +13,8 @@
 	fmLoadModule( fm.datepicker.add_datepicker );
 
 	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.datepicker.add_datepicker );
+	$( document ).on( 'focus',
+			'input[class*="fm-datepicker-group"]:not(.fm-has-date-picker)',
+			fm.autocomplete.enable_autocomplete
+		);
 } ) ( jQuery );

--- a/js/fieldmanager-datepicker.js
+++ b/js/fieldmanager-datepicker.js
@@ -13,8 +13,6 @@
 	fmLoadModule( fm.datepicker.add_datepicker );
 
 	$( document ).on( 'fm_collapsible_toggle fm_added_element fm_displayif_toggle fm_activate_tab', fm.datepicker.add_datepicker );
-	$( document ).on( 'focus',
-			'input[class*="fm-datepicker-group"]:not(.fm-has-date-picker)',
-			fm.autocomplete.enable_autocomplete
-		);
+	$( document ).on( 'focus', 'input[class*="fm-datepicker-group"]:not(.fm-has-date-picker)', fm.autocomplete.add_datepicker );
+
 } ) ( jQuery );


### PR DESCRIPTION
Closes #793.

- Allows Autocomplete and Date fields in Gutenberg to load jQuery scripts on input focus. In the Gutenberg context fields are not enabled as the jQuery `$( 'FIELD_NAME:visible' )` returns undefined, unless re-initialized as needed which prevents the need to auto-enabled ALL fields on the page (many of which are hidden by default using the `display_if` option).