### PR TITLE
Pass previous value when updating post meta in Storable context

### DIFF
--- a/php/context/class-fieldmanager-context-storable.php
+++ b/php/context/class-fieldmanager-context-storable.php
@@ -87,7 +87,7 @@ abstract class Fieldmanager_Context_Storable extends Fieldmanager_Context {
 		$data    = $this->prepare_data( $current, $data, $field );
 		if ( ! $field->skip_save ) {
 			if ( $field->serialize_data ) {
-				$this->update_data( $this->fm->data_id, $field->get_element_key(), $data );
+				$this->update_data( $this->fm->data_id, $field->get_element_key(), $data, $current );
 			} else {
 				$this->delete_data( $this->fm->data_id, $field->get_element_key() );
 				foreach ( $data as $value ) {


### PR DESCRIPTION
Closes #800 

Passes `$current` to `update_data` so `$prev_value` is available down the line.