### PR TITLE
fix: exact field-key match in trigger_display_if to prevent false positives

### DIFF
--- a/js/fieldmanager.js
+++ b/js/fieldmanager.js
@@ -296,7 +296,8 @@ var fm_init = function () {
 		}
 		$( this ).closest( '.fm-wrapper' ).siblings().each( function() {
 			if ( $( this ).hasClass( 'fm-display-if' ) ) {
-				if ( name && name.match( $( this ).data( 'display-src' ) ) != null ) {
+				var displaySrc = $( this ).data( 'display-src' );
+				if ( name && ( name === displaySrc || name.indexOf( '[' + displaySrc + ']' ) !== -1 ) ) {
 					if ( match_value( getCompareValues( this ), val ) ) {
 						$( this ).show();
 					} else {


### PR DESCRIPTION
## What

`trigger_display_if` used `name.match( displaySrc )` to decide whether a
changed input should trigger visibility changes on `display_if` siblings.
`String.prototype.match()` treats its argument as a regex and matches
substrings, so any trigger input whose full HTML `name` attribute contains
`displaySrc` as a substring incorrectly fires the display logic.

## Reproducer (from #873)

```php
$custom_meta_group = new Fieldmanager_Group([
    'name'           => 'custom_meta_group',  // contains "meta" as a substring
    'serialize_data' => false,
    'children'       => [
        'meta'         => new Fieldmanager_Checkbox(['checked_value' => 'meta']),
        'text_field'   => new Fieldmanager_Textfield(['display_if' => ['src' => 'meta', 'value' => 'meta']]),
        'subject_prefix' => new Fieldmanager_Select([...]),
    ],
]);
```

When `subject_prefix` changes, its input name is
`custom_meta_group[subject_prefix]`. The old code evaluates:

```js
'custom_meta_group[subject_prefix]'.match('meta') != null  // → true!
```

…because `"meta"` is a substring of `"custom_meta_group"`. This causes
`text_field` to be shown or hidden whenever `subject_prefix` changes,
even though `text_field` should only react to `meta`.

## Fix

Replace the partial regex match with an exact bracket-key check:

```js
// Before
if ( name && name.match( $( this ).data( 'display-src' ) ) != null ) {

// After
var displaySrc = $( this ).data( 'display-src' );
if ( name && ( name === displaySrc || name.indexOf( '[' + displaySrc + ']' ) !== -1 ) ) {
```

- `name === displaySrc` handles top-level Fieldmanager fields whose
  input name is the bare field key (no bracket notation).
- `name.indexOf( '[' + displaySrc + ']' ) !== -1` handles nested fields
  where the key is wrapped in brackets (e.g. `group[meta]`). The
  surrounding brackets ensure `[meta]` cannot match `[meta_info]` or
  `[custom_meta_group]`.

## Testing

1. Set up the group from the reproducer above.
2. Change `subject_prefix` — confirm `text_field` visibility does **not** change.
3. Check the `meta` checkbox — confirm `text_field` shows/hides correctly.
4. Run the existing JS test suite: `npm test` (or equivalent).

Fixes #873

---
*Development and testing assisted by AI. All code reviewed and verified manually.*