### PR TITLE
Allow end user to define a label for the empty option in a select

### DIFF
--- a/php/class-fieldmanager-select.php
+++ b/php/class-fieldmanager-select.php
@@ -37,6 +37,13 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 	public $first_empty = false;
 
 	/**
+	 * String to use for first empty element.
+	 *
+	 * @var string
+	 */
+	public $empty_string = '&nbsp;';
+
+	/**
 	 * Tell FM to save multiple values.
 	 *
 	 * @var bool
@@ -120,7 +127,7 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 
 		$opts = '';
 		if ( $this->is_repeatable() || $this->first_empty ) {
-			$opts .= '<option value="">&nbsp;</option>';
+			$opts .= '<option value="">' . $this->empty_string . '</option>';
 		}
 		$opts .= $this->form_data_elements( $value );
 


### PR DESCRIPTION
Exactly as it says. This PR adds a parameter "empty_string" that allows changing of the displayed name for empty options. The value of this option remains empty.