### PR TITLE
Limit fm_renumber traversal to repeatables

### DIFF
--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -15,8 +15,7 @@ var init_sortable_container = function( el ) {
 				$( document ).trigger( 'fm_sortable_drag', el );
 			},
 			stop: function( e, ui ) {
-				var $parent = ui.item.parents( '.fm-wrapper' ).first();
-				fm_renumber( $parent );
+				fm_renumber( ui.item.closest( '.fm-wrapper[data-fm-array-position]' ) );
 				$( document ).trigger( 'fm_sortable_drop', el );
 			}
 		} );
@@ -96,7 +95,6 @@ var init_label_macros = function() {
 					return; // continue;
 				}
 
-				// TODO: nested fields get iterated over multiple times, is this avoidable?
 				$( this ).find( '.fm-element, .fm-incrementable' ).each( function() {
 					var $element = $( this );
 					var fname = $element.attr( 'name' );
@@ -142,7 +140,7 @@ var init_label_macros = function() {
 		}
 
 		// Iterate over subgroups.
-		fm_renumber( $( this ).find( '.fm-wrapper' ) );
+		fm_renumber( $( this ).find( '.fm-wrapper[data-fm-array-position]' ) );
 
 		// Remove temporary name prefix in renumbered fields.
 		if ( modified_elements.length ) {
@@ -194,9 +192,12 @@ fm_add_another = function( $element ) {
 	var $new_element = $( '.fmjs-proto.fm-' + el_name, $element.closest( '.fm-wrapper' ) ).first().clone();
 
 	$new_element.removeClass( 'fmjs-proto' );
-	$new_element = add_more_position == "bottom" ? $new_element.insertBefore( $element.parent() ) :
-						$new_element.insertAfter( $element.parent() )	;
-	fm_renumber( $element.parents( '.fm-wrapper' ) );
+	$new_element = add_more_position == "bottom"
+		? $new_element.insertBefore( $element.parent() )
+		: $new_element.insertAfter( $element.parent() );
+
+	fm_renumber( $element.closest( '.fm-wrapper[data-fm-array-position]' ) );
+
 	// Trigger for subclasses to do any post-add event handling for the new element
 	$element.parent().siblings().last().trigger( 'fm_added_element' );
 	init_label_macros();

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -541,6 +541,7 @@ abstract class Fieldmanager_Field {
 					$parent = $parent->parent; // parent's parent; root element has null parent which breaks while loop.
 				}
 			}
+			$fm_wrapper_attrs['data-fm-array-position'] = $html_array_position;
 		}
 
 		// Checks to see if element has display_if data values, and inserts the data attributes if it does.
@@ -558,9 +559,8 @@ abstract class Fieldmanager_Field {
 			$fm_wrapper_attr_string .= sprintf( '%s="%s" ', sanitize_key( $attr ), esc_attr( $val ) );
 		}
 		$out .= sprintf(
-			'<div class="%s" data-fm-array-position="%d" %s>',
+			'<div class="%s" %s>',
 			esc_attr( implode( ' ', $classes ) ),
-			absint( $html_array_position ),
 			$fm_wrapper_attr_string
 		);
 


### PR DESCRIPTION
This is a performance improvement to fm_renumber. It works by limiting the `fm-wrapper` elements which get `data-fm-array-position` attributes to only those with limits != 1. In JS, only`.fm-element[data-fm-array-position]` elements are traversed. Using a sample group with deep nesting, DOM traversal dropped from thousands of elements to dozens and performance improved about as one would expect.

To be clear, this isn't an end-all-be-all *_fix_*. DOM traversal in this function is still a problem, and it's still very possible to generate a nesting of groups and fields that blocks the event loop for multiple seconds on sorting, but this should solve 99.9% of real world use cases. Further refinement should be weighed by its opportunity costs, since that time could be better spent on a deeper overhaul using React or VueJS.

Refs #829﻿
