### PR TITLE
Issue-867: Update class constructor docblocks to support specifying an `array` or a `string` for `$label`

### DIFF
--- a/php/class-fieldmanager-autocomplete.php
+++ b/php/class-fieldmanager-autocomplete.php
@@ -65,8 +65,8 @@ class Fieldmanager_Autocomplete extends Fieldmanager_Field {
 	 *
 	 * @throws FM_Developer_Exception Must use a datasource.
 	 *
-	 * @param string $label   The label.
-	 * @param array  $options The options for the field.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->attributes = array(

--- a/php/class-fieldmanager-colorpicker.php
+++ b/php/class-fieldmanager-colorpicker.php
@@ -32,8 +32,8 @@ class Fieldmanager_Colorpicker extends Fieldmanager_Field {
 	/**
 	 * Build the colorpicker object and enqueue assets.
 	 *
-	 * @param string $label   The label to use.
-	 * @param array  $options The options.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		fm_add_script( 'fm_colorpicker', 'js/fieldmanager-colorpicker.js', array( 'fm_loader', 'jquery', 'wp-color-picker' ), FM_VERSION, true );

--- a/php/class-fieldmanager-datepicker.php
+++ b/php/class-fieldmanager-datepicker.php
@@ -65,8 +65,8 @@ class Fieldmanager_Datepicker extends Fieldmanager_Field {
 	/**
 	 * Construct default attributes and enqueue JavaScript.
 	 *
-	 * @param string $label   Field label.
-	 * @param array  $options Associative array of class property values. @see Fieldmanager_Field::__construct().
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		fm_add_style( 'fm-jquery-ui', 'css/jquery-ui/jquery-ui-1.10.2.custom.min.css' );

--- a/php/class-fieldmanager-draggablepost.php
+++ b/php/class-fieldmanager-draggablepost.php
@@ -47,8 +47,8 @@ class Fieldmanager_DraggablePost extends Fieldmanager_Field {
 	/**
 	 * Add scripts and styles and other setup tasks.
 	 *
-	 * @param string $label   The label.
-	 * @param array  $options The field options.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		_deprecated_function( __METHOD__, '1.2.0' );

--- a/php/class-fieldmanager-field.php
+++ b/php/class-fieldmanager-field.php
@@ -401,8 +401,8 @@ abstract class Fieldmanager_Field {
 	 * Superclass constructor, just populates options and sanity-checks common elements.
 	 * It might also die, but only helpfully, to catch errors in development.
 	 *
-	 * @param string $label   Title of form field.
-	 * @param array  $options With keys matching vars of the field in use.
+	 * @param string|array $label   The field label.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->set_options( $label, $options );
@@ -429,8 +429,8 @@ abstract class Fieldmanager_Field {
 	 * @throws FM_Developer_Exception If an option is set but not defined in this class or the child class.
 	 * @throws FM_Developer_Exception If an option is set but not public.
 	 *
-	 * @param string $label   Title of form field.
-	 * @param array  $options With keys matching vars of the field in use.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function set_options( $label, $options ) {
 		if ( is_array( $label ) ) {

--- a/php/class-fieldmanager-grid.php
+++ b/php/class-fieldmanager-grid.php
@@ -39,8 +39,8 @@ class Fieldmanager_Grid extends Fieldmanager_Field {
 	/**
 	 * Constructor which adds several scrips and CSS.
 	 *
-	 * @param string $label   The form label.
-	 * @param array  $options The form options.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		_deprecated_function( __METHOD__, '1.4.0' );

--- a/php/class-fieldmanager-group.php
+++ b/php/class-fieldmanager-group.php
@@ -139,8 +139,8 @@ class Fieldmanager_Group extends Fieldmanager_Field {
 	 *
 	 * @throws FM_Developer_Exception Not serializing data with repeatable groups.
 	 *
-	 * @param string $label   The form label.
-	 * @param array  $options The form options.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 

--- a/php/class-fieldmanager-link.php
+++ b/php/class-fieldmanager-link.php
@@ -13,8 +13,8 @@ class Fieldmanager_Link extends Fieldmanager_Textfield {
 	/**
 	 * Construct default attributes, set link sanitizer.
 	 *
-	 * @param string $label   The form label.
-	 * @param array  $options The form options.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->sanitize = 'esc_url_raw';

--- a/php/class-fieldmanager-media.php
+++ b/php/class-fieldmanager-media.php
@@ -95,8 +95,8 @@ class Fieldmanager_Media extends Fieldmanager_Field {
 	/**
 	 * Construct default attributes.
 	 *
-	 * @param string $label   The form label.
-	 * @param array  $options The form options.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->button_label         = __( 'Attach a File', 'fieldmanager' );

--- a/php/class-fieldmanager-options.php
+++ b/php/class-fieldmanager-options.php
@@ -64,8 +64,8 @@ abstract class Fieldmanager_Options extends Fieldmanager_Field {
 	/**
 	 * Add CSS, construct parent.
 	 *
-	 * @param string $label   The form label.
-	 * @param mixed  $options The form options.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->sanitize = array( $this, 'sanitize' );

--- a/php/class-fieldmanager-password.php
+++ b/php/class-fieldmanager-password.php
@@ -29,8 +29,8 @@ class Fieldmanager_Password extends Fieldmanager_Field {
 	/**
 	 * Override constructor to set default size.
 	 *
-	 * @param string $label   Field label.
-	 * @param array  $options Associative array of class property values. @see Fieldmanager_Field::__construct().
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->attributes = array(

--- a/php/class-fieldmanager-richtextarea.php
+++ b/php/class-fieldmanager-richtextarea.php
@@ -104,8 +104,8 @@ class Fieldmanager_RichTextArea extends Fieldmanager_Field {
 	/**
 	 * Construct defaults for this field.
 	 *
-	 * @param string $label   Title of form field.
-	 * @param array  $options With keys matching vars of the field in use.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->sanitize = array( $this, 'sanitize' );

--- a/php/class-fieldmanager-select.php
+++ b/php/class-fieldmanager-select.php
@@ -46,8 +46,8 @@ class Fieldmanager_Select extends Fieldmanager_Options {
 	/**
 	 * Override constructor to add chosen.js maybe.
 	 *
-	 * @param string $label   The form label.
-	 * @param array  $options The form options.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 

--- a/php/class-fieldmanager-textarea.php
+++ b/php/class-fieldmanager-textarea.php
@@ -27,8 +27,8 @@ class Fieldmanager_TextArea extends Fieldmanager_Field {
 	/**
 	 * Construct default attributes; 50x10 textarea.
 	 *
-	 * @param string $label   Field label.
-	 * @param array  $options Associative array of class property values. @see Fieldmanager_Field::__construct().
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->attributes = array(

--- a/php/class-fieldmanager-textfield.php
+++ b/php/class-fieldmanager-textfield.php
@@ -20,8 +20,8 @@ class Fieldmanager_TextField extends Fieldmanager_Field {
 	/**
 	 * Override constructor to set default size.
 	 *
-	 * @param string $label   The form label.
-	 * @param array  $options The form options.
+	 * @param string|array $label   The field label. A provided string sets $options['label'], while an array sets $options, overriding any existing data in $options.
+	 * @param array        $options The field options.
 	 */
 	public function __construct( $label = '', $options = array() ) {
 		$this->attributes = array(


### PR DESCRIPTION
### Summary
This pull request updates class constructor docblocks to accurately reflect that `$label` can be either an `array` or a `string`. This change aims to address issues with code quality tools like `phpstan` that arise due to the current incorrect specification of `$label` as a string only. Fixes #867

### Background
Each constructor within the project has a `$label` parameter, which, according to the current docblocks, accepts only a string. This has been identified as incorrect since `$label` can also be an array. The mismatch between the implementation and the documentation causes tools like `phpstan` to report errors, potentially affecting code quality assurance processes.

### Changes
- Updated the docblocks across various constructors to specify that `$label` can be either a `string` or an `array`.
- Ensured that all related documentation is updated to reflect this change, preventing any confusion or discrepancies in the future.

### Testing
1. Set up `phpstan` on a project that utilizes `wordpress-fieldmanager`.
2. Register a new Fieldmanager field, providing an `array` for `$label`, to simulate the scenario that previously led to errors.
3. Run `phpstan` to ensure that it no longer reports errors regarding the type of `$label`.

### Additional Notes
This change is categorized as an enhancement rather than a bug fix, as it primarily aims to improve compatibility with code quality tools without altering the functionality of the existing codebase.

### References
- Issue link: [https://github.com/alleyinteractive/wordpress-fieldmanager/issues/867](https://github.com/alleyinteractive/wordpress-fieldmanager/issues/867)
