### PR TITLE
Fix performance regression in fm_renumber

### DIFF
--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -75,27 +75,29 @@ var fm_renumber = function( $wrappers ) {
 	$wrappers.each( function() {
 		var level_pos = $( this ).data( 'fm-array-position' ) - 0;
 		var order = 0;
+		var modified_elements = [];
 		if ( level_pos > 0 ) {
 			$( this ).find( '> .fm-item' ).each( function() {
 				if ( $( this ).hasClass( 'fmjs-proto' ) ) {
 					return; // continue
 				}
 				$( this ).find( '.fm-element, .fm-incrementable' ).each( function() {
-					var fname = $(this).attr( 'name' );
+					var $element = $( this );
+					var fname = $element.attr( 'name' );
 					if ( fname ) {
-						fname = fname.replace( /\]/g, '' );
-						parts = fname.split( '[' );
+						parts = fname.replace( /\]/g, '' ).split( '[' );
 						if ( parts[ level_pos ] != order ) {
 							parts[ level_pos ] = order;
 							var new_fname = parts[ 0 ] + '[' + parts.slice( 1 ).join( '][' ) + ']';
 							// Rename the field and add a temporary prefix to prevent name collisions.
-							$( this ).attr( 'name', 'fmtemp_' + ( ++fmtemp ).toString() + '_' + new_fname );
-							if ( $( this ).attr( 'id' ) && $( this ).attr( 'id' ).match( '-proto' ) && ! new_fname.match( 'proto' ) ) {
-								$( this ).attr( 'id', 'fm-edit-dynamic-' + dynamic_seq );
-								if ( $( this ).parent().hasClass( 'fm-option' ) ) {
-									$( this ).parent().find( 'label' ).attr( 'for', 'fm-edit-dynamic-' + dynamic_seq );
+							$element.attr( 'name', 'fmtemp_' + ( ++fmtemp ).toString() + '_' + new_fname );
+							modified_elements.push( $element );
+							if ( $element.attr( 'id' ) && $element.attr( 'id' ).match( '-proto' ) && ! new_fname.match( 'proto' ) ) {
+								$element.attr( 'id', 'fm-edit-dynamic-' + dynamic_seq );
+								if ( $element.parent().hasClass( 'fm-option' ) ) {
+									$element.parent().find( 'label' ).attr( 'for', 'fm-edit-dynamic-' + dynamic_seq );
 								} else {
-									var parent = $( this ).closest( '.fm-item' );
+									var parent = $element.closest( '.fm-item' );
 									if ( parent.length && parent.find( '.fm-label label' ).length ) {
 										parent.find( '.fm-label label' ).attr( 'for', 'fm-edit-dynamic-' + dynamic_seq );
 									}
@@ -105,8 +107,8 @@ var fm_renumber = function( $wrappers ) {
 							}
 						}
 					}
-					if ( $( this ).hasClass( 'fm-incrementable' ) ) {
-						$( this ).attr( 'id', 'fm-edit-dynamic-' + dynamic_seq );
+					if ( $element.hasClass( 'fm-incrementable' ) ) {
+						$element.attr( 'id', 'fm-edit-dynamic-' + dynamic_seq );
 						dynamic_seq++;
 					}
 				} );
@@ -118,9 +120,11 @@ var fm_renumber = function( $wrappers ) {
 		} );
 
 		// Remove temporary name prefix in renumbered fields.
-		$( '.fm-element[name^="fmtemp_"], .fm-incrementable[name^="fmtemp_"]' ).each( function() {
-			$( this ).attr( 'name', $( this ).attr( 'name' ).replace( /^fmtemp_\d+_/, '' ) );
-		} );
+		if ( modified_elements.length ) {
+			$.each( modified_elements, function( index, $element ) {
+				$element.attr( 'name', $element.attr( 'name' ).replace( /^fmtemp_\d+_/, '' ) );
+			} );
+		}
 	} );
 }
 


### PR DESCRIPTION
The performance regression from 1.3 → 1.4 was due to this traversal:

```js
$( '.fm-element[name^="fmtemp_"], .fm-incrementable[name^="fmtemp_"]' ).each( ... )
```

Since the script knows which elements it changed, this update stores a reference to each changed element to avoid the later DOM traversal.

While this fixes the regression from 1.3 → 1.4, `fm_renumber()`﻿is still very slow at scale because of all the DOM traversal. A significant refactor is in order.

Resolves #827

---

For posterity, here's some sample code to produce a very slow experience adding and sorting...

```php
add_action(
	'init',
	function() {
		register_post_type(
			'demo',
			[
				'labels'   => [ 'name' => 'Demos' ],
				'public'   => false,
				'show_ui'  => true,
				'supports' => [ 'title' ],
			]
		);
	}
);

add_action(
	'fm_post_demo',
	function() {
		// Make a big array of sample data.
		$options = range(1, 100);
		$modules = [];
		foreach ( $options as $option ) {
			$modules[ $option ] = new Fieldmanager_Group( get_panel_args( $option ) );
		}

		$fm = new Fieldmanager_Group([
			'name' => 'modules',
			'label' => 'Modules',
			'children' => [
				'module' => new Fieldmanager_Group([
					'label' => 'New Module',
					'label_macro' => [ 'Module: %s', 'module_name' ],
					'limit' => 0,
					'add_more_label' => 'Add another module',
					'collapsible' => true,
					'collapsed' => true,
					'sortable' => true,
					'starting_count' => 1,
					'extra_elements' => 0,
					'children' => array_merge(
						[
							'type' => new Fieldmanager_Select([
								'label' => 'Module Type',
								'options' => $options,
							]),
							'module_name' => new Fieldmanager_TextField([
								'label' => 'Module Name',
							]),
						],
						$modules
					),
				]),
			],
		]);
		$fm->add_meta_box( 'Page Modules', ['demo']);
	}
);

function get_panel_args( $key ) {
	return [
		'label' => $key,
		'display_if' => [
			'src' => 'type',
			'value' => $key,
		],
		'children' => [
			'intro' => new Fieldmanager_RichTextArea('Intro'),
			'items' => new Fieldmanager_Group([
				'label' => 'Item',
				'label_macro' => [ 'Item: %s', 'name' ],
				'limit' => 0,
				'add_more_label' =>  'Add another item',
				'collapsible' => true,
				'collapsed' => true,
				'sortable' => true,
				'starting_count' => 1,
				'extra_elements' => 0,
				'children' => [
					'name' => new Fieldmanager_TextField('Name'),
					'type' => new Fieldmanager_Select([
						'label' => 'Type',
						'type_ahead' => true,
						'first_empty' => true,
						'options' => [
							'nested1' => 'Nested 1',
							'nested2' => 'Nested 2',
						],
					]),
				],
			]),
		],
	];
}

```
