### PR TITLE
Issue-863: PHP Deprecated:  htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/php/class-fieldmanager-textarea.php
+++ b/php/class-fieldmanager-textarea.php
@@ -18,6 +18,13 @@ class Fieldmanager_TextArea extends Fieldmanager_Field {
 	public $field_class = 'text';
 
 	/**
+	 * The default value for the field, if unset.
+	 *
+	 * @var mixed Default value
+	 */
+	public $default_value = '';
+
+	/**
 	 * Construct default attributes; 50x10 textarea.
 	 *
 	 * @param string $label   Field label.

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -39,3 +39,4 @@ function _fm_phpunit_is_wp_at_least( $min_version ) {
 // Load includes.
 require_once __DIR__ . '/includes/class-fieldmanager-assets-unit-test-case.php';
 require_once __DIR__ . '/includes/class-fieldmanager-options-mock.php';
+require_once __DIR__ . '/includes/class-fieldmanager-deprecation-exception.php';

--- a/tests/php/includes/class-fieldmanager-deprecation-exception.php
+++ b/tests/php/includes/class-fieldmanager-deprecation-exception.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * An exception class that triggers on expected deprecations
+ */
+
+class Fieldmanager_Deprecation_Exception extends Exception {}

--- a/tests/php/test-fieldmanager-textarea-field.php
+++ b/tests/php/test-fieldmanager-textarea-field.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Tests the Fieldmanager TextArea Field
+ *
+ * @group field
+ * @group textarea
+ */
+class Test_Fieldmanager_TextArea_Field extends WP_UnitTestCase {
+
+	/**
+	 * The post ID of the test post.
+	 *
+	 * @var int
+	 */
+	private int $post_id = 0;
+
+	/**
+	 * The post object of the test post.
+	 *
+	 * @var WP_Post
+	 */
+	private WP_Post $post;
+
+	public function set_up() {
+		parent::set_up();
+		Fieldmanager_Field::$debug = true;
+
+		$this->post_id = $this->factory->post->create(
+			array(
+				'post_title' => rand_str(),
+				'post_date'  => '2024-02-29 00:00:00',
+			)
+		);
+		$this->post    = get_post( $this->post_id );
+	}
+
+	/**
+	 * Test to confirm that not defining a default value for a field
+	 * does not cause that field to throw a deprecation warning when
+	 * a textarea field is used.
+	 *
+	 * @see https://github.com/alleyinteractive/wordpress-fieldmanager/issues/863
+	 */
+	public function test_default_value_does_not_throw_deprecation() {
+		set_error_handler(
+			/**
+			 * Convert deprecations to exceptions. This was removed from PHPUnit in
+			 * PHPUnit 10, so doing so manually here for future compatibility.
+			 *
+			 * @see https://github.com/sebastianbergmann/phpunit/issues/5062
+			 */
+            function ( $errno, $errstr ) {
+                throw new Fieldmanager_Deprecation_Exception( $errstr, $errno );
+            },
+            E_DEPRECATED | E_USER_DEPRECATED
+        );
+
+		$this->expectNotToPerformAssertions();
+
+		try {
+			ob_start();
+
+			$fm = new Fieldmanager_Textarea(
+				[
+					'name'          => 'example-textarea',
+					'description'   => 'Description Text',
+				]
+			);
+			$fm->add_meta_box( 'Test TextArea', 'post' )
+				->render_meta_box( $this->post, array() );
+
+			ob_get_clean();
+		} catch( Fieldmanager_Deprecation_Exception $e ) {
+			$this->fail( $e->getMessage() );
+		}
+
+		// Restore default error handler.
+		restore_error_handler();
+	}
+}


### PR DESCRIPTION
Note: To minimize the impact on the rest of the Fieldmanager fields, this change is localized to the TextArea field, since that appears to be where the issue is occurring.

### Fixes Issue
[PHP Deprecated:  htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated](https://github.com/alleyinteractive/wordpress-fieldmanager/issues/863)

### Description of Change
To address the issue of PHP deprecation errors when a `default_value` field is not set and defaults to `null`, we have modified the logic in the printing of fields within the WP admin area. Specifically, in scenarios where a default value is not set, which leads to a `null` return value, a ternary operation or a direct assignment now ensures that `esc_textarea` receives an empty string instead of `null`. This change prevents `htmlspecialchars()` from throwing a deprecation notice due to receiving a `null` value.

The modification was implemented in the handling of default values within the `Fieldmanager_TextArea` class to circumvent the deprecation notice. It's crucial to emphasize that the default behavior for handling default values remains unaltered to prevent unintended side effects in other areas of the application.

### Use Case Affected
This change impacts any site using fields that extend `Fieldmanager_TextArea`, specifically in scenarios where the `default_value` is not explicitly set. The new default value will be an empty string and not `null` as it was previously.

### Comments/Suggestions
- [@renatonascalves](https://github.com/renatonascalves) has played a crucial role in suggesting the approach of defaulting to an empty string within the `Fieldmanager_Textarea` class to address this deprecation issue.

### Acceptance Criteria
- With no default value set, resulting in a `null` return value, `esc_textarea` will now receive an empty string instead of `null`.
- The approach to handling default values should not be fundamentally altered to avoid unintended consequences in other parts of the application.