### PR TITLE
Bugfix/fab 49482

### DIFF
--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -395,10 +395,20 @@ abstract class Fieldmanager_Field {
 	 */
 	public function element_markup( $values = array() ) {
 		$values = $this->preload_alter_values( $values );
-		if ( $this->limit != 1 ) {
-			$max = max( $this->minimum_count, count( $values ) + $this->extra_elements );
 
-			// Ensure that we don't display more fields than we can save
+		if ( 1 != $this->limit ) {
+			// count() generates a warning when passed non-countable values in PHP 7.2.
+			if ( is_scalar( $values ) ) {
+				$count_values = 1;
+			} elseif ( ! is_array( $values ) && ! ( $values instanceof \Countable ) ) {
+				$count_values = 0;
+			} else {
+				$count_values = count( $values );
+			}
+
+			$max = max( $this->minimum_count, $count_values + $this->extra_elements );
+
+			// Ensure that we don't display more fields than we can save.
 			if ( $this->limit > 1 && $max > $this->limit ) {
 				$max = $this->limit;
 			}

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -789,6 +789,7 @@ abstract class Fieldmanager_Field {
 				if ( is_array( $value ) ) {
 					return ! empty( $value );
 				} else {
+					$value = $value ?? '';
 					return strlen( $value );
 				}
 			} );

--- a/php/context/class-fieldmanager-context.php
+++ b/php/context/class-fieldmanager-context.php
@@ -85,8 +85,19 @@ abstract class Fieldmanager_Context {
 		$data = array_key_exists( 'data', $args ) ? $args['data'] : null;
 		$echo = isset( $args['echo'] ) ? $args['echo'] : true;
 
+		// handle case where null values are passed down to prevent error in htmlspecialchars() in 8.1
+		if ($data !== null) {
+			array_walk_recursive($data, static function(&$value){
+				if (is_null($value)) {
+					$value = '';
+				}
+			});
+		} else {
+			return null;
+		}
+
 		$nonce = wp_nonce_field( 'fieldmanager-save-' . $this->fm->name, 'fieldmanager-' . $this->fm->name . '-nonce', true, false );
-		$field = $this->fm->element_markup( $data );
+		$field = $this->fm->element_markup( $data ?? []);
 		if ( $echo ) {
 			echo $nonce . $field;
 		} else {


### PR DESCRIPTION
Fixes for php 8.1 to prevent nulls being passed down to wp-core`htmlspecialchars()` calls and to prevent deprecated call of `strlen()` with null values.