### PR TITLE
Loader: Fix loader callback timing

### DIFF
--- a/js/fieldmanager-loader.js
+++ b/js/fieldmanager-loader.js
@@ -26,7 +26,7 @@ function fmLoadModule( callback ) {
 				 */
 				if (
 					wp.data.select( 'core/edit-post' ).areMetaBoxesInitialized()
-					&& document.querySelector( '.edit-post-meta-boxes-area__container' )
+					&& document.querySelector( '.edit-post-meta-boxes-area__container .metabox-location-normal' )
 				) {
 					callback();
 					unsubscribeListener();


### PR DESCRIPTION
This is a followup to 754f101e to make sure that we wait for the `.metabox-location-normal` form to be moved into `.edit-post-meta-boxes-area__container` in the block editor before running our loading callbacks. Otherwise, there is the possibility that the callbacks will still fire too early, before the FM forms are ready.