### PR TITLE
Replacing set-output with GITHUB_OUTPUT, moving to shared PHPCS configuration

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -1,56 +1,14 @@
 name: PHPCS
 
 on:
+  push:
+    branches:
+      - main
+      - develop
   pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   coding-standards:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-
-    name: Coding Standards
-    steps:
-      - name: Cancel previous runs of this workflow (pull requests only)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: styfle/cancel-workflow-action@0.5.0
-        with:
-          access_token: ${{ github.token }}
-
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - name: Get Composer cache directory
-        id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-
-      - name: Set up Composer caching
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-composer-dependencies
-        with:
-          path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-composer-
-
-      - name: Set up PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
-          tools: composer:v2
-          coverage: none
-
-      - name: Validate Composer config
-        run: composer validate --strict
-
-      - name: Install composer dependencies
-        uses: nick-invision/retry@v1
-        with:
-          timeout_minutes: 5
-          max_attempts: 5
-          command: composer install
-
-      - name: Run PHPCS
-        run: composer run phpcs -- -v
+    uses: alleyinteractive/.github/.github/workflows/php-coding-standards.yml@main

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get Composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Set up Composer caching
         uses: actions/cache@v2

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,10 @@
     }
   ],
   "require": {
-    "composer/installers": "~1.0",
-	"php": "^5.4|^7.4|^8.0"
+    "composer/installers": "~1.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3.0",
-    "phpunit/phpunit": "^5.7.21 || ^7.5",
     "yoast/phpunit-polyfills": "^1.0"
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -7,11 +7,12 @@
   "authors": [
     {
       "name": "Alley Interactive",
-      "email": "noreply@alley.co"
+      "email": "info@alley.com"
     }
   ],
   "require": {
-    "composer/installers": "~1.0"
+    "composer/installers": "~1.0",
+	"php": "^5.4|^7.4|^8.0"
   },
   "require-dev": {
     "alleyinteractive/alley-coding-standards": "^0.3.0",


### PR DESCRIPTION
- Replaces set-output with GITHUB_OUTPUT to fix the deprecation: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- Move the phpcs action to the shared action for the organization. 