### PR TITLE
PHP 8.0: Autocomplete field with Extra Element causes Array to String Conversion Warning

### DIFF
--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -131,6 +131,9 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 			$this->attributes['data-options'] = htmlspecialchars( wp_json_encode( $this->datasource->get_items() ) );
 		}
 
+		if ( is_array( $value ) && empty( $value ) ) {
+			$value = '';
+		}
 		$display_value = $this->datasource->get_value( $value );
 		if ( '' === $display_value && ! $this->exact_match && ! isset( $this->datasource->options[ $value ] ) ) {
 			$display_value = $value;

--- a/tests/php/test-fieldmanager-autocomplete-field.php
+++ b/tests/php/test-fieldmanager-autocomplete-field.php
@@ -117,4 +117,31 @@ class Test_Fieldmanager_Autocomplete_Field extends WP_UnitTestCase {
 
 		$this->assertSame( 1, count( $items ) );
 	}
+
+	/**
+	 * Test that an autocomplete field with an extra element is output correctly.
+	 */
+	public function test_exact_match_with_no_default_and_extra_element() {
+		$args = array(
+			'name'          => 'test_autocomplete_with_extra_element',
+			'datasource'                => new Fieldmanager_Datasource_Term(
+				[
+					'taxonomy'              => 'post_tag',
+					'append_taxonomy'       => false,
+					'only_save_to_taxonomy' => true,
+				]
+			),
+			'exact_match'               => true,
+			'remove_default_meta_boxes' => true,
+			'limit'                     => 1,
+			'extra_elements'            => 1,
+			'add_more_label'            => 'Add Tag',
+		);
+
+		$fm = new Fieldmanager_Autocomplete( $args );
+		ob_start();
+		$fm->add_meta_box( 'Test Autocomplete', 'post' )->render_meta_box( $this->post, array() );
+		$html = ob_get_clean();
+		$this->assertStringContainsString( 'fm-test_autocomplete_with_extra_element-0', $html );
+	}
 }


### PR DESCRIPTION
This resolves https://github.com/alleyinteractive/wordpress-fieldmanager/issues/839

I am adding a test along with this patch. Without this patch, the test will fail, as pictured:

<img width="1073" alt="Screen Shot 2022-08-23 at 5 28 43 PM" src="https://user-images.githubusercontent.com/7308162/186288952-765fa700-ad14-46d6-a8f2-9493bae5d839.png">

