### PR TITLE
Fix FM module loader in Gutenberg context

### DIFF
--- a/fieldmanager.php
+++ b/fieldmanager.php
@@ -18,7 +18,7 @@ Author URI: https://www.alley.co/
 /**
  * Current version of Fieldmanager.
  */
-define( 'FM_VERSION', '1.3.0' );
+define( 'FM_VERSION', '1.3.1' );
 
 /**
  * Filesystem path to Fieldmanager.

--- a/js/fieldmanager-loader.js
+++ b/js/fieldmanager-loader.js
@@ -4,22 +4,44 @@
  * Ensures that metaboxes have loaded before initializing functionality.
  * @param {function} callback - The callback function to execute when the DOM is ready.
  */
-function fmLoadModule( callback ) {
-	if ( 'object' === typeof wp && 'function' === typeof wp.domReady ) {
-		wp.domReady( callback );
-	} else if ( jQuery ) {
-		jQuery( document ).ready( callback );
-	} else {
-		// Shim wp.domReady.
-		if (
-			document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
-			document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
-		) {
-			callback();
-			return;
-		}
+ function fmLoadModule( callback ) {
+	// For the Gutenberg editor only, load FM module after metabox initialization.
+	if (wp.data) {
+		var metaboxesInitializedUnsubscribe = wp.data.subscribe(() => {
+			if (wp.data.select( 'core/edit-post' ).areMetaBoxesInitialized()) {
+				/**
+				 * `areMetaBoxesInitialized` is called immediately before the
+				 * `MetaBoxesArea` component is rendered, which is where the metabox
+				 * HTML is moved from the hidden div and into the main form element.
+				 *
+				 * This means we need to delay the callback a bit to allow this
+				 * component to render such that the jQuery `:visible` selector
+				 * can work as expected.
+				 */
+				setTimeout(() => {
+					callback();
+				}, 100);
 
-		// DOMContentLoaded has not fired yet, delay callback until then.
-		document.addEventListener( 'DOMContentLoaded', callback );
+				metaboxesInitializedUnsubscribe();
+			}
+		});
+	} else {
+		if ( 'object' === typeof wp && 'function' === typeof wp.domReady ) {
+			wp.domReady( callback );
+		} else if ( jQuery ) {
+			jQuery( document ).ready( callback );
+		} else {
+			// Shim wp.domReady.
+			if (
+				document.readyState === 'complete' || // DOMContentLoaded + Images/Styles/etc loaded, so we call directly.
+				document.readyState === 'interactive' // DOMContentLoaded fires at this point, so we call directly.
+			) {
+				callback();
+				return;
+			}
+
+			// DOMContentLoaded has not fired yet, delay callback until then.
+			document.addEventListener( 'DOMContentLoaded', callback );
+		}
 	}
 }


### PR DESCRIPTION
# Problem
Most FM initializes happens when the DOM is ready and only if that element is considered visible via the jQuery `.is(':visible')` function. In a recent Gutenberg update, metabox contents are not rendered until after the DOM is ready. (related to - https://github.com/alleyinteractive/wordpress-fieldmanager/issues/793#issuecomment-778538322)

This can lead to issues with initialization since some metabox elements will not be rendered properly on DOM ready and therefore will return `false` for `.is(':visible')`.

Potentially closes - https://github.com/alleyinteractive/wordpress-fieldmanager/pull/812

# Solution
When loading FM in a Gutenberg context, hook into the `areMetaBoxesInitialized` (wait a short period of time) and perform all FM initializations. This ensures that all metabox elements are rendered and in the DOM before any `.is(':visible')` checks are executed.