### PR TITLE
Change Fieldmanager media field to save 0 instead of null when no image set

### DIFF
--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -140,7 +140,7 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 	 */
 	public function presave( $value, $current_value = array() ) {
 		if ( 0 == $value || ! is_numeric( $value ) ) {
-			return null;
+			return 0;
 		}
 		return absint( $value );
 	}


### PR DESCRIPTION
We are encountering an issue with Fieldmanager Media field saving null instead of `0` when there is no image selected.  The presave function PHPDoc indicates that an integer is always returned, but it is not.

The specific issue is when we need to make the field available in the REST API for use in the Gutenberg editor. 
   We have several instances where we need to integrate the value with a Gutenberg plugin and doing so requires us to add some code like

```
register_meta(
	'post',
	'index_featured_image',
	[
		'type'              => 'integer',
		'description'       => __( 'Index featured image ID.', 'alley' ),
		'show_in_rest'      => true,
		'single'            => true,
	]
);
```

In this case, `index_featured_image` is the name of the Fieldmanager field.  We are specifying that the `type` is `integer`.

That code will cause the following error when `null` is the value:

 **Updating failed. The index_featured_image property has an invalid stored value, and cannot be updated to null.**

This change resolves this issue.
