### PR TITLE
Remove jQuery :visible check during sortable list initialization

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -18,7 +18,7 @@ Author URI: https://www.alley.co/
 /**
  * Current version of Fieldmanager.
  */
-define( 'FM_VERSION', '1.3.0' );
+define( 'FM_VERSION', '1.3.1' );
 
 /**
  * Filesystem path to Fieldmanager.

--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -25,16 +25,7 @@ var init_sortable_container = function( el ) {
 
 var init_sortable = function() {
 	$( '.fmjs-sortable' ).each( function() {
-		if ( $( this ).is( ':visible' ) ) {
-			init_sortable_container( this );
-		} else {
-			var sortable = this;
-			$( sortable ).parents( '.fm-group' ).bind( 'fm_collapsible_toggle', function() {
-				if ( $( sortable ).is( ':visible' ) ) {
-					init_sortable_container( sortable );
-				}
-			} );
-		}
+		init_sortable_container( this );
 	} );
 }
 


### PR DESCRIPTION
# Description

FM uses the jQuery `:visible` selector to determine if the sortable list should be initialized. This can return `false` during initialization when rendered in Gutenberg. Based on some of my research this seems to be related to the sortable list element having a width and height of `0` when the function is called.

Overall, I do not have much insight into why the visibility check was added (outside of assuming it was to prevent initializing sortable lists for collapsed meta boxes), so I am unsure what effects this update will have.